### PR TITLE
support for OS X, minor tool fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,9 @@ endif(CMAKE_BUILD_TYPE STREQUAL Debug)
 
 include_directories(.)
 find_package(Threads REQUIRED)
-find_library(RT_LIB rt)
+if(NOT APPLE)
+    find_library(RT_LIB rt)
+endif(NOT APPLE)
 include(UseMultiArch) # needed for debian packaging
 
 set(RTRLIB_SRC rtrlib/rtr_mgr.c rtrlib/lib/utils.c rtrlib/lib/ip.c rtrlib/lib/ipv4.c rtrlib/lib/ipv6.c rtrlib/lib/log.c

--- a/tools/cli-validator.c
+++ b/tools/cli-validator.c
@@ -91,7 +91,10 @@ int main(int argc, char *argv[]) {
 			return 0;
 		}
 
-		fgets(input, 256, stdin);
+		if(!fgets(input, 256, stdin)) {
+            printf("input error\n");
+            return 1;
+        }
 		// Remove newline, if present
 		inputLength = strlen(input) - 1;
 		if (input[inputLength] == '\n')

--- a/tools/cli-validator.c
+++ b/tools/cli-validator.c
@@ -92,9 +92,9 @@ int main(int argc, char *argv[]) {
 		}
 
 		if(!fgets(input, 256, stdin)) {
-            printf("input error\n");
-            return 1;
-        }
+			printf("input error\n");
+			return 1;
+		}
 		// Remove newline, if present
 		inputLength = strlen(input) - 1;
 		if (input[inputLength] == '\n')


### PR DESCRIPTION
I made some minor changes to compile and run rtrlib under OS X (10.10, to be precise). These will not affect any other systems (Ubuntu, BSD), just some #ifdef statements.

Further a fix for cli-validator.c is also provided, fixing a problem with broken input pipe. Resulting in high cpu load by a quasi zombie cli-validator process.