### PR TITLE
Newer LibSSH 0.6.0 API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(RTRLIB_SRC rtrlib/rtr_mgr.c rtrlib/lib/utils.c rtrlib/lib/ip.c rtrlib/lib/ip
     rtrlib/transport/tcp/tcp_transport.c rtrlib/rtr/rtr.c rtrlib/rtr/packets.c)
 set(RTRLIB_LINK ${RT_LIB} ${CMAKE_THREAD_LIBS_INIT})
 
-find_package(LibSSH 0.4.0)
+find_package(LibSSH 0.6.0)
 if(LIBSSH_FOUND)
     set(RTRLIB_HAVE_LIBSSH 1)
     message(STATUS "libssh found, building librtr with SSH support")
@@ -63,7 +63,7 @@ set_target_properties(rtrlib PROPERTIES SOVERSION ${LIBRARY_SOVERSION} VERSION $
 install(TARGETS rtrlib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/)
 
 #install includes
-install(DIRECTORY rtrlib/ DESTINATION include/rtrlib 
+install(DIRECTORY rtrlib/ DESTINATION include/rtrlib
     FILES_MATCHING PATTERN "*.h"
     PATTERN rtrlib/rtr_mgr. EXCLUDE)
 

--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -45,9 +45,8 @@
  * @param host Hostname or IP address to connect to.
  * @param port Port to connect to.
  * @param username Username for authentication.
- * @param server_hostkey_path Path to the public SSH key of the server.
- * @param client_privkey_path Path to the private key of the authentication keypair.
- * @param client_pubkey_path Path to the public key of the authentication keypair.
+ * @param server_hostkey_path Path to the public SSH key of the server or `NULL` for the LibSSH default.
+ * @param client_privkey_path Path to the private key of the authentication keypair or `NULL` for the LibSSH default.
  */
 struct tr_ssh_config {
     char *host;
@@ -55,7 +54,6 @@ struct tr_ssh_config {
     char *username;
     char *server_hostkey_path;
     char *client_privkey_path;
-    char *client_pubkey_path;
 };
 
 /**


### PR DESCRIPTION
The newer LibSSH 0.6.0 API prefers ssh_options_set() calls for setting usernames and private keys. Also, public key "support" has been removed (moved to legacy.h). This simplifies things quite a bit. Also, specifying the host key file and the private key file can be optional this way.
