### PR TITLE
rtr_mgr_group is an anonymous struct, thus sizeof cannot be used on it.

### DIFF
--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -67,7 +67,7 @@ typedef enum {
  * @param preference The preference value of this group. Groups with lower preference values are preferred.
  * @param status Status of the group.
  */
-typedef struct {
+typedef struct rtr_mgr_group {
     rtr_socket** sockets;
     unsigned int sockets_len;
     uint8_t preference;


### PR DESCRIPTION
Simple change that gives the rtr_mgr_group type's anonymous struct a name.
