### PR TITLE
Update documentation related to default options for "known hosts" and "private key"

### DIFF
--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -46,9 +46,10 @@
  * @param port Port to connect to.
  * @param username Username for authentication.
  * @param server_hostkey_path Path to public SSH key of the server or NULL to
-                              don't verify host authenticity.
+                              use the system default (e.g. ~/.ssh/known_hosts).
  * @param client_privkey_path Path to private key of the authentication keypair
- *                            or NULL to use ~/.ssh/id_rsa.
+ *                            or NULL to use the system default (e.g.
+ *                            ~/.ssh/id_rsa).
  */
 struct tr_ssh_config {
     char *host;


### PR DESCRIPTION
The documentation is wrong regarding what happens when the "known hosts" and "private key" options are NULL. According to the documentation at http://api.libssh.org/stable/group__libssh__session.html#ga7a801b85800baa3f4e16f5b47db0a73d they both default to the system default, which is not always ~/.ssh/*.

P.S.: I don't know why GitHub keeps telling me that I would like to pull request more than one commit when it is actually only one. I pulled from upstream (rtrlib/rtrlib), pushed to origin (my fork), made my changes, pushed to origin and filed the pull request.
