### PR TITLE
SSH Transport: use new LibSSH API

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ Requirements
 To build the RTRlib, the CMake build system must be installed.
 
 To establish an SSH connection between RTR-Client and RTR-Server, the
-libssh 0.6.x library must also be installed.
+libssh 0.6.x or higher library must also be installed.
 
 Doxygen (optional) is required to create the HTML documentation.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,5 @@
+  * Update libssh API
+
 librtr0 (0.3.5-1) stable; urgency=low
 
   * New upstream version 0.3.5

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: librtr0
 Section: libs
 Priority: optional
 Maintainer: Fabian Holler <mail@fholler.de>
-Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev, doxygen
+Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev (>= 0.6.0), doxygen
 Standards-Version: 3.9.4
 Vcs-Git: git://github.com/rtrlib/rtrlib.git
 Vcs-Browser: https://github.com/rtrlib/rtrlib
@@ -12,7 +12,7 @@ Package: librtr0
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}, libssh-4
+Depends: ${shlibs:Depends}, ${misc:Depends}, libssh-4 (>= 0.6.0)
 Description: Small extensible RPKI-RTR-Client C library.
  RTRlib is an open-source C implementation of the  RPKI/Router Protocol
  client. The library allows one to fetch and store validated prefix origin data
@@ -69,7 +69,7 @@ Description: Small extensible RPKI-RTR-Client C library. Documentation files
 Package: rtrclient
 Section: utils
 Architecture: any
-Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libssh-4
+Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libssh-4 (>= 0.6.0)
 Description: RPKI-RTR command line tool
  Rtrclient is command line that connects to an RPKI-RTR server and prints
  protocol information and information about the fetched ROAs to the console.
@@ -90,7 +90,7 @@ Description: RPKI-RTR command line tool
 Package: cli-validator
 Section: utils
 Architecture: any
-Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libssh-4
+Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libssh-4 (>= 0.6.0)
 Description: RPKI-RTR command line tool
  Cli-validator is a command line tool that connects to an RPKI-RTR server and
  allows to validate given IP prefixes and origin ASes.

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -146,19 +146,14 @@ int tr_ssh_recv_async(const struct tr_ssh_socket *tr_ssh_sock, void *buf, const 
     return rtval;
 }
 
-// channel_select is broken, it ignores the timeval parameter and blocks forever :/
-// ssh_channel_select is corrected with timeval parameter :-)
 int tr_ssh_recv(const void* tr_ssh_sock, void* buf, const size_t buf_len, const time_t timeout){
     ssh_channel rchans[2] = { ((struct tr_ssh_socket*) tr_ssh_sock)->channel, NULL };
 
     struct timeval timev = { 1, 0 };
 
-    const int rtval = ssh_channel_select(rchans, NULL, NULL, &timev);
-
-    if(rtval == SSH_ERROR)
-        return TR_ERROR;
-    if(rtval == SSH_EINTR)
+    if(ssh_channel_select(rchans, NULL, NULL, &timev) == SSH_EINTR)
         return TR_INTR;
+
     if(ssh_channel_is_eof(((struct tr_ssh_socket*) tr_ssh_sock)->channel) != 0)
         return SSH_ERROR;
 

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -129,27 +129,6 @@ void tr_ssh_free(struct tr_socket *tr_sock)
     SSH_DBG1("Socket freed", tr_ssh_sock);
 }
 
