### PR TITLE
Refs #3 (Kernel coding style): Eliminate typedef structs

### DIFF
--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -8,8 +8,8 @@ int main(){
     char ssh_hostkey[]	= "/etc/rpki-rtr/hostkey";
     char ssh_privkey[]	= "/etc/rpki-rtr/client.priv";
     char ssh_pubkey[]	= "/etc/rpki-rtr/client.pub";
-    tr_socket tr_ssh;
-    tr_ssh_config config = {
+    struct tr_socket tr_ssh;
+    struct tr_ssh_config config = {
         ssh_host,					//IP
         22,							//Port
         ssh_user,
@@ -20,44 +20,44 @@ int main(){
     tr_ssh_init(&config, &tr_ssh);
 
     //create a TCP transport socket
-    tr_socket tr_tcp1;
+    struct tr_socket tr_tcp1;
 	char tcp1_host[]	= "rpki.realmv6.org";
 	char tcp1_port[]	= "42420";
 
-    tr_tcp_config tcp_config1 = {
+    struct tr_tcp_config tcp_config1 = {
         tcp1_host,          //IP
         tcp1_port           //Port
     };
     tr_tcp_init(&tcp_config1, &tr_tcp1);
 
     //create another TCP transport socket
-    tr_socket tr_tcp2;
+    struct tr_socket tr_tcp2;
 	char tcp2_host[]	= "localhost";
 	char tcp2_port[]	= "8282";
-    tr_tcp_config tcp_config2 = {
+    struct tr_tcp_config tcp_config2 = {
         tcp2_host,                //IP
         tcp2_port,                //Port
     };
     tr_tcp_init(&tcp_config2, &tr_tcp2);
 
     //create 3 rtr_sockets and associate them with the transprort sockets
-    rtr_socket rtr_ssh, rtr_tcp1, rtr_tcp2;
+    struct rtr_socket rtr_ssh, rtr_tcp1, rtr_tcp2;
     rtr_ssh.tr_socket = &tr_ssh;
     rtr_tcp1.tr_socket = &tr_tcp1;
     rtr_tcp2.tr_socket = &tr_tcp2;
 
     //create a rtr_mgr_group array with 2 elements
-    rtr_mgr_group groups[2];
-    
+    struct rtr_mgr_group groups[2];
+
     //The first group contains both TCP RTR sockets
-    groups[0].sockets = malloc(2 * sizeof(rtr_socket*));
+    groups[0].sockets = malloc(2 * sizeof(struct rtr_socket*));
     groups[0].sockets_len = 2;
     groups[0].sockets[0] = &rtr_tcp1;
     groups[0].sockets[1] = &rtr_tcp2;
     groups[0].preference = 1;       //Preference value of this group
 
     //The seconds group contains only the SSH RTR socket
-    groups[1].sockets = malloc(1 * sizeof(rtr_socket*));
+    groups[1].sockets = malloc(1 * sizeof(struct rtr_socket*));
     groups[1].sockets_len = 1;
     groups[1].sockets[0] = &rtr_ssh;
     groups[1].preference = 2;
@@ -65,7 +65,7 @@ int main(){
     //create a rtr_mgr_config struct that stores the group
 
     //initialize all rtr_sockets in the server pool with the same settings
-    rtr_mgr_config *conf = rtr_mgr_init(groups, 2, 240, 520, NULL, NULL, NULL);
+    struct rtr_mgr_config *conf = rtr_mgr_init(groups, 2, 240, 520, NULL, NULL, NULL);
 
     //start the connection manager
     rtr_mgr_start(conf);
@@ -75,7 +75,7 @@ int main(){
         sleep(1);
 
     //validate the BGP-Route 10.10.0.0/24, origin ASN: 12345
-    ip_addr pref;
+    struct ip_addr pref;
     ip_str_to_addr("10.10.0.0", &pref);
     pfxv_state result;
     rtr_mgr_validate(conf, 12345, &pref, 24, &result);

--- a/doxygen/examples/ssh_tr.c
+++ b/doxygen/examples/ssh_tr.c
@@ -2,14 +2,14 @@
 #include "rtrlib/transport/ssh/ssh_transport.h"
 
 int main(){
-    tr_socket ssh_socket;
+    struct tr_socket ssh_socket;
     char ssh_host[]		= "123.231.123.221";
     char ssh_user[]		= "rpki_user";
     char ssh_hostkey[]	= "/etc/rpki-rtr/hostkey";
     char ssh_privkey[]	= "/etc/rpki-rtr/client.priv";
     char ssh_pubkey[]	= "/etc/rpki-rtr/client.pub";
 
-    tr_ssh_config config = {
+    struct tr_ssh_config config = {
         ssh_host,
         22,
         ssh_user,

--- a/rtrlib/lib/ip.c
+++ b/rtrlib/lib/ip.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include "rtrlib/lib/ip.h"
 
-bool ip_addr_is_zero(const ip_addr prefix) {
+bool ip_addr_is_zero(const struct ip_addr prefix) {
     if(prefix.ver == IPV6) {
         if(prefix.u.addr6.addr[0] == 0 && prefix.u.addr6.addr[1] == 0 && prefix.u.addr6.addr[2] == 0 && prefix.u.addr6.addr[3] == 0 ) {
             return true;
@@ -36,8 +36,8 @@ bool ip_addr_is_zero(const ip_addr prefix) {
     return false;
 }
 
-ip_addr ip_addr_get_bits(const ip_addr *val, const uint8_t from, const uint8_t number) {
-    ip_addr result;
+struct ip_addr ip_addr_get_bits(const struct ip_addr *val, const uint8_t from, const uint8_t number) {
+    struct ip_addr result;
     if(val->ver == IPV6) {
         result.ver = IPV6;
         result.u.addr6 = ipv6_get_bits(&(val->u.addr6), from, number);
@@ -49,7 +49,7 @@ ip_addr ip_addr_get_bits(const ip_addr *val, const uint8_t from, const uint8_t n
     return result;
 }
 
-bool ip_addr_equal(const ip_addr a, const ip_addr b ) {
+bool ip_addr_equal(const struct ip_addr a, const struct ip_addr b ) {
     if(a.ver != b.ver)
         return false;
     if(a.ver == IPV6) {
@@ -58,13 +58,13 @@ bool ip_addr_equal(const ip_addr a, const ip_addr b ) {
     return ipv4_addr_equal(&(a.u.addr4), &(b.u.addr4));
 }
 
-int ip_addr_to_str(const ip_addr *ip, char *str, const unsigned int len) {
+int ip_addr_to_str(const struct ip_addr *ip, char *str, const unsigned int len) {
     if(ip->ver == IPV6)
         return ipv6_addr_to_str(&(ip->u.addr6), str, len);
     return ipv4_addr_to_str(&(ip->u.addr4), str, len);
 }
 
-int ip_str_to_addr(const char *str, ip_addr *ip) {
+int ip_str_to_addr(const char *str, struct ip_addr *ip) {
     if(strchr(str, ':') == NULL) {
         ip->ver = IPV4;;
         return ipv4_str_to_addr(str, &(ip->u.addr4));
@@ -73,8 +73,8 @@ int ip_str_to_addr(const char *str, ip_addr *ip) {
     return ipv6_str_to_addr(str, &(ip->u.addr6));
 }
 
-bool ip_str_cmp(const ip_addr *addr1, const char *addr2) {
-    ip_addr tmp;
+bool ip_str_cmp(const struct ip_addr *addr1, const char *addr2) {
+    struct ip_addr tmp;
     if(ip_str_to_addr(addr2, &tmp) == -1)
         return false;
     return(ip_addr_equal(*addr1, tmp));

--- a/rtrlib/lib/ip.h
+++ b/rtrlib/lib/ip.h
@@ -42,13 +42,13 @@ typedef enum {
  * @param ver Specifies the type of the stored address.
  * @param u Union holding a ipv4_addr or ipv6_addr.
  */
-typedef struct {
+struct ip_addr {
     ip_version ver;
     union {
-        ipv4_addr addr4;
-        ipv6_addr addr6;
+        struct ipv4_addr addr4;
+        struct ipv6_addr addr6;
     } u;
-} ip_addr;
+};
 
 /**
  * @brief Detects if the ip_addr only contains 0 bits.
@@ -56,7 +56,7 @@ typedef struct {
  * @returns true If the saved ip_addr is 0.
  * @returns false If the saved ip_addr isn't 0.
  */
-bool ip_addr_is_zero(const ip_addr);
+bool ip_addr_is_zero(const struct ip_addr);
 
 /**
  * @brief Extracts number bits from the passed ip_addr, starting at bit number from. The bit with the highest
@@ -66,7 +66,7 @@ bool ip_addr_is_zero(const ip_addr);
  * @param[in] number How many bits will be extracted.
  * @returns An ipv4_addr, where all bits that aren't in the specified range are set to 0.
 */
-ip_addr ip_addr_get_bits(const ip_addr *val, const uint8_t from, const uint8_t number);
+struct ip_addr ip_addr_get_bits(const struct ip_addr *val, const uint8_t from, const uint8_t number);
 
 /**
  * @defgroup util_h Utility functions
@@ -78,7 +78,7 @@ ip_addr ip_addr_get_bits(const ip_addr *val, const uint8_t from, const uint8_t n
  * @return true If a == b.
  * @return false If a != b.
  */
-bool ip_addr_equal(const ip_addr a, const ip_addr b);
+bool ip_addr_equal(const struct ip_addr a, const struct ip_addr b);
 
 /**
  * Converts the passed ip_addr struct to string representation.
@@ -89,7 +89,7 @@ bool ip_addr_equal(const ip_addr a, const ip_addr b);
  * @result 0 On success.
  * @result -1 On error.
 */
-int ip_addr_to_str(const ip_addr *ip, char *str, const unsigned int len);
+int ip_addr_to_str(const struct ip_addr *ip, char *str, const unsigned int len);
 
 /**
  * Converts the passed IP address in string representation to an ip_addr.
@@ -98,7 +98,7 @@ int ip_addr_to_str(const ip_addr *ip, char *str, const unsigned int len);
  * @result 0 On success.
  * @result -1 On error.
 */
-int ip_str_to_addr(const char *str, ip_addr *ip);
+int ip_str_to_addr(const char *str, struct ip_addr *ip);
 
 /**
  * Compares addr1 in the ip_addr struct with addr2 in string representation.
@@ -107,7 +107,7 @@ int ip_str_to_addr(const char *str, ip_addr *ip);
  * @return true If a == b
  * @return false If a != b
 */
-bool ip_str_cmp(const ip_addr *addr1, const char *addr2);
+bool ip_str_cmp(const struct ip_addr *addr1, const char *addr2);
 
 #endif
 /* @} */

--- a/rtrlib/lib/ipv4.c
+++ b/rtrlib/lib/ipv4.c
@@ -25,13 +25,13 @@
 #include <assert.h>
 #include <stdio.h>
 
-ipv4_addr ipv4_get_bits(const ipv4_addr *val, const uint8_t from, const uint8_t quantity) {
-    ipv4_addr result;
+struct ipv4_addr ipv4_get_bits(const struct ipv4_addr *val, const uint8_t from, const uint8_t quantity) {
+    struct ipv4_addr result;
     result.addr = rtr_get_bits(val->addr, from, quantity);
     return result;
 }
 
-int ipv4_addr_to_str(const ipv4_addr *ip, char *str, unsigned int len) {
+int ipv4_addr_to_str(const struct ipv4_addr *ip, char *str, unsigned int len) {
     const uint8_t *t = (uint8_t *) &(ip->addr);
 
     if (snprintf(str, len, "%hhu.%hhu.%hhu.%hhu", t[3], t[2], t[1], t[0]) < 0) {
@@ -40,14 +40,14 @@ int ipv4_addr_to_str(const ipv4_addr *ip, char *str, unsigned int len) {
     return 0;
 }
 
-int ipv4_str_to_addr(const char *str, ipv4_addr *ip) {
+int ipv4_str_to_addr(const char *str, struct ipv4_addr *ip) {
     unsigned char *t =  (unsigned char *) &(ip->addr);
     if(sscanf(str, "%hhu.%hhu.%hhu.%hhu", &(t[3]), &(t[2]), &(t[1]), &(t[0])) != 4)
         return -1;
     return 0;
 }
 
-bool ipv4_addr_equal(const ipv4_addr *a, const ipv4_addr *b) {
+bool ipv4_addr_equal(const struct ipv4_addr *a, const struct ipv4_addr *b) {
     if(a->addr == b->addr)
         return true;
     return false;

--- a/rtrlib/lib/ipv4.h
+++ b/rtrlib/lib/ipv4.h
@@ -29,9 +29,9 @@
  * @brief Struct storing an IPv4 address in host byte order.
  * @param addr The IPv4 address.
  */
-typedef struct {
+struct ipv4_addr {
     uint32_t addr;
-} ipv4_addr;
+};
 
 /**
  * @brief Extracts number bits from the passed ipv4_addr, starting at bit number from. The bit with the highest
@@ -41,7 +41,7 @@ typedef struct {
  * @param[in] number How many bits will be extracted.
  * @returns An ipv4_addr, where all bits that aren't in the specified range are set to 0.
 */
-ipv4_addr ipv4_get_bits(const ipv4_addr *val, const uint8_t from, const uint8_t number);
+struct ipv4_addr ipv4_get_bits(const struct ipv4_addr *val, const uint8_t from, const uint8_t number);
 
 /**
  * Converts the passed IPv4 address in string representation to an ipv4_addr struct.
@@ -50,7 +50,7 @@ ipv4_addr ipv4_get_bits(const ipv4_addr *val, const uint8_t from, const uint8_t 
  * @result 0 on success
  * @result -1 on error
 */
-int ipv4_str_to_addr(const char *str, ipv4_addr *ip);
+int ipv4_str_to_addr(const char *str, struct ipv4_addr *ip);
 
 /**
  * Converts the passed ipv4_addr to string representation.
@@ -59,7 +59,7 @@ int ipv4_str_to_addr(const char *str, ipv4_addr *ip);
  * @result 0 on success
  * @result -1 on error
 */
-int ipv4_addr_to_str(const ipv4_addr *ip, char *str, const unsigned int len);
+int ipv4_addr_to_str(const struct ipv4_addr *ip, char *str, const unsigned int len);
 
 /**
  * Compares two ipv4_addr structs.
@@ -68,6 +68,6 @@ int ipv4_addr_to_str(const ipv4_addr *ip, char *str, const unsigned int len);
  * @return true if a == b
  * @return false if a != b
 */
-bool ipv4_addr_equal(const ipv4_addr *a, const ipv4_addr *b);
+bool ipv4_addr_equal(const struct ipv4_addr *a, const struct ipv4_addr *b);
 
 #endif

--- a/rtrlib/lib/ipv6.c
+++ b/rtrlib/lib/ipv6.c
@@ -28,19 +28,19 @@
 #include <string.h>
 #include <stdio.h>
 
-inline bool ipv6_addr_equal(const ipv6_addr *a, const ipv6_addr *b) {
+inline bool ipv6_addr_equal(const struct ipv6_addr *a, const struct ipv6_addr *b) {
     if(a->addr[0] == b->addr[0] && a->addr[1] == b->addr[1] && a->addr[2] == b->addr[2] && a->addr[3] == b->addr[3])
         return true;
     return false;
 }
 
-ipv6_addr ipv6_get_bits(const ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity) {
+struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity) {
     assert(first_bit <= 127);
     assert(quantity <= 128);
     assert(first_bit + quantity <= 128);
 
     // if no bytes get extracted the result has to be 0
-    ipv6_addr result;
+    struct ipv6_addr result;
     memset(&result, 0, sizeof(result));
 
     uint8_t bits_left = quantity;
@@ -81,7 +81,7 @@ ipv6_addr ipv6_get_bits(const ipv6_addr *val, const uint8_t first_bit, const uin
 /*
  * This function was copied from the bird routing daemon's ip_pton(..) function.
  */
-int ipv6_str_to_addr(const char *a, ipv6_addr *ip) {
+int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip) {
     uint32_t *o = ip->addr;
     uint16_t words[8];
     int i, j, k, l, hfil;
@@ -121,7 +121,7 @@ int ipv6_str_to_addr(const char *a, ipv6_addr *ip) {
         if (*a == ':' && a[1])
             a++;
         else if (*a == '.' && (i == 6 || (i < 6 && hfil >= 0))) {             /* Embedded IPv4 address */
-            ipv4_addr addr4;
+            struct ipv4_addr addr4;
             if (ipv4_str_to_addr(start, &addr4) == -1)
                 return -1;
             words[i++] = addr4.addr >> 16;
@@ -153,7 +153,7 @@ int ipv6_str_to_addr(const char *a, ipv6_addr *ip) {
 /*
  * This function was copied from the bird routing daemon's ip_ntop(..) function.
 */
-int ipv6_addr_to_str(const ipv6_addr *ip_addr, char *b, const unsigned int len) {
+int ipv6_addr_to_str(const struct ipv6_addr *ip_addr, char *b, const unsigned int len) {
     if(len < INET6_ADDRSTRLEN)
         return -1;
     const uint32_t *a = ip_addr->addr;

--- a/rtrlib/lib/ipv6.h
+++ b/rtrlib/lib/ipv6.h
@@ -31,9 +31,9 @@
  * @brief Struct holding an IPv6 address in host byte order.
  * @param addr The IPv6 address.
  */
-typedef struct {
+struct ipv6_addr {
     uint32_t addr[4];
-} ipv6_addr;
+};
 
 /**
  * Compares two ipv6_addr structs
@@ -42,7 +42,7 @@ typedef struct {
  * @return true if a == b
  * @return false if a != b
 */
-bool ipv6_addr_equal(const ipv6_addr *a, const ipv6_addr *b);
+bool ipv6_addr_equal(const struct ipv6_addr *a, const struct ipv6_addr *b);
 
 /**
  * @brief Extracts quantity bits from a ip address. The bit with the highest
@@ -52,7 +52,7 @@ bool ipv6_addr_equal(const ipv6_addr *a, const ipv6_addr *b);
  * @param[in] quantity How many bits will be extracted.
  * @returns An ipv6_addr, where all bits that aren't in the specified range are set to 0.
 */
-ipv6_addr ipv6_get_bits(const ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity);
+struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity);
 
 /**
  * Converts the passed ipv6_addr to string representation
@@ -61,7 +61,7 @@ ipv6_addr ipv6_get_bits(const ipv6_addr *val, const uint8_t first_bit, const uin
  * @result 0 on success
  * @result -1 on error
 */
-int ipv6_addr_to_str(const ipv6_addr *ip_addr, char *b, const unsigned int len);
+int ipv6_addr_to_str(const struct ipv6_addr *ip_addr, char *b, const unsigned int len);
 
 /**
  * Converts the passed IPv6 address in string representation to an ipv6_addr struct.
@@ -70,7 +70,7 @@ int ipv6_addr_to_str(const ipv6_addr *ip_addr, char *b, const unsigned int len);
  * @result 0 on success
  * @result -1 on error
 */
-int ipv6_str_to_addr(const char *a, ipv6_addr *ip);
+int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip);
 
 /**
  * @ingroup util_h[{

--- a/rtrlib/pfx/lpfst/lpfst-pfx.h
+++ b/rtrlib/pfx/lpfst/lpfst-pfx.h
@@ -49,12 +49,12 @@
  * @param update_fp
  * @param lock
  */
-typedef struct pfx_table {
-    lpfst_node *ipv4;
-    lpfst_node *ipv6;
+struct pfx_table {
+    struct lpfst_node *ipv4;
+    struct lpfst_node *ipv6;
     pfx_update_fp update_fp;
     pthread_rwlock_t lock;
-} pfx_table;
+};
 
 #endif
 /* @} */

--- a/rtrlib/pfx/lpfst/lpfst.c
+++ b/rtrlib/pfx/lpfst/lpfst.c
@@ -23,11 +23,11 @@
 #include <stdlib.h>
 #include "rtrlib/pfx/lpfst/lpfst.h"
 
-void lpfst_insert(lpfst_node *root_node, lpfst_node *new_node, const unsigned int level) {
+void lpfst_insert(struct lpfst_node *root_node, struct lpfst_node *new_node, const unsigned int level) {
     if(new_node->len > root_node->len)
     {
         //switch node data
-        lpfst_node tmp;
+        struct lpfst_node tmp;
         tmp.prefix = root_node->prefix;
         tmp.len = root_node->len;
         tmp.data = root_node->data;
@@ -56,11 +56,11 @@ void lpfst_insert(lpfst_node *root_node, lpfst_node *new_node, const unsigned in
     }
 }
 
-lpfst_node *lpfst_lookup(const lpfst_node *root_node, const ip_addr *prefix, const uint8_t mask_len, unsigned int *level) {
+struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, unsigned int *level) {
     while(root_node != NULL)
     {
         if(root_node->len <= mask_len && ip_addr_equal(ip_addr_get_bits(&(root_node->prefix), 0, root_node->len), ip_addr_get_bits(prefix, 0, root_node->len)))
-            return (lpfst_node *) root_node;
+            return (struct lpfst_node *) root_node;
 
         if(ip_addr_is_zero(ip_addr_get_bits(prefix, *level, 1)))
             root_node = root_node->lchild;
@@ -72,7 +72,7 @@ lpfst_node *lpfst_lookup(const lpfst_node *root_node, const ip_addr *prefix, con
     return NULL;
 }
 
-lpfst_node *lpfst_lookup_exact(lpfst_node *root_node, const ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found) {
+struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found) {
     *found = false;
     while(root_node != NULL)
     {
@@ -82,7 +82,7 @@ lpfst_node *lpfst_lookup_exact(lpfst_node *root_node, const ip_addr *prefix, con
         }
         if(root_node->len == mask_len && ip_addr_equal(root_node->prefix, *prefix)) {
             *found = true;
-            return (lpfst_node *) root_node;
+            return (struct lpfst_node *) root_node;
         }
 
         if(ip_addr_is_zero(ip_addr_get_bits(prefix, *level, 1))) {
@@ -104,7 +104,7 @@ lpfst_node *lpfst_lookup_exact(lpfst_node *root_node, const ip_addr *prefix, con
 }
 
 //returns node that isnt used anymore in the tree
-lpfst_node *lpfst_remove(lpfst_node *root_node, const ip_addr *prefix, const uint8_t mask_len, const unsigned int level) {
+struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, const unsigned int level) {
     if(root_node->len == mask_len && ip_addr_equal(root_node->prefix, *prefix)) {
         if(lpfst_is_leaf(root_node)) {
             if(level != 0) {
@@ -147,10 +147,10 @@ lpfst_node *lpfst_remove(lpfst_node *root_node, const ip_addr *prefix, const uin
     }
 }
 
-int lpfst_get_children(const lpfst_node *root_node, lpfst_node ***array, unsigned int *len) {
+int lpfst_get_children(const struct lpfst_node *root_node, struct lpfst_node ***array, unsigned int *len) {
     if(root_node->lchild != NULL) {
         *len += 1;
-        *array = realloc(*array, (*len) * sizeof(lpfst_node *));
+        *array = realloc(*array, (*len) * sizeof(struct lpfst_node *));
         if(*array == NULL)
             return -1;
         (*array)[(*len) - 1] = root_node->lchild;
@@ -160,7 +160,7 @@ int lpfst_get_children(const lpfst_node *root_node, lpfst_node ***array, unsigne
 
     if(root_node->rchild != NULL) {
         *len += 1;
-        *array = realloc(*array, (*len) * sizeof(lpfst_node *));
+        *array = realloc(*array, (*len) * sizeof(struct lpfst_node *));
         if(*array == NULL)
             return -1;
         (*array)[(*len) - 1] = root_node->rchild;
@@ -170,6 +170,6 @@ int lpfst_get_children(const lpfst_node *root_node, lpfst_node ***array, unsigne
     return 0;
 }
 
-inline int lpfst_is_leaf(const lpfst_node *node) {
+inline int lpfst_is_leaf(const struct lpfst_node *node) {
     return node->lchild == NULL && node->rchild == NULL;
 }

--- a/rtrlib/pfx/lpfst/lpfst.h
+++ b/rtrlib/pfx/lpfst/lpfst.h
@@ -34,14 +34,14 @@
  * @param parent
  * @param data
  */
-typedef struct lpfst_node_t {
-    ip_addr prefix;
+struct lpfst_node {
+    struct ip_addr prefix;
     uint8_t len;
-    struct lpfst_node_t *rchild;
-    struct lpfst_node_t *lchild;
-    struct lpfst_node_t *parent;
+    struct lpfst_node *rchild;
+    struct lpfst_node *lchild;
+    struct lpfst_node *parent;
     void *data;
-} lpfst_node;
+};
 
 /**
  * @brief Inserts new_node in the tree.
@@ -49,7 +49,7 @@ typedef struct lpfst_node_t {
  * @param[in] new_node Node that will be inserted.
  * @param[in] level Level of the the root node in the tree.
  */
-void lpfst_insert(lpfst_node *root, lpfst_node *new_node, const unsigned int level);
+void lpfst_insert(struct lpfst_node *root, struct lpfst_node *new_node, const unsigned int level);
 
 /**
  * @brief Searches for the node with the longest prefix, matching the passed ip prefix and prefix length.
@@ -60,7 +60,7 @@ void lpfst_insert(lpfst_node *root, lpfst_node *new_node, const unsigned int lev
  * @returns A The lpfst_node with the longest prefix in the tree matching the passed ip prefix and prefix length.
  * @returns NULL if no node that matches the passed prefix and prefix length could be found.
  */
-lpfst_node *lpfst_lookup(const lpfst_node *root_node, const ip_addr *prefix, const uint8_t mask_len,  unsigned int *level);
+struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len,  unsigned int *level);
 
 /**
  * @brief Search for a node with the same prefix and prefix length.
@@ -73,7 +73,7 @@ lpfst_node *lpfst_lookup(const lpfst_node *root_node, const ip_addr *prefix, con
  * @return the parent of the node where the lookup operation stopped (found==false).
  * @return NULL if root_node is NULL.
 */
-lpfst_node *lpfst_lookup_exact(lpfst_node *root_node, const ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found);
+struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found);
 
 /**
  * @brief Removes the node with the passed IP prefix and mask_len from the tree.
@@ -84,7 +84,7 @@ lpfst_node *lpfst_lookup_exact(lpfst_node *root_node, const ip_addr *prefix, con
  * @returns Node that was removed from the tree.
  * @returns NULL If the Prefix could'nt be found in the tree.
  */
-lpfst_node *lpfst_remove(lpfst_node *root_node, const ip_addr *prefix, const uint8_t mask_len, const unsigned int level);
+struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, const unsigned int level);
 
 /**
  * @brief Detects if a node is a leaf in tree.
@@ -92,7 +92,7 @@ lpfst_node *lpfst_remove(lpfst_node *root_node, const ip_addr *prefix, const uin
  * @returns true if node is a leaf:
  * @returns false if node isn't a leaf.
  */
-int lpfst_is_leaf(const lpfst_node *node);
+int lpfst_is_leaf(const struct lpfst_node *node);
 
-int lpfst_get_children(const lpfst_node *root_node, lpfst_node ***array, unsigned int *len);
+int lpfst_get_children(const struct lpfst_node *root_node, struct lpfst_node ***array, unsigned int *len);
 #endif

--- a/rtrlib/pfx/pfx.h
+++ b/rtrlib/pfx/pfx.h
@@ -76,13 +76,13 @@ typedef enum pfxv_state {
  * @param max_len Maximum prefix length.
  * @param socket_id unique id of the rtr_socket that received this record.
  */
-typedef struct pfx_record {
+struct pfx_record {
     uint32_t asn;
-    ip_addr prefix;
+    struct ip_addr prefix;
     uint8_t min_len;
     uint8_t max_len;
     const struct rtr_socket *socket;
-} pfx_record;
+};
 
 /**
  * @brief A function pointer that is called if an record was added to the pfx_table or was removed from the pfx_table.
@@ -90,7 +90,7 @@ typedef struct pfx_record {
  * @param record pfx_record that was modified.
  * @param added True if the record was added, false if the record was removed.
  */
-typedef void (*pfx_update_fp)(struct pfx_table *pfx_table, const pfx_record record, const bool added);
+typedef void (*pfx_update_fp)(struct pfx_table *pfx_table, const struct pfx_record record, const bool added);
 
 /**
  * @brief Initializes the pfx_table struct.
@@ -113,7 +113,7 @@ void pfx_table_free(struct pfx_table *pfx_table);
  * @return PFX_ERROR On error.
  * @return PFX_DUPLICATE_RECORD If the pfx_record already exists.
  */
-int pfx_table_add(struct pfx_table *pfx_table, const pfx_record *pfx_record);
+int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *pfx_record);
 
 /**
  * @brief Removes a pfx_record from a pfx_table.
@@ -123,7 +123,7 @@ int pfx_table_add(struct pfx_table *pfx_table, const pfx_record *pfx_record);
  * @return PFX_ERROR On error.
  * @return PFX_RECORD_NOT_FOUND If pfx_records could'nt be found.
  */
-int pfx_table_remove(struct pfx_table *pfx_table, const pfx_record *pfx_record);
+int pfx_table_remove(struct pfx_table *pfx_table, const struct pfx_record *pfx_record);
 
 /**
  * @brief Removes all entries in the pfx_table that match the passed socket_id value from a pfx_table.
@@ -144,7 +144,7 @@ int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *s
  * @return PFX_SUCCESS On success.
  * @return PFX_ERROR On error.
  */
-int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const ip_addr *prefix, const uint8_t mask_len, pfxv_state *result);
+int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct ip_addr *prefix, const uint8_t mask_len, pfxv_state *result);
 
 /**
  * @brief Validates the origin of a BGP-Route and returns a list of pfx_record that decided the result.
@@ -158,7 +158,7 @@ int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const ip
  * @return PFX_SUCCESS On success.
  * @return PFX_ERROR On error.
  */
-int pfx_table_validate_r(struct pfx_table *pfx_table, pfx_record **reason, unsigned int *reason_len,  const uint32_t asn, const ip_addr *prefix, const uint8_t mask_len, pfxv_state *result);
+int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len,  const uint32_t asn, const struct ip_addr *prefix, const uint8_t mask_len, pfxv_state *result);
 
 /**
  * @brief Iterates over all IPv4 records in the pfx_table.

--- a/rtrlib/rtr/packets.h
+++ b/rtrlib/rtr/packets.h
@@ -32,10 +32,10 @@ static const unsigned int RTR_MAX_PDU_LEN = 3248; //error pdu: header(8) + len(4
 static const unsigned int RTR_RECV_TIMEOUT = 60;
 static const unsigned int RTR_SEND_TIMEOUT = 60;
 
-void rtr_change_socket_state(rtr_socket *rtr_socket, const rtr_socket_state new_state);
-int rtr_sync(rtr_socket *rtr_socket);
-int rtr_wait_for_sync(rtr_socket *rtr_socket);
-int rtr_send_serial_query(rtr_socket *rtr_socket);
-int rtr_send_reset_query(rtr_socket *rtr_socket);
+void rtr_change_socket_state(struct rtr_socket *rtr_socket, const rtr_socket_state new_state);
+int rtr_sync(struct rtr_socket *rtr_socket);
+int rtr_wait_for_sync(struct rtr_socket *rtr_socket);
+int rtr_send_serial_query(struct rtr_socket *rtr_socket);
+int rtr_send_reset_query(struct rtr_socket *rtr_socket);
 
 #endif

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -31,8 +31,8 @@
 
 const unsigned int ERR_TIMEOUT = 20;
 
-static void rtr_purge_outdated_records(rtr_socket *rtr_socket);
-static void rtr_fsm_start(rtr_socket *rtr_socket);
+static void rtr_purge_outdated_records(struct rtr_socket *rtr_socket);
+static void rtr_fsm_start(struct rtr_socket *rtr_socket);
 static void sighandler(int b);
 static int install_sig_handler();
 
@@ -63,7 +63,7 @@ static int install_sig_handler() {
     return sigaction(SIGUSR1, &sa, NULL);
 }
 
-void rtr_init(rtr_socket *rtr_socket, tr_socket *tr, struct pfx_table *pfx_table, const unsigned int polling_period, const unsigned int cache_timeout, rtr_connection_state_fp fp, void *fp_param) {
+void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr, struct pfx_table *pfx_table, const unsigned int polling_period, const unsigned int cache_timeout, rtr_connection_state_fp fp, void *fp_param) {
     if(tr != NULL)
         rtr_socket->tr_socket = tr;
     assert(polling_period <= 3600);
@@ -82,14 +82,14 @@ void rtr_init(rtr_socket *rtr_socket, tr_socket *tr, struct pfx_table *pfx_table
     rtr_socket->thread_id = 0;
 }
 
-int rtr_start(rtr_socket *rtr_socket) {
+int rtr_start(struct rtr_socket *rtr_socket) {
     int rtval = pthread_create(&(rtr_socket->thread_id), NULL, (void* ( *)(void *)) &rtr_fsm_start, rtr_socket);
     if(rtval == 0)
         return RTR_SUCCESS;
     return RTR_ERROR;
 }
 
-void rtr_purge_outdated_records(rtr_socket *rtr_socket) {
+void rtr_purge_outdated_records(struct rtr_socket *rtr_socket) {
     if(rtr_socket->last_update == 0)
         return;
     time_t cur_time;
@@ -105,7 +105,7 @@ void rtr_purge_outdated_records(rtr_socket *rtr_socket) {
     }
 }
 
-void rtr_fsm_start(rtr_socket *rtr_socket) {
+void rtr_fsm_start(struct rtr_socket *rtr_socket) {
     rtr_socket->state = RTR_CONNECTING;
     install_sig_handler();
     while(1) {
@@ -197,7 +197,7 @@ void rtr_fsm_start(rtr_socket *rtr_socket) {
     }
 }
 
-void rtr_stop(rtr_socket *rtr_socket) {
+void rtr_stop(struct rtr_socket *rtr_socket) {
     rtr_change_socket_state(rtr_socket, RTR_SHUTDOWN);
     if(rtr_socket->thread_id != 0) {
         pthread_kill(rtr_socket->thread_id, SIGUSR1);

--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -101,8 +101,8 @@ typedef void (*rtr_connection_state_fp)(const struct rtr_socket *rtr_socket, con
  * @param connection_state_fp A callback function that is executed when the state of the socket changes.
  * @param connection_state_fp_param Parameter that is passed to the connection_state_fp callback.
  */
-typedef struct rtr_socket {
-    tr_socket *tr_socket;
+struct rtr_socket {
+    struct tr_socket *tr_socket;
     unsigned int polling_period;
     time_t last_update;
     unsigned int cache_timeout;
@@ -114,7 +114,7 @@ typedef struct rtr_socket {
     pthread_t thread_id;
     rtr_connection_state_fp connection_state_fp;
     void *connection_state_fp_param;
-} rtr_socket;
+};
 
 /**
  * @brief Initializes a rtr_socket.
@@ -128,7 +128,7 @@ typedef struct rtr_socket {
  * @param[in] fp A callback function that is executed when the state of the socket changes.
  * @param[in] fp_data Parameter that is passed to the connection_state_fp callback.
  */
-void rtr_init(rtr_socket *rtr_socket, tr_socket *tr_socket, struct pfx_table *pfx_table, const unsigned int polling_period, const unsigned int cache_timeout, rtr_connection_state_fp fp, void *fp_data);
+void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr_socket, struct pfx_table *pfx_table, const unsigned int polling_period, const unsigned int cache_timeout, rtr_connection_state_fp fp, void *fp_data);
 
 /**
  * @brief Starts the RTR protocol state machine in a pthread. Connection to the rtr_server will be established and the
@@ -137,13 +137,13 @@ void rtr_init(rtr_socket *rtr_socket, tr_socket *tr_socket, struct pfx_table *pf
  * @return RTR_ERROR On error.
  * @return RTR_SUCCESS On success.
  */
-int rtr_start(rtr_socket *rtr_socket);
+int rtr_start(struct rtr_socket *rtr_socket);
 
 /**
  * @brief Stops the RTR connection and terminate the transport connection.
  * @param[in] rtr_socket rtr_socket that will be used.
  */
-void rtr_stop(rtr_socket *rtr_socket);
+void rtr_stop(struct rtr_socket *rtr_socket);
 
 /**
  * @brief Converts a rtr_socket_state to a String.

--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -49,14 +49,14 @@
  * @param client_privkey_path Path to the private key of the authentication keypair.
  * @param client_pubkey_path Path to the public key of the authentication keypair.
  */
-typedef struct tr_ssh_config {
+struct tr_ssh_config {
     char *host;
     unsigned int port;
     char *username;
     char *server_hostkey_path;
     char *client_privkey_path;
     char *client_pubkey_path;
-} tr_ssh_config;
+};
 
 /**
  * @brief Initializes the tr_socket struct for a SSH connection.
@@ -65,7 +65,7 @@ typedef struct tr_ssh_config {
  * @returns TR_SUCCESS On success.
  * @returns TR_ERROR On error.
  */
-int tr_ssh_init(const tr_ssh_config *config, tr_socket *socket);
+int tr_ssh_init(const struct tr_ssh_config *config, struct tr_socket *socket);
 
 #endif
 /* @} */

--- a/rtrlib/transport/tcp/tcp_transport.c
+++ b/rtrlib/transport/tcp/tcp_transport.c
@@ -35,15 +35,15 @@
 #define TCP_DBG(fmt, sock, ...) dbg("TCP Transport(%s:%s): " fmt, sock->config.host, sock->config.port, ## __VA_ARGS__)
 #define TCP_DBG1(a, sock) dbg("TCP Transport(%s:%s): " a,sock->config.host, sock->config.port)
 
-typedef struct tr_tcp_socket {
+struct tr_tcp_socket {
     int socket;
-    tr_tcp_config config;
+    struct tr_tcp_config config;
     char *ident;
-} tr_tcp_socket;
+};
 
 static int tr_tcp_open(void *tr_tcp_sock);
 static void tr_tcp_close(void *tr_tcp_sock);
-static void tr_tcp_free(tr_socket *tr_sock);
+static void tr_tcp_free(struct tr_socket *tr_sock);
 static int tr_tcp_recv(const void *tr_tcp_sock, void *pdu, const size_t len, const time_t timeout);
 static int tr_tcp_send(const void *tr_tcp_sock, const void *pdu, const size_t len, const time_t timeout);
 static const char *tr_tcp_ident(void *socket);
@@ -51,7 +51,7 @@ static const char *tr_tcp_ident(void *socket);
 int tr_tcp_open(void *tr_socket) {
 
     int rtval = TR_ERROR;
-    tr_tcp_socket *tcp_socket = tr_socket;
+    struct tr_tcp_socket *tcp_socket = tr_socket;
     assert(tcp_socket->socket == -1);
 
     struct addrinfo hints;
@@ -86,15 +86,15 @@ end:
 }
 
 void tr_tcp_close(void *tr_tcp_sock) {
-    tr_tcp_socket *tcp_socket = tr_tcp_sock;
+    struct tr_tcp_socket *tcp_socket = tr_tcp_sock;
     if(tcp_socket->socket != -1)
         close(tcp_socket->socket);
     TCP_DBG1("Socket closed", tcp_socket);
     tcp_socket->socket = -1;
 }
 
-void tr_tcp_free(tr_socket *tr_sock) {
-    tr_tcp_socket *tcp_sock = tr_sock->socket;
+void tr_tcp_free(struct tr_socket *tr_sock) {
+    struct tr_tcp_socket *tcp_sock = tr_sock->socket;
     assert(tcp_sock != NULL);
     assert(tcp_sock->socket == -1);
 
@@ -106,7 +106,7 @@ void tr_tcp_free(tr_socket *tr_sock) {
 }
 
 int tr_tcp_recv(const void *tr_tcp_sock, void *pdu, const size_t len, const time_t timeout) {
-    const tr_tcp_socket *tcp_socket = tr_tcp_sock;
+    const struct tr_tcp_socket *tcp_socket = tr_tcp_sock;
     int rtval;
     if(timeout == 0)
         rtval = recv(tcp_socket->socket, pdu, len, MSG_DONTWAIT);
@@ -133,7 +133,7 @@ int tr_tcp_recv(const void *tr_tcp_sock, void *pdu, const size_t len, const time
 }
 
 int tr_tcp_send(const void *tr_tcp_sock, const void *pdu, const size_t len, const time_t timeout) {
-    const tr_tcp_socket *tcp_socket = tr_tcp_sock;
+    const struct tr_tcp_socket *tcp_socket = tr_tcp_sock;
     int rtval;
     if(timeout == 0)
         rtval = send(tcp_socket->socket, pdu, len, MSG_DONTWAIT);
@@ -161,7 +161,7 @@ int tr_tcp_send(const void *tr_tcp_sock, const void *pdu, const size_t len, cons
 
 const char *tr_tcp_ident(void *socket) {
     size_t len;
-    tr_tcp_socket *sock = socket;
+    struct tr_tcp_socket *sock = socket;
 
     assert(socket != NULL);
 
@@ -177,7 +177,7 @@ const char *tr_tcp_ident(void *socket) {
     return sock->ident;
 }
 
-int tr_tcp_init(const tr_tcp_config *config, tr_socket *socket) {
+int tr_tcp_init(const struct tr_tcp_config *config, struct tr_socket *socket) {
 
     socket->close_fp = &tr_tcp_close;
     socket->free_fp = &tr_tcp_free;
@@ -186,8 +186,8 @@ int tr_tcp_init(const tr_tcp_config *config, tr_socket *socket) {
     socket->send_fp = &tr_tcp_send;
     socket->ident_fp = &tr_tcp_ident;
 
-    socket->socket = malloc(sizeof(tr_tcp_socket));
-    tr_tcp_socket *tcp_socket = socket->socket;
+    socket->socket = malloc(sizeof(struct tr_tcp_socket));
+    struct tr_tcp_socket *tcp_socket = socket->socket;
     tcp_socket->socket = -1;
     tcp_socket->config = *config;
     tcp_socket->ident = NULL;

--- a/rtrlib/transport/tcp/tcp_transport.h
+++ b/rtrlib/transport/tcp/tcp_transport.h
@@ -38,10 +38,10 @@
  * @param host Hostname or IP address to connect to.
  * @param port Port to connect to.
  */
-typedef struct tr_tcp_config {
+struct tr_tcp_config {
     char *host;
     char *port;
-} tr_tcp_config;
+};
 
 
 /**
@@ -51,6 +51,6 @@ typedef struct tr_tcp_config {
  * @returns TR_SUCCESS On success.
  * @returns TR_ERROR On error.
  */
-int tr_tcp_init(const tr_tcp_config *config, tr_socket *socket);
+int tr_tcp_init(const struct tr_tcp_config *config, struct tr_socket *socket);
 #endif
 /* @} */

--- a/rtrlib/transport/transport.c
+++ b/rtrlib/transport/transport.c
@@ -23,31 +23,31 @@
 #include "rtrlib/transport/transport.h"
 #include "rtrlib/lib/utils.h"
 
-inline int tr_open(tr_socket *socket) {
+inline int tr_open(struct tr_socket *socket) {
     return socket->open_fp(socket->socket);
 }
 
-inline void tr_close(tr_socket *socket) {
+inline void tr_close(struct tr_socket *socket) {
     socket->close_fp(socket->socket);
 }
 
-inline void tr_free(tr_socket *socket) {
+inline void tr_free(struct tr_socket *socket) {
     socket->free_fp(socket);
 }
 
-inline int tr_send(const tr_socket *socket, const void *pdu, const size_t len, const time_t timeout) {
+inline int tr_send(const struct tr_socket *socket, const void *pdu, const size_t len, const time_t timeout) {
     return socket->send_fp(socket->socket, pdu, len, timeout);
 }
 
-inline int tr_recv(const tr_socket *socket, void *buf, const size_t len, const time_t timeout) {
+inline int tr_recv(const struct tr_socket *socket, void *buf, const size_t len, const time_t timeout) {
     return socket->recv_fp(socket->socket, buf, len, timeout);
 }
 
-inline const char *tr_ident(tr_socket *sock) {
+inline const char *tr_ident(struct tr_socket *sock) {
 	return sock->ident_fp(sock->socket);
 }
 
-int tr_send_all(const tr_socket *socket, const void *pdu, const size_t len, const time_t timeout) {
+int tr_send_all(const struct tr_socket *socket, const void *pdu, const size_t len, const time_t timeout) {
     unsigned int total_send = 0;
     int rtval = 0;
     time_t end_time;
@@ -66,7 +66,7 @@ int tr_send_all(const tr_socket *socket, const void *pdu, const size_t len, cons
     return total_send;
 }
 
-int tr_recv_all(const tr_socket *socket, const void *pdu, const size_t len, const time_t timeout) {
+int tr_recv_all(const struct tr_socket *socket, const void *pdu, const size_t len, const time_t timeout) {
     size_t total_recv = 0;
     int rtval = 0;
     time_t end_time;

--- a/rtrlib/transport/transport.h
+++ b/rtrlib/transport/transport.h
@@ -102,7 +102,7 @@ typedef const char *(*tr_ident_fp)(void *socket);
  * @param send_fp Pointer to a function that sends data through this socket.
  * @param recv_fp Pointer to a function that receives data from this socket.
  */
-typedef struct tr_socket {
+struct tr_socket {
     void *socket;
     tr_open_fp open_fp;
     tr_close_fp close_fp;
@@ -110,7 +110,7 @@ typedef struct tr_socket {
     tr_send_fp send_fp;
     tr_recv_fp recv_fp;
     tr_ident_fp ident_fp;
-} tr_socket;
+};
 
 
 /**
@@ -119,20 +119,20 @@ typedef struct tr_socket {
  * @return TR_SUCCESS On success.
  * @return TR_ERROR On error.
  */
-int tr_open(tr_socket *socket);
+int tr_open(struct tr_socket *socket);
 
 /**
  * @brief Close the socket connection.
  * @param[in] socket Socket that will be closed.
  */
-void tr_close(tr_socket *socket);
+void tr_close(struct tr_socket *socket);
 
 /**
  * @brief Deallocates all memory that the passed socket uses.
  * Socket have to be closed before.
  * @param[in] socket which will be freed.
  */
-void tr_free(tr_socket *socket);
+void tr_free(struct tr_socket *socket);
 
 /**
  * @brief Receives <= len Bytes data from the socket.
@@ -144,7 +144,7 @@ void tr_free(tr_socket *socket);
  * @return TR_ERROR On error.
  * @return TR_WOULDBLOCK If no data was available at the socket before the timeout expired.
  */
-int tr_recv(const tr_socket *socket, void *buf, const size_t len, const time_t timeout);
+int tr_recv(const struct tr_socket *socket, void *buf, const size_t len, const time_t timeout);
 
 /**
  * @brief Send <= len Bytes data over the socket.
@@ -155,7 +155,7 @@ int tr_recv(const tr_socket *socket, void *buf, const size_t len, const time_t t
  * @return >0 Number of Bytes sent.
  * @return TR_ERROR On error.
  */
-int tr_send(const tr_socket *socket, const void *pdu, const size_t len, const time_t timeout);
+int tr_send(const struct tr_socket *socket, const void *pdu, const size_t len, const time_t timeout);
 
 /**
  * Repeatly calls tr_send(..) till len Bytes were sent, the timeout expired or an error occured.
@@ -167,7 +167,7 @@ int tr_send(const tr_socket *socket, const void *pdu, const size_t len, const ti
  * @return TR_ERROR On Error.
  * @return TR_WOULDBLOCK If send would block.
  */
-int tr_send_all(const tr_socket *socket, const void *pdu, const size_t len, const time_t timeout);
+int tr_send_all(const struct tr_socket *socket, const void *pdu, const size_t len, const time_t timeout);
 
 /**
  * Repeatly calls tr_recv(..) till len Bytes were received, the timeout expired or an error occured.
@@ -179,7 +179,7 @@ int tr_send_all(const tr_socket *socket, const void *pdu, const size_t len, cons
  * @return TR_ERROR On error.
  * @return TR_WOULDBLOCK If send would block.
  */
-int tr_recv_all(const tr_socket *socket, const void *buf, const size_t len, const time_t timeout);
+int tr_recv_all(const struct tr_socket *socket, const void *buf, const size_t len, const time_t timeout);
 
 /**
  * Returns an identifier for the socket endpoint, eg host:port.
@@ -187,7 +187,7 @@ int tr_recv_all(const tr_socket *socket, const void *buf, const size_t len, cons
  * return Pointer to a \0 terminated String
  * return NULL on error
  */
-const char *tr_ident(tr_socket *socket);
+const char *tr_ident(struct tr_socket *socket);
 
 #endif
 /* @} */

--- a/tests/test_lpfst.c
+++ b/tests/test_lpfst.c
@@ -33,10 +33,10 @@
 
 
 static void get_bits_testv4(){
-    ip_addr addr;
+    struct ip_addr addr;
     addr.ver = IPV4;
 
-    ip_addr result;
+    struct ip_addr result;
     addr.u.addr4.addr=0xAABBCC22;
 
     result = ip_addr_get_bits(&addr, 0, 32);
@@ -106,14 +106,14 @@ static void get_bits_testv4(){
 }
 
 static void get_bits_testv6(){
-    ip_addr addr;
+    struct ip_addr addr;
     addr.ver = IPV6;
     addr.u.addr6.addr[0] = 0x22AABBCC;
     addr.u.addr6.addr[1] = 0xDDEEFF99;
     addr.u.addr6.addr[2] = 0x33001122;
     addr.u.addr6.addr[3] = 0x33445566;
 
-    ip_addr result;
+    struct ip_addr result;
 
     result = ip_addr_get_bits(&addr, 0, 128);
     assert(result.u.addr6.addr[0] == addr.u.addr6.addr[0] && result.u.addr6.addr[1] == addr.u.addr6.addr[1] && result.u.addr6.addr[2] == addr.u.addr6.addr[2] && result.u.addr6.addr[3] == addr.u.addr6.addr[3]);
@@ -179,12 +179,12 @@ static void get_bits_testv6(){
 }
 
 static void lpfst_test(){
-    ip_addr addr;
+    struct ip_addr addr;
     addr.ver = IPV4;
-    lpfst_node* result;
+    struct lpfst_node* result;
     unsigned int lvl = 0;
     //n1
-    lpfst_node n1;
+    struct lpfst_node n1;
     n1.len = 16;
     n1.lchild = NULL;
     n1.rchild = NULL;
@@ -192,13 +192,13 @@ static void lpfst_test(){
     n1.data = NULL;
     ip_str_to_addr( "100.200.0.0", &(n1.prefix));
 
-    ip_str_to_addr( "100.200.0.0", &(addr)); 
+    ip_str_to_addr( "100.200.0.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
     assert(ip_str_cmp(&(result->prefix), "100.200.0.0"));
 
-    ip_str_to_addr( "100.200.30.0", &(addr)); 
+    ip_str_to_addr( "100.200.30.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
@@ -206,16 +206,16 @@ static void lpfst_test(){
 
 
     //n2
-    lpfst_node n2;
+    struct lpfst_node n2;
     n2.len = 16;
     n2.lchild = NULL;
     n2.rchild = NULL;
     n2.parent = NULL;
     n2.data = NULL;
-    ip_str_to_addr("132.200.0.0", &(n2.prefix)); 
+    ip_str_to_addr("132.200.0.0", &(n2.prefix));
     lpfst_insert(&n1, &n2, 0);
 
-    ip_str_to_addr("132.200.0.0", &(addr)); 
+    ip_str_to_addr("132.200.0.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
@@ -224,16 +224,16 @@ static void lpfst_test(){
 
 
     //n3
-    lpfst_node n3;
+    struct lpfst_node n3;
     n3.len = 16;
     n3.lchild = NULL;
     n3.rchild = NULL;
     n3.parent = NULL;
     n3.data = NULL;
-    ip_str_to_addr("101.200.0.0", &(n3.prefix)); 
+    ip_str_to_addr("101.200.0.0", &(n3.prefix));
     lpfst_insert(&n1, &n3, 0);
 
-    ip_str_to_addr("101.200.0.0", &(addr)); 
+    ip_str_to_addr("101.200.0.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
@@ -241,16 +241,16 @@ static void lpfst_test(){
     assert(n1.lchild == &n3);
 
     //n4
-    lpfst_node n4;
+    struct lpfst_node n4;
     n4.len = 24;
     n4.lchild = NULL;
     n4.rchild = NULL;
     n4.parent = NULL;
     n4.data = NULL;
-    ip_str_to_addr("132.200.3.0", &(n4.prefix)); 
+    ip_str_to_addr("132.200.3.0", &(n4.prefix));
     lpfst_insert(&n1, &n4, 0);
 
-    ip_str_to_addr("132.200.3.0", &(addr)); 
+    ip_str_to_addr("132.200.3.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 24, &lvl);
     assert(result != NULL);
@@ -264,13 +264,13 @@ static void lpfst_test(){
     assert(ip_str_cmp(&(n1.lchild->rchild->prefix), "100.200.0.0"));
     assert(n1.lchild->rchild->len == 16);
 
-    ip_str_to_addr("132.200.0.0", &(addr)); 
+    ip_str_to_addr("132.200.0.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
     assert(ip_str_cmp(&(result->prefix), "132.200.0.0"));
 
-    ip_str_to_addr("132.200.3.0", &(addr)); 
+    ip_str_to_addr("132.200.3.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
@@ -278,13 +278,13 @@ static void lpfst_test(){
 
 
     lvl = 0;
-    ip_str_to_addr("132.0.0.0", &(addr)); 
+    ip_str_to_addr("132.0.0.0", &(addr));
     bool found;
     result = lpfst_lookup_exact(&n1, &addr, 16, &lvl, &found);
     assert(!found);
 
     lvl = 0;
-    ip_str_to_addr("132.200.3.0", &(addr)); 
+    ip_str_to_addr("132.200.3.0", &(addr));
     result = lpfst_lookup_exact(&n1, &addr, 24, &lvl, &found);
     assert(found);
     assert(ip_str_cmp(&(result->prefix), "132.200.3.0"));
@@ -296,13 +296,13 @@ static void lpfst_test(){
     assert(ip_str_cmp(&(n1.lchild->rchild->prefix), "100.200.0.0"));
     assert(n1.rchild == NULL);
 
-    ip_str_to_addr("101.200.0.0", &(addr)); 
+    ip_str_to_addr("101.200.0.0", &(addr));
     result = lpfst_remove(&n1, &addr, 16, 0);
     assert(result != NULL);
     assert(ip_str_cmp(&(n1.lchild->prefix), "100.200.0.0"));
     assert(n1.rchild == NULL);
 
-    ip_str_to_addr("100.200.0.0", &(addr)); 
+    ip_str_to_addr("100.200.0.0", &(addr));
     result = lpfst_remove(&n1, &addr, 16, 0);
     assert(result != NULL);
     assert(n1.lchild == NULL);

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -32,11 +32,11 @@
 #include "rtrlib/pfx/lpfst/lpfst-pfx.h"
 
 static void remove_src_test(){
-    pfx_table pfxt;
+    struct pfx_table pfxt;
     pfx_table_init(&pfxt, NULL);
-   rtr_socket tr1;
+    struct rtr_socket tr1;
 
-    pfx_record pfx;
+    struct pfx_record pfx;
     pfx.min_len = 32;
     pfx.max_len = 32;
 
@@ -61,7 +61,7 @@ static void remove_src_test(){
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
     unsigned int len = 0;
-    lpfst_node** array = NULL;
+    struct lpfst_node** array = NULL;
     assert(lpfst_get_children(pfxt.ipv4, &array, &len) != -1);
     free(array);
     array = NULL;
@@ -90,10 +90,10 @@ static void remove_src_test(){
 }
 
 static void mass_test(){
-    pfx_table pfxt;
+    struct pfx_table pfxt;
     pfx_table_init(&pfxt, NULL);
 
-    pfx_record rec;
+    struct pfx_record rec;
     pfxv_state res;
     const uint32_t min_i = 0xFFFF0000;
     const uint32_t max_i = 0xFFFFFFF0;
@@ -165,10 +165,10 @@ static void mass_test(){
 }
 
 int main(){
-    pfx_table pfxt;
+    struct pfx_table pfxt;
     pfx_table_init(&pfxt, NULL);
 
-    pfx_record pfx;
+    struct pfx_record pfx;
     pfx.asn = 123;
     pfx.prefix.ver = IPV4;
     ip_str_to_addr("10.10.0.0", &(pfx.prefix));
@@ -334,7 +334,7 @@ int main(){
     pfx.asn=5;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
-    pfx_record* r = NULL;
+    struct pfx_record* r = NULL;
     unsigned int r_len = 0;
     assert(ip_str_to_addr("10.1.0.0", &(pfx.prefix)) == 0);
     assert(pfx_table_validate_r(&pfxt, &r, &r_len, 123, &(pfx.prefix), 16, &res) == PFX_SUCCESS);

--- a/tests/test_pfx_locks.c
+++ b/tests/test_pfx_locks.c
@@ -35,9 +35,9 @@
 uint32_t min_i = 0xFF000000;
 uint32_t max_i = 0xFFFFFFF0;
 
-static void rec_insert(pfx_table* pfxt){
+static void rec_insert(struct pfx_table* pfxt){
     const int tid = getpid();
-    pfx_record rec;
+    struct pfx_record rec;
     rec.min_len = 32;
     rec.max_len = 32;
     rec.prefix.ver = IPV4;
@@ -69,9 +69,9 @@ static void rec_insert(pfx_table* pfxt){
         //printf("%i: Record inserted\n", tid);
     }
 }
-static void rec_validate(pfx_table* pfxt){
+static void rec_validate(struct pfx_table* pfxt){
     const int tid = getpid();
-    pfx_record rec;
+    struct pfx_record rec;
     rec.min_len = 32;
     rec.max_len = 32;
     rec.prefix.ver = IPV4;
@@ -103,9 +103,9 @@ static void rec_validate(pfx_table* pfxt){
         usleep(rand() / (RAND_MAX / 20));
     }
 }
-static void rec_remove(pfx_table* pfxt){
+static void rec_remove(struct pfx_table* pfxt){
     const int tid = getpid();
-    pfx_record rec;
+    struct pfx_record rec;
     rec.min_len = 32;
     rec.max_len = 32;
     rec.prefix.ver = IPV4;
@@ -142,7 +142,7 @@ static void rec_remove(pfx_table* pfxt){
 
 int main(){
     unsigned int max_threads = 15;
-    pfx_table pfxt;
+    struct pfx_table pfxt;
     pfx_table_init(&pfxt, NULL);
     pthread_t threads[max_threads];
     srand(time(NULL));

--- a/tools/rtrclient.c
+++ b/tools/rtrclient.c
@@ -43,8 +43,8 @@ static void print_usage(char** argv){
 
 }
 
-static void status_fp(const rtr_mgr_group *group __attribute__((unused)),
-			   rtr_mgr_status mgr_status, const rtr_socket *rtr_sock,
+static void status_fp(const struct rtr_mgr_group *group __attribute__((unused)),
+			   rtr_mgr_status mgr_status, const struct rtr_socket *rtr_sock,
 			   void *data __attribute__((unused)))
 {
 	printf("RTR-Socket changed connection status to: %s, Mgr Status: %s\n",
@@ -52,7 +52,7 @@ static void status_fp(const rtr_mgr_group *group __attribute__((unused)),
 		   rtr_mgr_status_to_str(mgr_status));
 }
 
-static void update_cb(struct pfx_table* p  __attribute__((unused)), const pfx_record rec, const bool added){
+static void update_cb(struct pfx_table* p  __attribute__((unused)), const struct pfx_record rec, const bool added){
     char ip[INET6_ADDRSTRLEN];
     if(added)
         printf("+ ");
@@ -106,19 +106,19 @@ int main(int argc, char** argv){
         return(EXIT_FAILURE);
     }
 
-    tr_socket tr_sock;
-    tr_tcp_config tcp_config;
+    struct tr_socket tr_sock;
+    struct tr_tcp_config tcp_config;
 #ifdef RTRLIB_HAVE_LIBSSH
-    tr_ssh_config ssh_config;
+    struct tr_ssh_config ssh_config;
 #endif
     if(mode == TCP){
-        tcp_config = (tr_tcp_config) { host, port };
+        tcp_config = (struct tr_tcp_config) { host, port };
         tr_tcp_init(&tcp_config, &tr_sock);
     }
 #ifdef RTRLIB_HAVE_LIBSSH
     else{
         unsigned int iport = atoi(port);
-        ssh_config = (tr_ssh_config) {
+        ssh_config = (struct tr_ssh_config) {
             host,
             iport,
             user,
@@ -130,13 +130,13 @@ int main(int argc, char** argv){
     }
 #endif
 
-    rtr_socket rtr;
+    struct rtr_socket rtr;
     rtr.tr_socket = &tr_sock;
-    rtr_mgr_config *conf;
+    struct rtr_mgr_config *conf;
 
-    rtr_mgr_group groups[1];
+    struct rtr_mgr_group groups[1];
     groups[0].sockets_len = 1;
-    groups[0].sockets = malloc(1 * sizeof(rtr_socket*));
+    groups[0].sockets = malloc(1 * sizeof(rtr));
     groups[0].sockets[0] = &rtr;
     groups[0].preference = 1;
 


### PR DESCRIPTION
Eliminated all "typedef struct"s as it says "It's a _mistake_ to use typedef for structures and pointers." in the Kernel coding style.