-/*
-int tr_ssh_recv(const void* tr_ssh_sock, void* buf, unsigned int buf_len, const unsigned int timeout){
-    if(timeout > 0){
-        struct timeval timev;
-        //timev.tv_sec = timeout;
-        timev.tv_sec = 0;
-        timev.tv_usec = 1;
-        ssh_channel channels[2] = { (((tr_ssh_socket*) tr_ssh_sock)->channel), NULL };
-
-        if(channel_select(channels, NULL, NULL, &timev) == SSH_OK){
-        SSH_DBG("END");
-            if(channels[0] == NULL)
-                return -2;
-        }
-        SSH_DBG("END");
-        //TODO: select kann INTr zurückgeben, wurde durch signal unterbrochen, dann verbleibende zeit berechnen und nochma
-        //select ausführen
-    }
-    return channel_read_nonblocking(((tr_ssh_socket*) tr_ssh_sock)->channel, buf, buf_len, false);
-}
-*/
 int tr_ssh_recv_async(const struct tr_ssh_socket *tr_ssh_sock, void *buf, const size_t buf_len)
 {
     const int rtval = ssh_channel_read_nonblocking(tr_ssh_sock->channel, buf, buf_len, false);

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -17,8 +17,8 @@
 #include "../../lib/utils.h"
 #include "ssh_transport.h"
 
-#define SSH_DBG(fmt, sock, ...) dbg("SSH Transport(%s@%s:%u): " fmt, sock->config.username, sock->config.host, sock->config.port, ## __VA_ARGS__)
-#define SSH_DBG1(a, sock) dbg("SSH Transport(%s@%s:%u): " a, sock->config.username, sock->config.host, sock->config.port)
+#define SSH_DBG(fmt, sock, ...) dbg("SSH Transport(%s@%s:%u): " fmt, (sock)->config.username, (sock)->config.host, (sock)->config.port, ## __VA_ARGS__)
+#define SSH_DBG1(a, sock) dbg("SSH Transport(%s@%s:%u): " a, (sock)->config.username, (sock)->config.host, (sock)->config.port)
 
 struct tr_ssh_socket {
     ssh_session session;
@@ -79,13 +79,13 @@ int tr_ssh_open(void *socket)
         goto error;
     }
 
-    if((ssh_socket->channel = channel_new(ssh_socket->session)) == NULL)
+    if((ssh_socket->channel = ssh_channel_new(ssh_socket->session)) == NULL)
         goto error;
 
-    if(channel_open_session(ssh_socket->channel) == SSH_ERROR)
+    if(ssh_channel_open_session(ssh_socket->channel) == SSH_ERROR)
         goto error;
 
-    if(channel_request_subsystem(ssh_socket->channel, "rpki-rtr") == SSH_ERROR) {
+    if(ssh_channel_request_subsystem(ssh_socket->channel, "rpki-rtr") == SSH_ERROR) {
         SSH_DBG1("tr_ssh_init: Error requesting subsystem rpki-rtr", ssh_socket);
         goto error;
     }
@@ -104,9 +104,9 @@ void tr_ssh_close(void *tr_ssh_sock)
     struct tr_ssh_socket *socket = tr_ssh_sock;
 
     if(socket->channel != NULL) {
-        if(channel_is_open(socket->channel))
-            channel_close(socket->channel);
-        channel_free(socket->channel);
+        if(ssh_channel_is_open(socket->channel))
+            ssh_channel_close(socket->channel);
+        ssh_channel_free(socket->channel);
         socket->channel = NULL;
     }
     if(socket->session != NULL) {
@@ -129,32 +129,11 @@ void tr_ssh_free(struct tr_socket *tr_sock)
     SSH_DBG1("Socket freed", tr_ssh_sock);
 }
 
-/*
-int tr_ssh_recv(const void* tr_ssh_sock, void* buf, unsigned int buf_len, const unsigned int timeout){
-    if(timeout > 0){
-        struct timeval timev;
-        //timev.tv_sec = timeout;
-        timev.tv_sec = 0;
-        timev.tv_usec = 1;
-        ssh_channel channels[2] = { (((tr_ssh_socket*) tr_ssh_sock)->channel), NULL };
-
-        if(channel_select(channels, NULL, NULL, &timev) == SSH_OK){
-        SSH_DBG("END");
-            if(channels[0] == NULL)
-                return -2;
-        }
-        SSH_DBG("END");
-        //TODO: select kann INTr zurückgeben, wurde durch signal unterbrochen, dann verbleibende zeit berechnen und nochma
-        //select ausführen
-    }
-    return channel_read_nonblocking(((tr_ssh_socket*) tr_ssh_sock)->channel, buf, buf_len, false);
-}
-*/
 int tr_ssh_recv_async(const struct tr_ssh_socket *tr_ssh_sock, void *buf, const size_t buf_len)
 {
-    const int rtval = channel_read_nonblocking(tr_ssh_sock->channel, buf, buf_len, false);
+    const int rtval = ssh_channel_read_nonblocking(tr_ssh_sock->channel, buf, buf_len, false);
     if(rtval == 0) {
-        if(channel_is_eof(tr_ssh_sock->channel) != 0) {
+        if(ssh_channel_is_eof(tr_ssh_sock->channel) != 0) {
             SSH_DBG1("remote has sent EOF", tr_ssh_sock);
             return TR_CLOSED;
         } else {
@@ -164,59 +143,37 @@ int tr_ssh_recv_async(const struct tr_ssh_socket *tr_ssh_sock, void *buf, const 
         SSH_DBG1("recv(..) error", tr_ssh_sock);
         return TR_ERROR;
     }
+
     return rtval;
 }
 
-int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const time_t timeout)
+int tr_ssh_recv(const void* tr_ssh_sock, void* buf, const size_t buf_len, const time_t timeout)
 {
-    if(timeout == 0)
-        return tr_ssh_recv_async(tr_ssh_sock, buf, buf_len);
-
-    time_t end_time;
-    rtr_get_monotonic_time(&end_time);
-    end_time += timeout;
-    time_t cur_time;
-    do {
-        int rtval = channel_poll(((struct tr_ssh_socket *) tr_ssh_sock)->channel, false);
-        if(rtval > 0)
-            return tr_ssh_recv_async(tr_ssh_sock, buf, buf_len);
-        else if(rtval == SSH_ERROR) {
-            return TR_ERROR;
-        }
-
-        sleep(1);
-        rtr_get_monotonic_time(&cur_time);
-    } while((end_time - cur_time) >0);
-    return TR_WOULDBLOCK;;
-}
-
-// channel_select is broken, it ignores the timeval parameter and blocks forever :/
-/*
-int tr_ssh_recv(const void* tr_ssh_sock, void* buf, const size_t buf_len, const time_t timeout){
-    ssh_channel rchans[2] = { ((tr_ssh_socket*) tr_ssh_sock)->channel, NULL };
+    ssh_channel rchans[2] = { ((struct tr_ssh_socket*) tr_ssh_sock)->channel, NULL };
 
     struct timeval timev = { 1, 0 };
 
-    const int rtval = channel_select(rchans, NULL, NULL, &timev);
+    const int rtval = ssh_channel_select(rchans, NULL, NULL, &timev);
 
-    if(rtval == SSH_ERROR)
-        return TR_ERROR;
+    if(rtval == SSH_ERROR) {
+	SSH_DBG1("recv(..) error", (const struct tr_ssh_socket *)tr_ssh_sock);
+	return TR_ERROR;
+    }
     if(rtval == SSH_EINTR)
         return TR_INTR;
-    if(channel_is_eof(((tr_ssh_socket*) tr_ssh_sock)->channel) != 0)
+    if(ssh_channel_is_eof(((struct tr_ssh_socket*) tr_ssh_sock)->channel) != 0)
         return SSH_ERROR;
 
     if(rchans[0] == NULL)
         return TR_WOULDBLOCK;
 
-
     return tr_ssh_recv_async(tr_ssh_sock, buf, buf_len);
 }
-*/
+
 
 int tr_ssh_send(const void *tr_ssh_sock, const void *pdu, const size_t len, const time_t timeout __attribute__((unused)))
 {
-    return channel_write(((struct tr_ssh_socket *) tr_ssh_sock)->channel, pdu, len);
+    return ssh_channel_write(((struct tr_ssh_socket *) tr_ssh_sock)->channel, pdu, len);
 }
 
 const char *tr_ssh_ident(void *tr_ssh_sock)

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -17,8 +17,8 @@
 #include "../../lib/utils.h"
 #include "ssh_transport.h"
 
-#define SSH_DBG(fmt, sock, ...) dbg("SSH Transport(%s@%s:%u): " fmt, (sock)->config.username, (sock)->config.host, (sock)->config.port, ## __VA_ARGS__)
-#define SSH_DBG1(a, sock) dbg("SSH Transport(%s@%s:%u): " a, (sock)->config.username, (sock)->config.host, (sock)->config.port)
+#define SSH_DBG(fmt, sock, ...) dbg("SSH Transport(%s@%s:%u): " fmt, sock->config.username, sock->config.host, sock->config.port, ## __VA_ARGS__)
+#define SSH_DBG1(a, sock) dbg("SSH Transport(%s@%s:%u): " a, sock->config.username, sock->config.host, sock->config.port)
 
 struct tr_ssh_socket {
     ssh_session session;
@@ -79,13 +79,13 @@ int tr_ssh_open(void *socket)
         goto error;
     }
 
-    if((ssh_socket->channel = ssh_channel_new(ssh_socket->session)) == NULL)
+    if((ssh_socket->channel = channel_new(ssh_socket->session)) == NULL)
         goto error;
 
-    if(ssh_channel_open_session(ssh_socket->channel) == SSH_ERROR)
+    if(channel_open_session(ssh_socket->channel) == SSH_ERROR)
         goto error;
 
-    if(ssh_channel_request_subsystem(ssh_socket->channel, "rpki-rtr") == SSH_ERROR) {
+    if(channel_request_subsystem(ssh_socket->channel, "rpki-rtr") == SSH_ERROR) {
         SSH_DBG1("tr_ssh_init: Error requesting subsystem rpki-rtr", ssh_socket);
         goto error;
     }
@@ -104,9 +104,9 @@ void tr_ssh_close(void *tr_ssh_sock)
     struct tr_ssh_socket *socket = tr_ssh_sock;
 
     if(socket->channel != NULL) {
-        if(ssh_channel_is_open(socket->channel))
-            ssh_channel_close(socket->channel);
-        ssh_channel_free(socket->channel);
+        if(channel_is_open(socket->channel))
+            channel_close(socket->channel);
+        channel_free(socket->channel);
         socket->channel = NULL;
     }
     if(socket->session != NULL) {
@@ -129,11 +129,32 @@ void tr_ssh_free(struct tr_socket *tr_sock)
     SSH_DBG1("Socket freed", tr_ssh_sock);
 }
 
+/*
+int tr_ssh_recv(const void* tr_ssh_sock, void* buf, unsigned int buf_len, const unsigned int timeout){
+    if(timeout > 0){
+        struct timeval timev;
+        //timev.tv_sec = timeout;
+        timev.tv_sec = 0;
+        timev.tv_usec = 1;
+        ssh_channel channels[2] = { (((tr_ssh_socket*) tr_ssh_sock)->channel), NULL };
+
+        if(channel_select(channels, NULL, NULL, &timev) == SSH_OK){
+        SSH_DBG("END");
+            if(channels[0] == NULL)
+                return -2;
+        }
+        SSH_DBG("END");
+        //TODO: select kann INTr zurückgeben, wurde durch signal unterbrochen, dann verbleibende zeit berechnen und nochma
+        //select ausführen
+    }
+    return channel_read_nonblocking(((tr_ssh_socket*) tr_ssh_sock)->channel, buf, buf_len, false);
+}
+*/
 int tr_ssh_recv_async(const struct tr_ssh_socket *tr_ssh_sock, void *buf, const size_t buf_len)
 {
-    const int rtval = ssh_channel_read_nonblocking(tr_ssh_sock->channel, buf, buf_len, false);
+    const int rtval = channel_read_nonblocking(tr_ssh_sock->channel, buf, buf_len, false);
     if(rtval == 0) {
-        if(ssh_channel_is_eof(tr_ssh_sock->channel) != 0) {
+        if(channel_is_eof(tr_ssh_sock->channel) != 0) {
             SSH_DBG1("remote has sent EOF", tr_ssh_sock);
             return TR_CLOSED;
         } else {
@@ -143,37 +164,59 @@ int tr_ssh_recv_async(const struct tr_ssh_socket *tr_ssh_sock, void *buf, const 
         SSH_DBG1("recv(..) error", tr_ssh_sock);
         return TR_ERROR;
     }
-
     return rtval;
 }
 
-int tr_ssh_recv(const void* tr_ssh_sock, void* buf, const size_t buf_len, const time_t timeout)
+int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const time_t timeout)
 {
-    ssh_channel rchans[2] = { ((struct tr_ssh_socket*) tr_ssh_sock)->channel, NULL };
+    if(timeout == 0)
+        return tr_ssh_recv_async(tr_ssh_sock, buf, buf_len);
+
+    time_t end_time;
+    rtr_get_monotonic_time(&end_time);
+    end_time += timeout;
+    time_t cur_time;
+    do {
+        int rtval = channel_poll(((struct tr_ssh_socket *) tr_ssh_sock)->channel, false);
+        if(rtval > 0)
+            return tr_ssh_recv_async(tr_ssh_sock, buf, buf_len);
+        else if(rtval == SSH_ERROR) {
+            return TR_ERROR;
+        }
+
+        sleep(1);
+        rtr_get_monotonic_time(&cur_time);
+    } while((end_time - cur_time) >0);
+    return TR_WOULDBLOCK;;
+}
+
+// channel_select is broken, it ignores the timeval parameter and blocks forever :/
+/*
+int tr_ssh_recv(const void* tr_ssh_sock, void* buf, const size_t buf_len, const time_t timeout){
+    ssh_channel rchans[2] = { ((tr_ssh_socket*) tr_ssh_sock)->channel, NULL };
 
     struct timeval timev = { 1, 0 };
 
-    const int rtval = ssh_channel_select(rchans, NULL, NULL, &timev);
+    const int rtval = channel_select(rchans, NULL, NULL, &timev);
 
-    if(rtval == SSH_ERROR) {
-	SSH_DBG1("recv(..) error", (const struct tr_ssh_socket *)tr_ssh_sock);
-	return TR_ERROR;
-    }
+    if(rtval == SSH_ERROR)
+        return TR_ERROR;
     if(rtval == SSH_EINTR)
         return TR_INTR;
-    if(ssh_channel_is_eof(((struct tr_ssh_socket*) tr_ssh_sock)->channel) != 0)
+    if(channel_is_eof(((tr_ssh_socket*) tr_ssh_sock)->channel) != 0)
         return SSH_ERROR;
 
     if(rchans[0] == NULL)
         return TR_WOULDBLOCK;
 
+
     return tr_ssh_recv_async(tr_ssh_sock, buf, buf_len);
 }
-
+*/
 
 int tr_ssh_send(const void *tr_ssh_sock, const void *pdu, const size_t len, const time_t timeout __attribute__((unused)))
 {
-    return ssh_channel_write(((struct tr_ssh_socket *) tr_ssh_sock)->channel, pdu, len);
+    return channel_write(((struct tr_ssh_socket *) tr_ssh_sock)->channel, pdu, len);
 }
 
 const char *tr_ssh_ident(void *tr_ssh_sock)


### PR DESCRIPTION
The old version did not catch an interrupt signal in the rtr_fsm thread for closing ssh socket.