### PR TITLE
Remove collisional namespace

### DIFF
--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -76,8 +76,8 @@ int main(){
         sleep(1);
 
     //validate the BGP-Route 10.10.0.0/24, origin ASN: 12345
-    struct rtr_ip_addr pref;
-    ip_str_to_addr("10.10.0.0", &pref);
+    struct lrtr_ip_addr pref;
+    lrtr_ip_str_to_addr("10.10.0.0", &pref);
     enum pfxv_state result;
     rtr_mgr_validate(conf, 12345, &pref, 24, &result);
 

--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -76,7 +76,7 @@ int main(){
         sleep(1);
 
     //validate the BGP-Route 10.10.0.0/24, origin ASN: 12345
-    struct ip_addr pref;
+    struct rtr_ip_addr pref;
     ip_str_to_addr("10.10.0.0", &pref);
     enum pfxv_state result;
     rtr_mgr_validate(conf, 12345, &pref, 24, &result);

--- a/rtrlib/lib/ip.c
+++ b/rtrlib/lib/ip.c
@@ -11,9 +11,9 @@
 #include <string.h>
 #include "rtrlib/lib/ip.h"
 
-bool ip_addr_is_zero(const struct ip_addr prefix)
+bool ip_addr_is_zero(const struct rtr_ip_addr prefix)
 {
-    if(prefix.ver == IPV6) {
+    if(prefix.ver == RTRLIB_IPV6) {
         if(prefix.u.addr6.addr[0] == 0 && prefix.u.addr6.addr[1] == 0 && prefix.u.addr6.addr[2] == 0 && prefix.u.addr6.addr[3] == 0 ) {
             return true;
         }
@@ -23,49 +23,49 @@ bool ip_addr_is_zero(const struct ip_addr prefix)
     return false;
 }
 
-struct ip_addr ip_addr_get_bits(const struct ip_addr *val, const uint8_t from, const uint8_t number)
+struct rtr_ip_addr ip_addr_get_bits(const struct rtr_ip_addr *val, const uint8_t from, const uint8_t number)
 {
-    struct ip_addr result;
-    if(val->ver == IPV6) {
-        result.ver = IPV6;
+    struct rtr_ip_addr result;
+    if(val->ver == RTRLIB_IPV6) {
+        result.ver = RTRLIB_IPV6;
         result.u.addr6 = ipv6_get_bits(&(val->u.addr6), from, number);
     } else {
-        result.ver = IPV4;
+        result.ver = RTRLIB_IPV4;
         result.u.addr4 = ipv4_get_bits(&(val->u.addr4), from, number);
     }
     return result;
 }
 
-bool ip_addr_equal(const struct ip_addr a, const struct ip_addr b )
+bool ip_addr_equal(const struct rtr_ip_addr a, const struct rtr_ip_addr b )
 {
     if(a.ver != b.ver)
         return false;
-    if(a.ver == IPV6) {
+    if(a.ver == RTRLIB_IPV6) {
         return ipv6_addr_equal(&(a.u.addr6), &(b.u.addr6));
     }
     return ipv4_addr_equal(&(a.u.addr4), &(b.u.addr4));
 }
 
-int ip_addr_to_str(const struct ip_addr *ip, char *str, const unsigned int len)
+int ip_addr_to_str(const struct rtr_ip_addr *ip, char *str, const unsigned int len)
 {
-    if(ip->ver == IPV6)
+    if(ip->ver == RTRLIB_IPV6)
         return ipv6_addr_to_str(&(ip->u.addr6), str, len);
     return ipv4_addr_to_str(&(ip->u.addr4), str, len);
 }
 
-int ip_str_to_addr(const char *str, struct ip_addr *ip)
+int ip_str_to_addr(const char *str, struct rtr_ip_addr *ip)
 {
     if(strchr(str, ':') == NULL) {
-        ip->ver = IPV4;;
+        ip->ver = RTRLIB_IPV4;;
         return ipv4_str_to_addr(str, &(ip->u.addr4));
     }
-    ip->ver = IPV6;
+    ip->ver = RTRLIB_IPV6;
     return ipv6_str_to_addr(str, &(ip->u.addr6));
 }
 
-bool ip_str_cmp(const struct ip_addr *addr1, const char *addr2)
+bool ip_str_cmp(const struct rtr_ip_addr *addr1, const char *addr2)
 {
-    struct ip_addr tmp;
+    struct rtr_ip_addr tmp;
     if(ip_str_to_addr(addr2, &tmp) == -1)
         return false;
     return(ip_addr_equal(*addr1, tmp));

--- a/rtrlib/lib/ip.c
+++ b/rtrlib/lib/ip.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include "rtrlib/lib/ip.h"
 
-bool ip_addr_is_zero(const struct rtr_ip_addr prefix)
+bool lrtr_ip_addr_is_zero(const struct lrtr_ip_addr prefix)
 {
     if(prefix.ver == RTRLIB_IPV6) {
         if(prefix.u.addr6.addr[0] == 0 && prefix.u.addr6.addr[1] == 0 && prefix.u.addr6.addr[2] == 0 && prefix.u.addr6.addr[3] == 0 ) {
@@ -23,12 +23,12 @@ bool ip_addr_is_zero(const struct rtr_ip_addr prefix)
     return false;
 }
 
-struct rtr_ip_addr ip_addr_get_bits(const struct rtr_ip_addr *val, const uint8_t from, const uint8_t number)
+struct lrtr_ip_addr lrtr_ip_addr_get_bits(const struct lrtr_ip_addr *val, const uint8_t from, const uint8_t number)
 {
-    struct rtr_ip_addr result;
+    struct lrtr_ip_addr result;
     if(val->ver == RTRLIB_IPV6) {
         result.ver = RTRLIB_IPV6;
-        result.u.addr6 = ipv6_get_bits(&(val->u.addr6), from, number);
+        result.u.addr6 = lrtr_ipv6_get_bits(&(val->u.addr6), from, number);
     } else {
         result.ver = RTRLIB_IPV4;
         result.u.addr4 = ipv4_get_bits(&(val->u.addr4), from, number);
@@ -36,37 +36,37 @@ struct rtr_ip_addr ip_addr_get_bits(const struct rtr_ip_addr *val, const uint8_t
     return result;
 }
 
-bool ip_addr_equal(const struct rtr_ip_addr a, const struct rtr_ip_addr b )
+bool lrtr_ip_addr_equal(const struct lrtr_ip_addr a, const struct lrtr_ip_addr b )
 {
     if(a.ver != b.ver)
         return false;
     if(a.ver == RTRLIB_IPV6) {
-        return ipv6_addr_equal(&(a.u.addr6), &(b.u.addr6));
+        return lrtr_ipv6_addr_equal(&(a.u.addr6), &(b.u.addr6));
     }
-    return ipv4_addr_equal(&(a.u.addr4), &(b.u.addr4));
+    return lrtr_ipv4_addr_equal(&(a.u.addr4), &(b.u.addr4));
 }
 
-int ip_addr_to_str(const struct rtr_ip_addr *ip, char *str, const unsigned int len)
+int lrtr_ip_addr_to_str(const struct lrtr_ip_addr *ip, char *str, const unsigned int len)
 {
     if(ip->ver == RTRLIB_IPV6)
-        return ipv6_addr_to_str(&(ip->u.addr6), str, len);
-    return ipv4_addr_to_str(&(ip->u.addr4), str, len);
+        return lrtr_ipv6_addr_to_str(&(ip->u.addr6), str, len);
+    return lrtr_ipv4_addr_to_str(&(ip->u.addr4), str, len);
 }
 
-int ip_str_to_addr(const char *str, struct rtr_ip_addr *ip)
+int lrtr_ip_str_to_addr(const char *str, struct lrtr_ip_addr *ip)
 {
     if(strchr(str, ':') == NULL) {
         ip->ver = RTRLIB_IPV4;;
-        return ipv4_str_to_addr(str, &(ip->u.addr4));
+        return lrtr_ipv4_str_to_addr(str, &(ip->u.addr4));
     }
     ip->ver = RTRLIB_IPV6;
-    return ipv6_str_to_addr(str, &(ip->u.addr6));
+    return lrtr_ipv6_str_to_addr(str, &(ip->u.addr6));
 }
 
-bool ip_str_cmp(const struct rtr_ip_addr *addr1, const char *addr2)
+bool lrtr_ip_str_cmp(const struct lrtr_ip_addr *addr1, const char *addr2)
 {
-    struct rtr_ip_addr tmp;
-    if(ip_str_to_addr(addr2, &tmp) == -1)
+    struct lrtr_ip_addr tmp;
+    if(lrtr_ip_str_to_addr(addr2, &tmp) == -1)
         return false;
-    return(ip_addr_equal(*addr1, tmp));
+    return(lrtr_ip_addr_equal(*addr1, tmp));
 }

--- a/rtrlib/lib/ip.h
+++ b/rtrlib/lib/ip.h
@@ -16,21 +16,21 @@
 /**
  * @brief Version of the IP protocol.
  */
-enum ip_version {
+enum rtr_ip_version {
     /** IPV4 */
-    IPV4,
+            RTRLIB_IPV4,
 
     /** IPV6 */
-    IPV6
+            RTRLIB_IPV6
 };
 
 /**
- * @brief The ip_addr struct stores a IPv4 or IPv6 address in host byte order.
+ * @brief The rtr_ip_addr struct stores a IPv4 or IPv6 address in host byte order.
  * @param ver Specifies the type of the stored address.
  * @param u Union holding a ipv4_addr or ipv6_addr.
  */
-struct ip_addr {
-    enum ip_version ver;
+struct rtr_ip_addr {
+    enum rtr_ip_version ver;
     union {
         struct ipv4_addr addr4;
         struct ipv6_addr addr6;
@@ -38,63 +38,63 @@ struct ip_addr {
 };
 
 /**
- * @brief Detects if the ip_addr only contains 0 bits.
- * @param[in] ip_addr
- * @returns true If the saved ip_addr is 0.
- * @returns false If the saved ip_addr isn't 0.
+ * @brief Detects if the rtr_ip_addr only contains 0 bits.
+ * @param[in] rtr_ip_addr
+ * @returns true If the saved rtr_ip_addr is 0.
+ * @returns false If the saved rtr_ip_addr isn't 0.
  */
-bool ip_addr_is_zero(const struct ip_addr);
+bool ip_addr_is_zero(const struct rtr_ip_addr);
 
 /**
- * @brief Extracts number bits from the passed ip_addr, starting at bit number from. The bit with the highest
+ * @brief Extracts number bits from the passed rtr_ip_addr, starting at bit number from. The bit with the highest
  * significance is bit 0. All bits that aren't in the specified range will be 0.
- * @param[in] val ip_addr
+ * @param[in] val rtr_ip_addr
  * @param[in] from Position of the first bit that is extracted.
  * @param[in] number How many bits will be extracted.
  * @returns An ipv4_addr, where all bits that aren't in the specified range are set to 0.
 */
-struct ip_addr ip_addr_get_bits(const struct ip_addr *val, const uint8_t from, const uint8_t number);
+struct rtr_ip_addr ip_addr_get_bits(const struct rtr_ip_addr *val, const uint8_t from, const uint8_t number);
 
 /**
  * @defgroup util_h Utility functions
  * @{
  *
- * @brief Checks if two ip_addr structs are equal.
- * @param[in] a ip_addr
- * @param[in] b ip_addr
+ * @brief Checks if two rtr_ip_addr structs are equal.
+ * @param[in] a rtr_ip_addr
+ * @param[in] b rtr_ip_addr
  * @return true If a == b.
  * @return false If a != b.
  */
-bool ip_addr_equal(const struct ip_addr a, const struct ip_addr b);
+bool ip_addr_equal(const struct rtr_ip_addr a, const struct rtr_ip_addr b);
 
 /**
- * Converts the passed ip_addr struct to string representation.
- * @param[in] ip ip_addr
- * @param[out] str Pointer to a char array. The array must be at least INET_ADDRSTRLEN bytes long if the passed ip_addr stores
- * an IPv4 address. If ip_addr stores an IPv6 address, str must be at least INET6_ADDRSTRLEN bytes long.
+ * Converts the passed rtr_ip_addr struct to string representation.
+ * @param[in] ip rtr_ip_addr
+ * @param[out] str Pointer to a char array. The array must be at least INET_ADDRSTRLEN bytes long if the passed rtr_ip_addr stores
+ * an IPv4 address. If rtr_ip_addr stores an IPv6 address, str must be at least INET6_ADDRSTRLEN bytes long.
  * @param[in] len Length of the str array.
  * @result 0 On success.
  * @result -1 On error.
 */
-int ip_addr_to_str(const struct ip_addr *ip, char *str, const unsigned int len);
+int ip_addr_to_str(const struct rtr_ip_addr *ip, char *str, const unsigned int len);
 
 /**
- * Converts the passed IP address in string representation to an ip_addr.
+ * Converts the passed IP address in string representation to an rtr_ip_addr.
  * @param[in] str Pointer to a Null terminated char array.
- * @param[out] ip Pointer to a ip_addr struct.
+ * @param[out] ip Pointer to a rtr_ip_addr struct.
  * @result 0 On success.
  * @result -1 On error.
 */
-int ip_str_to_addr(const char *str, struct ip_addr *ip);
+int ip_str_to_addr(const char *str, struct rtr_ip_addr *ip);
 
 /**
- * Compares addr1 in the ip_addr struct with addr2 in string representation.
- * @param[in] addr1 ip_addr
+ * Compares addr1 in the rtr_ip_addr struct with addr2 in string representation.
+ * @param[in] addr1 rtr_ip_addr
  * @param[in] addr2 IP-address as string
  * @return true If a == b
  * @return false If a != b
 */
-bool ip_str_cmp(const struct ip_addr *addr1, const char *addr2);
+bool ip_str_cmp(const struct rtr_ip_addr *addr1, const char *addr2);
 
 #endif
 /* @} */

--- a/rtrlib/lib/ip.h
+++ b/rtrlib/lib/ip.h
@@ -7,8 +7,8 @@
  * Website: http://rtrlib.realmv6.org/
 */
 
-#ifndef RTR_IP_H
-#define RTR_IP_H
+#ifndef LRTR_IP_H
+#define LRTR_IP_H
 #include "rtrlib/lib/ipv4.h"
 #include "rtrlib/lib/ipv6.h"
 
@@ -16,7 +16,7 @@
 /**
  * @brief Version of the IP protocol.
  */
-enum rtr_ip_version {
+enum lrtr_ip_version {
     /** IPV4 */
             RTRLIB_IPV4,
 
@@ -29,11 +29,11 @@ enum rtr_ip_version {
  * @param ver Specifies the type of the stored address.
  * @param u Union holding a ipv4_addr or ipv6_addr.
  */
-struct rtr_ip_addr {
-    enum rtr_ip_version ver;
+struct lrtr_ip_addr {
+    enum lrtr_ip_version ver;
     union {
-        struct ipv4_addr addr4;
-        struct ipv6_addr addr6;
+        struct lrtr_ipv4_addr addr4;
+        struct lrtr_ipv6_addr addr6;
     } u;
 };
 
@@ -43,7 +43,7 @@ struct rtr_ip_addr {
  * @returns true If the saved rtr_ip_addr is 0.
  * @returns false If the saved rtr_ip_addr isn't 0.
  */
-bool ip_addr_is_zero(const struct rtr_ip_addr);
+bool lrtr_ip_addr_is_zero(const struct lrtr_ip_addr);
 
 /**
  * @brief Extracts number bits from the passed rtr_ip_addr, starting at bit number from. The bit with the highest
@@ -53,7 +53,7 @@ bool ip_addr_is_zero(const struct rtr_ip_addr);
  * @param[in] number How many bits will be extracted.
  * @returns An ipv4_addr, where all bits that aren't in the specified range are set to 0.
 */
-struct rtr_ip_addr ip_addr_get_bits(const struct rtr_ip_addr *val, const uint8_t from, const uint8_t number);
+struct lrtr_ip_addr lrtr_ip_addr_get_bits(const struct lrtr_ip_addr *val, const uint8_t from, const uint8_t number);
 
 /**
  * @defgroup util_h Utility functions
@@ -65,7 +65,7 @@ struct rtr_ip_addr ip_addr_get_bits(const struct rtr_ip_addr *val, const uint8_t
  * @return true If a == b.
  * @return false If a != b.
  */
-bool ip_addr_equal(const struct rtr_ip_addr a, const struct rtr_ip_addr b);
+bool lrtr_ip_addr_equal(const struct lrtr_ip_addr a, const struct lrtr_ip_addr b);
 
 /**
  * Converts the passed rtr_ip_addr struct to string representation.
@@ -76,7 +76,7 @@ bool ip_addr_equal(const struct rtr_ip_addr a, const struct rtr_ip_addr b);
  * @result 0 On success.
  * @result -1 On error.
 */
-int ip_addr_to_str(const struct rtr_ip_addr *ip, char *str, const unsigned int len);
+int lrtr_ip_addr_to_str(const struct lrtr_ip_addr *ip, char *str, const unsigned int len);
 
 /**
  * Converts the passed IP address in string representation to an rtr_ip_addr.
@@ -85,7 +85,7 @@ int ip_addr_to_str(const struct rtr_ip_addr *ip, char *str, const unsigned int l
  * @result 0 On success.
  * @result -1 On error.
 */
-int ip_str_to_addr(const char *str, struct rtr_ip_addr *ip);
+int lrtr_ip_str_to_addr(const char *str, struct lrtr_ip_addr *ip);
 
 /**
  * Compares addr1 in the rtr_ip_addr struct with addr2 in string representation.
@@ -94,7 +94,7 @@ int ip_str_to_addr(const char *str, struct rtr_ip_addr *ip);
  * @return true If a == b
  * @return false If a != b
 */
-bool ip_str_cmp(const struct rtr_ip_addr *addr1, const char *addr2);
+bool lrtr_ip_str_cmp(const struct lrtr_ip_addr *addr1, const char *addr2);
 
 #endif
 /* @} */

--- a/rtrlib/lib/ipv4.c
+++ b/rtrlib/lib/ipv4.c
@@ -12,14 +12,14 @@
 #include <assert.h>
 #include <stdio.h>
 
-struct ipv4_addr ipv4_get_bits(const struct ipv4_addr *val, const uint8_t from, const uint8_t quantity)
+struct lrtr_ipv4_addr ipv4_get_bits(const struct lrtr_ipv4_addr *val, const uint8_t from, const uint8_t quantity)
 {
-    struct ipv4_addr result;
-    result.addr = rtr_get_bits(val->addr, from, quantity);
+    struct lrtr_ipv4_addr result;
+    result.addr = lrtr_get_bits(val->addr, from, quantity);
     return result;
 }
 
-int ipv4_addr_to_str(const struct ipv4_addr *ip, char *str, unsigned int len)
+int lrtr_ipv4_addr_to_str(const struct lrtr_ipv4_addr *ip, char *str, unsigned int len)
 {
     const uint8_t *t = (uint8_t *) &(ip->addr);
 
@@ -29,7 +29,7 @@ int ipv4_addr_to_str(const struct ipv4_addr *ip, char *str, unsigned int len)
     return 0;
 }
 
-int ipv4_str_to_addr(const char *str, struct ipv4_addr *ip)
+int lrtr_ipv4_str_to_addr(const char *str, struct lrtr_ipv4_addr *ip)
 {
     unsigned char *t =  (unsigned char *) &(ip->addr);
     if(sscanf(str, "%hhu.%hhu.%hhu.%hhu", &(t[3]), &(t[2]), &(t[1]), &(t[0])) != 4)
@@ -37,7 +37,7 @@ int ipv4_str_to_addr(const char *str, struct ipv4_addr *ip)
     return 0;
 }
 
-bool ipv4_addr_equal(const struct ipv4_addr *a, const struct ipv4_addr *b)
+bool lrtr_ipv4_addr_equal(const struct lrtr_ipv4_addr *a, const struct lrtr_ipv4_addr *b)
 {
     if(a->addr == b->addr)
         return true;

--- a/rtrlib/lib/ipv4.h
+++ b/rtrlib/lib/ipv4.h
@@ -7,8 +7,8 @@
  * Website: http://rtrlib.realmv6.org/
 */
 
-#ifndef RTR_IPV4_H
-#define RTR_IPV4_H
+#ifndef LRTR_IPV4_H
+#define LRTR_IPV4_H
 #include <inttypes.h>
 #include <stdbool.h>
 
@@ -16,7 +16,7 @@
  * @brief Struct storing an IPv4 address in host byte order.
  * @param addr The IPv4 address.
  */
-struct ipv4_addr {
+struct lrtr_ipv4_addr {
     uint32_t addr;
 };
 
@@ -28,7 +28,7 @@ struct ipv4_addr {
  * @param[in] number How many bits will be extracted.
  * @returns An ipv4_addr, where all bits that aren't in the specified range are set to 0.
 */
-struct ipv4_addr ipv4_get_bits(const struct ipv4_addr *val, const uint8_t from, const uint8_t number);
+struct lrtr_ipv4_addr ipv4_get_bits(const struct lrtr_ipv4_addr *val, const uint8_t from, const uint8_t number);
 
 /**
  * Converts the passed IPv4 address in string representation to an ipv4_addr struct.
@@ -37,7 +37,7 @@ struct ipv4_addr ipv4_get_bits(const struct ipv4_addr *val, const uint8_t from, 
  * @result 0 on success
  * @result -1 on error
 */
-int ipv4_str_to_addr(const char *str, struct ipv4_addr *ip);
+int lrtr_ipv4_str_to_addr(const char *str, struct lrtr_ipv4_addr *ip);
 
 /**
  * Converts the passed ipv4_addr to string representation.
@@ -46,7 +46,7 @@ int ipv4_str_to_addr(const char *str, struct ipv4_addr *ip);
  * @result 0 on success
  * @result -1 on error
 */
-int ipv4_addr_to_str(const struct ipv4_addr *ip, char *str, const unsigned int len);
+int lrtr_ipv4_addr_to_str(const struct lrtr_ipv4_addr *ip, char *str, const unsigned int len);
 
 /**
  * Compares two ipv4_addr structs.
@@ -55,6 +55,6 @@ int ipv4_addr_to_str(const struct ipv4_addr *ip, char *str, const unsigned int l
  * @return true if a == b
  * @return false if a != b
 */
-bool ipv4_addr_equal(const struct ipv4_addr *a, const struct ipv4_addr *b);
+bool lrtr_ipv4_addr_equal(const struct lrtr_ipv4_addr *a, const struct lrtr_ipv4_addr *b);
 
 #endif

--- a/rtrlib/lib/ipv6.c
+++ b/rtrlib/lib/ipv6.c
@@ -133,7 +133,7 @@ int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip)
             words[i] = 0;
     }
 
-    /* Convert the address to ip_addr format */
+    /* Convert the address to rtr_ip_addr format */
     for(i=0; i<4; i++)
         o[i] = (words[2*i] << 16) | words[2*i+1];
     return 0;
@@ -142,11 +142,11 @@ int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip)
 /*
  * This function was copied from the bird routing daemon's ip_ntop(..) function.
 */
-int ipv6_addr_to_str(const struct ipv6_addr *ip_addr, char *b, const unsigned int len)
+int ipv6_addr_to_str(const struct ipv6_addr *rtr_ip_addr, char *b, const unsigned int len)
 {
     if(len < INET6_ADDRSTRLEN)
         return -1;
-    const uint32_t *a = ip_addr->addr;
+    const uint32_t *a = rtr_ip_addr->addr;
     uint16_t words[8];
     int bestpos, bestlen, curpos, curlen, i;
 

--- a/rtrlib/lib/ipv6.c
+++ b/rtrlib/lib/ipv6.c
@@ -15,21 +15,21 @@
 #include <string.h>
 #include <stdio.h>
 
-inline bool ipv6_addr_equal(const struct ipv6_addr *a, const struct ipv6_addr *b)
+inline bool lrtr_ipv6_addr_equal(const struct lrtr_ipv6_addr *a, const struct lrtr_ipv6_addr *b)
 {
     if(a->addr[0] == b->addr[0] && a->addr[1] == b->addr[1] && a->addr[2] == b->addr[2] && a->addr[3] == b->addr[3])
         return true;
     return false;
 }
 
-struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity)
+struct lrtr_ipv6_addr lrtr_ipv6_get_bits(const struct lrtr_ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity)
 {
     assert(first_bit <= 127);
     assert(quantity <= 128);
     assert(first_bit + quantity <= 128);
 
     // if no bytes get extracted the result has to be 0
-    struct ipv6_addr result;
+    struct lrtr_ipv6_addr result;
     memset(&result, 0, sizeof(result));
 
     uint8_t bits_left = quantity;
@@ -38,7 +38,7 @@ struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_
         const uint8_t q = quantity > 32 ? 32 : quantity;
         assert(bits_left >= q);
         bits_left -= q;
-        result.addr[0] = rtr_get_bits(val->addr[0], first_bit, q);
+        result.addr[0] = lrtr_get_bits(val->addr[0], first_bit, q);
     }
 
     if((first_bit <= 63) && ((first_bit + quantity) > 32)) {
@@ -46,7 +46,7 @@ struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_
         const uint8_t q = bits_left > 32 ? 32 : bits_left;
         assert(bits_left >= q);
         bits_left -= q;
-        result.addr[1] = rtr_get_bits(val->addr[1], fr, q);
+        result.addr[1] = lrtr_get_bits(val->addr[1], fr, q);
     }
 
     if((first_bit <= 95) && ((first_bit + quantity) > 64)) {
@@ -54,7 +54,7 @@ struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_
         const uint8_t q = bits_left > 32 ? 32 : bits_left;
         assert(bits_left >= q);
         bits_left -= q;
-        result.addr[2] = rtr_get_bits(val->addr[2], fr, q);
+        result.addr[2] = lrtr_get_bits(val->addr[2], fr, q);
     }
 
     if((first_bit <= 127) && ((first_bit + quantity) > 96)) {
@@ -62,7 +62,7 @@ struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_
         const uint8_t q = bits_left > 32 ? 32 : bits_left;
         assert(bits_left >= q);
         bits_left -= q;
-        result.addr[3] = rtr_get_bits(val->addr[3], fr, q);
+        result.addr[3] = lrtr_get_bits(val->addr[3], fr, q);
     }
     return result;
 }
@@ -70,7 +70,7 @@ struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_
 /*
  * This function was copied from the bird routing daemon's ip_pton(..) function.
  */
-int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip)
+int lrtr_ipv6_str_to_addr(const char *a, struct lrtr_ipv6_addr *ip)
 {
     uint32_t *o = ip->addr;
     uint16_t words[8];
@@ -111,8 +111,8 @@ int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip)
         if (*a == ':' && a[1])
             a++;
         else if (*a == '.' && (i == 6 || (i < 6 && hfil >= 0))) {             /* Embedded IPv4 address */
-            struct ipv4_addr addr4;
-            if (ipv4_str_to_addr(start, &addr4) == -1)
+            struct lrtr_ipv4_addr addr4;
+            if (lrtr_ipv4_str_to_addr(start, &addr4) == -1)
                 return -1;
             words[i++] = addr4.addr >> 16;
             words[i++] = addr4.addr;
@@ -142,7 +142,7 @@ int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip)
 /*
  * This function was copied from the bird routing daemon's ip_ntop(..) function.
 */
-int ipv6_addr_to_str(const struct ipv6_addr *rtr_ip_addr, char *b, const unsigned int len)
+int lrtr_ipv6_addr_to_str(const struct lrtr_ipv6_addr *rtr_ip_addr, char *b, const unsigned int len)
 {
     if(len < INET6_ADDRSTRLEN)
         return -1;
@@ -196,7 +196,7 @@ int ipv6_addr_to_str(const struct ipv6_addr *rtr_ip_addr, char *b, const unsigne
     return 0;
 }
 
-void ipv6_addr_to_host_byte_order(const uint32_t *src, uint32_t *dest)
+void lrtr_ipv6_addr_to_host_byte_order(const uint32_t *src, uint32_t *dest)
 {
     for(int i = 0; i < 4; i++)
         dest[i] = ntohl(src[i]);

--- a/rtrlib/lib/ipv6.h
+++ b/rtrlib/lib/ipv6.h
@@ -48,7 +48,7 @@ struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_
  * @result 0 on success
  * @result -1 on error
 */
-int ipv6_addr_to_str(const struct ipv6_addr *ip_addr, char *b, const unsigned int len);
+int ipv6_addr_to_str(const struct ipv6_addr *rtr_ip_addr, char *b, const unsigned int len);
 
 /**
  * Converts the passed IPv6 address in string representation to an ipv6_addr struct.

--- a/rtrlib/lib/ipv6.h
+++ b/rtrlib/lib/ipv6.h
@@ -7,8 +7,8 @@
  * Website: http://rtrlib.realmv6.org/
 */
 
-#ifndef RTR_IPV6_H
-#define RTR_IPV6_H
+#ifndef LRTR_IPV6_H
+#define LRTR_IPV6_H
 #include <sys/types.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -18,7 +18,7 @@
  * @brief Struct holding an IPv6 address in host byte order.
  * @param addr The IPv6 address.
  */
-struct ipv6_addr {
+struct lrtr_ipv6_addr {
     uint32_t addr[4];
 };
 
@@ -29,7 +29,7 @@ struct ipv6_addr {
  * @return true if a == b
  * @return false if a != b
 */
-bool ipv6_addr_equal(const struct ipv6_addr *a, const struct ipv6_addr *b);
+bool lrtr_ipv6_addr_equal(const struct lrtr_ipv6_addr *a, const struct lrtr_ipv6_addr *b);
 
 /**
  * @brief Extracts quantity bits from a ip address. The bit with the highest
@@ -39,7 +39,7 @@ bool ipv6_addr_equal(const struct ipv6_addr *a, const struct ipv6_addr *b);
  * @param[in] quantity How many bits will be extracted.
  * @returns An ipv6_addr, where all bits that aren't in the specified range are set to 0.
 */
-struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity);
+struct lrtr_ipv6_addr lrtr_ipv6_get_bits(const struct lrtr_ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity);
 
 /**
  * Converts the passed ipv6_addr to string representation
@@ -48,7 +48,7 @@ struct ipv6_addr ipv6_get_bits(const struct ipv6_addr *val, const uint8_t first_
  * @result 0 on success
  * @result -1 on error
 */
-int ipv6_addr_to_str(const struct ipv6_addr *rtr_ip_addr, char *b, const unsigned int len);
+int lrtr_ipv6_addr_to_str(const struct lrtr_ipv6_addr *rtr_ip_addr, char *b, const unsigned int len);
 
 /**
  * Converts the passed IPv6 address in string representation to an ipv6_addr struct.
@@ -57,7 +57,7 @@ int ipv6_addr_to_str(const struct ipv6_addr *rtr_ip_addr, char *b, const unsigne
  * @result 0 on success
  * @result -1 on error
 */
-int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip);
+int lrtr_ipv6_str_to_addr(const char *a, struct lrtr_ipv6_addr *ip);
 
 /**
  * @ingroup util_h[{
@@ -66,6 +66,6 @@ int ipv6_str_to_addr(const char *a, struct ipv6_addr *ip);
  * @param[out] dest Pointer a uint32_t array that will be used to store the ipv6 addr in host byte order.
  * }
 */
-void ipv6_addr_to_host_byte_order(const uint32_t *src, uint32_t *dest);
+void lrtr_ipv6_addr_to_host_byte_order(const uint32_t *src, uint32_t *dest);
 
 #endif

--- a/rtrlib/lib/log.c
+++ b/rtrlib/lib/log.c
@@ -16,7 +16,7 @@
 #include "rtrlib/lib/log.h"
 
 
-void dbg(const char *frmt, ...)
+void lrtr_dbg(const char *frmt, ...)
 {
 #ifndef NDEBUG
     va_list argptr;

--- a/rtrlib/lib/log.h
+++ b/rtrlib/lib/log.h
@@ -7,8 +7,8 @@
  * Website: http://rtrlib.realmv6.org/
 */
 
-#ifndef RTR_LOG_H
-#define RTR_LOG_H
+#ifndef LRTR_LOG_H
+#define LRTR_LOG_H
 #include <time.h>
 #include <stdlib.h>
 #include "rtrlib/lib/ip.h"
@@ -17,6 +17,6 @@
  * @brief Writes a message to stdout if NDEBUG isn't defined.
  * @param[in] frmt log message in printf format style.
  */
-void dbg(const char *frmt, ...) __attribute__ ((format (printf, 1, 2)));
+void lrtr_dbg(const char *frmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 #endif

--- a/rtrlib/lib/utils.c
+++ b/rtrlib/lib/utils.c
@@ -23,7 +23,7 @@
 static double timeconvert = 0.0;
 #endif
 
-int rtr_get_monotonic_time(time_t *seconds)
+int lrtr_get_monotonic_time(time_t *seconds)
 {
 #ifdef __MACH__
   if (timeconvert == 0.0) {
@@ -45,7 +45,7 @@ int rtr_get_monotonic_time(time_t *seconds)
     return 0;
 }
 
-uint32_t rtr_get_bits(const uint32_t val, const uint8_t from, const uint8_t number)
+uint32_t lrtr_get_bits(const uint32_t val, const uint8_t from, const uint8_t number)
 {
     assert(number < 33);
     assert(number > 0);

--- a/rtrlib/lib/utils.h
+++ b/rtrlib/lib/utils.h
@@ -7,8 +7,8 @@
  * Website: http://rtrlib.realmv6.org/
 */
 
-#ifndef RTR_UTILS_H
-#define RTR_UTILS_H
+#ifndef LRTR_UTILS_H
+#define LRTR_UTILS_H
 #include <time.h>
 #include "rtrlib/lib/ip.h"
 
@@ -18,7 +18,7 @@
  * @return 0 on successs
  * @return -1 on error
  */
-int rtr_get_monotonic_time(time_t *seconds);
+int lrtr_get_monotonic_time(time_t *seconds);
 
 /**
  * @brief Extracts number bits from the passed uint32_t, starting at bit number from. The bit with the highest
@@ -28,6 +28,6 @@ int rtr_get_monotonic_time(time_t *seconds);
  * @param[in] number How many bits will be extracted.
  * @returns a uint32_t, where all bits that aren't in the specified range are set to 0.
 */
-uint32_t rtr_get_bits(const uint32_t val, const uint8_t from, const uint8_t number);
+uint32_t lrtr_get_bits(const uint32_t val, const uint8_t from, const uint8_t number);
 
 #endif

--- a/rtrlib/pfx/lpfst/lpfst-pfx.c
+++ b/rtrlib/pfx/lpfst/lpfst-pfx.c
@@ -24,7 +24,7 @@ struct node_data {
     struct data_elem *ary;
 };
 
-static struct lpfst_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum ip_version ver);
+static struct lpfst_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum rtr_ip_version ver);
 static int pfx_table_del_elem(struct node_data *data, const unsigned int index);
 static int pfx_table_create_node(struct lpfst_node **node, const struct pfx_record *record);
 static int pfx_table_append_elem(struct node_data *data, const struct pfx_record *record);
@@ -124,10 +124,10 @@ struct data_elem *pfx_table_find_elem(const struct node_data *data, const struct
     return NULL;
 }
 
-//returns pfx_table->ipv4 if record version is IPV4 else pfx_table->ipv6
-inline struct lpfst_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum ip_version ver)
+//returns pfx_table->ipv4 if record version is RTRLIB_IPV4 else pfx_table->ipv6
+inline struct lpfst_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum rtr_ip_version ver)
 {
-    return ver == IPV4 ? pfx_table->ipv4 : pfx_table->ipv6;
+    return ver == RTRLIB_IPV4 ? pfx_table->ipv4 : pfx_table->ipv6;
 }
 
 int pfx_table_del_elem(struct node_data *data, const unsigned int index)
@@ -186,7 +186,7 @@ int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *record)
             pthread_rwlock_unlock(&pfx_table->lock);
             return PFX_ERROR;
         }
-        if(record->prefix.ver == IPV4)
+        if(record->prefix.ver == RTRLIB_IPV4)
             pfx_table->ipv4 = new_node;
         else
             pfx_table->ipv6 = new_node;
@@ -229,7 +229,7 @@ int pfx_table_remove(struct pfx_table *pfx_table, const struct pfx_record *recor
         assert(node != NULL);
 
         if(node == root) {
-            if(record->prefix.ver == IPV4)
+            if(record->prefix.ver == RTRLIB_IPV4)
                 pfx_table->ipv4 = NULL;
             else
                 pfx_table->ipv6 = NULL;
@@ -280,7 +280,7 @@ inline void pfx_table_free_reason(struct pfx_record **reason, unsigned int *reas
         *reason_len = 0;
 }
 
-int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len, const uint32_t asn, const struct ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
+int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
 {
     //assert(reason_len == NULL || *reason_len  == 0);
     //assert(reason == NULL || *reason == NULL);
@@ -353,7 +353,7 @@ int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason
     return PFX_SUCCESS;
 }
 
-int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
+int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
 {
     return pfx_table_validate_r(pfx_table, NULL, NULL, asn, prefix, prefix_len, result);
 }

--- a/rtrlib/pfx/lpfst/lpfst-pfx.c
+++ b/rtrlib/pfx/lpfst/lpfst-pfx.c
@@ -24,7 +24,7 @@ struct node_data {
     struct data_elem *ary;
 };
 
-static struct lpfst_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum rtr_ip_version ver);
+static struct lpfst_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum lrtr_ip_version ver);
 static int pfx_table_del_elem(struct node_data *data, const unsigned int index);
 static int pfx_table_create_node(struct lpfst_node **node, const struct pfx_record *record);
 static int pfx_table_append_elem(struct node_data *data, const struct pfx_record *record);
@@ -125,7 +125,7 @@ struct data_elem *pfx_table_find_elem(const struct node_data *data, const struct
 }
 
 //returns pfx_table->ipv4 if record version is RTRLIB_IPV4 else pfx_table->ipv6
-inline struct lpfst_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum rtr_ip_version ver)
+inline struct lpfst_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum lrtr_ip_version ver)
 {
     return ver == RTRLIB_IPV4 ? pfx_table->ipv4 : pfx_table->ipv6;
 }
@@ -280,7 +280,7 @@ inline void pfx_table_free_reason(struct pfx_record **reason, unsigned int *reas
         *reason_len = 0;
 }
 
-int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
+int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
 {
     //assert(reason_len == NULL || *reason_len  == 0);
     //assert(reason == NULL || *reason == NULL);
@@ -319,7 +319,7 @@ int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason
     }
 
     while(!pfx_table_elem_matches(node->data, asn, prefix_len)) {
-        if(ip_addr_is_zero(ip_addr_get_bits(prefix, lvl++, 1))) //post-incr lvl, lpfst_lookup is performed on child_nodes => parent lvl + 1
+        if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, lvl++, 1))) //post-incr lvl, lpfst_lookup is performed on child_nodes => parent lvl + 1
             node = lpfst_lookup(node->lchild, prefix, prefix_len, &lvl);
         else
             node = lpfst_lookup(node->rchild, prefix, prefix_len, &lvl);
@@ -353,7 +353,7 @@ int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason
     return PFX_SUCCESS;
 }
 
-int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
+int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
 {
     return pfx_table_validate_r(pfx_table, NULL, NULL, asn, prefix, prefix_len, result);
 }

--- a/rtrlib/pfx/lpfst/lpfst.c
+++ b/rtrlib/pfx/lpfst/lpfst.c
@@ -25,7 +25,7 @@ void lpfst_insert(struct lpfst_node *root_node, struct lpfst_node *new_node, con
         new_node->len = tmp.len;
         new_node->data = tmp.data;
     }
-    if(ip_addr_is_zero(ip_addr_get_bits(&(new_node->prefix), level, 1))) {
+    if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(&(new_node->prefix), level, 1))) {
         if(root_node->lchild == NULL) {
             root_node->lchild = new_node;
             new_node->parent = root_node;
@@ -40,13 +40,13 @@ void lpfst_insert(struct lpfst_node *root_node, struct lpfst_node *new_node, con
     }
 }
 
-struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level)
+struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level)
 {
     while(root_node != NULL) {
-        if(root_node->len <= mask_len && ip_addr_equal(ip_addr_get_bits(&(root_node->prefix), 0, root_node->len), ip_addr_get_bits(prefix, 0, root_node->len)))
+        if(root_node->len <= mask_len && lrtr_ip_addr_equal(lrtr_ip_addr_get_bits(&(root_node->prefix), 0, root_node->len), lrtr_ip_addr_get_bits(prefix, 0, root_node->len)))
             return (struct lpfst_node *) root_node;
 
-        if(ip_addr_is_zero(ip_addr_get_bits(prefix, *level, 1)))
+        if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, *level, 1)))
             root_node = root_node->lchild;
         else
             root_node = root_node->rchild;
@@ -56,7 +56,7 @@ struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct
     return NULL;
 }
 
-struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found)
+struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found)
 {
     *found = false;
     while(root_node != NULL) {
@@ -64,12 +64,12 @@ struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct
             (*level)--;
             return root_node->parent;
         }
-        if(root_node->len == mask_len && ip_addr_equal(root_node->prefix, *prefix)) {
+        if(root_node->len == mask_len && lrtr_ip_addr_equal(root_node->prefix, *prefix)) {
             *found = true;
             return (struct lpfst_node *) root_node;
         }
 
-        if(ip_addr_is_zero(ip_addr_get_bits(prefix, *level, 1))) {
+        if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, *level, 1))) {
             if(root_node->lchild == NULL)
                 return root_node;
             else
@@ -87,9 +87,9 @@ struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct
 }
 
 //returns node that isnt used anymore in the tree
-struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, const unsigned int level)
+struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, const unsigned int level)
 {
-    if(root_node->len == mask_len && ip_addr_equal(root_node->prefix, *prefix)) {
+    if(root_node->len == mask_len && lrtr_ip_addr_equal(root_node->prefix, *prefix)) {
         if(lpfst_is_leaf(root_node)) {
             if(level != 0) {
                 if(root_node->parent->lchild == root_node)
@@ -117,7 +117,7 @@ struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct rtr_i
             }
         }
     }
-    if(ip_addr_is_zero(ip_addr_get_bits(prefix, level, 1))) {
+    if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, level, 1))) {
         if(root_node->lchild == NULL)
             return NULL;
         return lpfst_remove(root_node->lchild, prefix, mask_len, level+1);

--- a/rtrlib/pfx/lpfst/lpfst.c
+++ b/rtrlib/pfx/lpfst/lpfst.c
@@ -40,7 +40,7 @@ void lpfst_insert(struct lpfst_node *root_node, struct lpfst_node *new_node, con
     }
 }
 
-struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, unsigned int *level)
+struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level)
 {
     while(root_node != NULL) {
         if(root_node->len <= mask_len && ip_addr_equal(ip_addr_get_bits(&(root_node->prefix), 0, root_node->len), ip_addr_get_bits(prefix, 0, root_node->len)))
@@ -56,7 +56,7 @@ struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct
     return NULL;
 }
 
-struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found)
+struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found)
 {
     *found = false;
     while(root_node != NULL) {
@@ -87,7 +87,7 @@ struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct
 }
 
 //returns node that isnt used anymore in the tree
-struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, const unsigned int level)
+struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, const unsigned int level)
 {
     if(root_node->len == mask_len && ip_addr_equal(root_node->prefix, *prefix)) {
         if(lpfst_is_leaf(root_node)) {

--- a/rtrlib/pfx/lpfst/lpfst.h
+++ b/rtrlib/pfx/lpfst/lpfst.h
@@ -22,7 +22,7 @@
  * @param data
  */
 struct lpfst_node {
-    struct ip_addr prefix;
+    struct rtr_ip_addr prefix;
     uint8_t len;
     struct lpfst_node *rchild;
     struct lpfst_node *lchild;
@@ -41,18 +41,18 @@ void lpfst_insert(struct lpfst_node *root, struct lpfst_node *new_node, const un
 /**
  * @brief Searches for the node with the longest prefix, matching the passed ip prefix and prefix length.
  * @param[in] root_node Node were the lookup process starts.
- * @param[in] ip_addr IP-Prefix.
+ * @param[in] rtr_ip_addr IP-Prefix.
  * @param[in] mask_len Length of the network mask of the prefix.
  * @param[in,out] level of the the node root in the tree. Is set to the level of the node that is returned.
  * @returns A The lpfst_node with the longest prefix in the tree matching the passed ip prefix and prefix length.
  * @returns NULL if no node that matches the passed prefix and prefix length could be found.
  */
-struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len,  unsigned int *level);
+struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len,  unsigned int *level);
 
 /**
  * @brief Search for a node with the same prefix and prefix length.
  * @param[in] root_node Node were the lookup process starts.
- * @param[in] ip_addr IP-Prefix.
+ * @param[in] rtr_ip_addr IP-Prefix.
  * @param[in] mask_len Length of the network mask of the prefix.
  * @param[in,out] level of the the node root in the tree. Is set to the level of the node that is returned.
  * @param[in] found Is true if a node which matches could be found else found is set to false.
@@ -60,7 +60,7 @@ struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct
  * @return the parent of the node where the lookup operation stopped (found==false).
  * @return NULL if root_node is NULL.
 */
-struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found);
+struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found);
 
 /**
  * @brief Removes the node with the passed IP prefix and mask_len from the tree.
@@ -71,7 +71,7 @@ struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct
  * @returns Node that was removed from the tree.
  * @returns NULL If the Prefix could'nt be found in the tree.
  */
-struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct ip_addr *prefix, const uint8_t mask_len, const unsigned int level);
+struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, const unsigned int level);
 
 /**
  * @brief Detects if a node is a leaf in tree.

--- a/rtrlib/pfx/lpfst/lpfst.h
+++ b/rtrlib/pfx/lpfst/lpfst.h
@@ -22,7 +22,7 @@
  * @param data
  */
 struct lpfst_node {
-    struct rtr_ip_addr prefix;
+    struct lrtr_ip_addr prefix;
     uint8_t len;
     struct lpfst_node *rchild;
     struct lpfst_node *lchild;
@@ -47,7 +47,7 @@ void lpfst_insert(struct lpfst_node *root, struct lpfst_node *new_node, const un
  * @returns A The lpfst_node with the longest prefix in the tree matching the passed ip prefix and prefix length.
  * @returns NULL if no node that matches the passed prefix and prefix length could be found.
  */
-struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len,  unsigned int *level);
+struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct lrtr_ip_addr *prefix, const uint8_t mask_len,  unsigned int *level);
 
 /**
  * @brief Search for a node with the same prefix and prefix length.
@@ -60,7 +60,7 @@ struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node, const struct
  * @return the parent of the node where the lookup operation stopped (found==false).
  * @return NULL if root_node is NULL.
 */
-struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found);
+struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, unsigned int *level, bool *found);
 
 /**
  * @brief Removes the node with the passed IP prefix and mask_len from the tree.
@@ -71,7 +71,7 @@ struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node, const struct
  * @returns Node that was removed from the tree.
  * @returns NULL If the Prefix could'nt be found in the tree.
  */
-struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct rtr_ip_addr *prefix, const uint8_t mask_len, const unsigned int level);
+struct lpfst_node *lpfst_remove(struct lpfst_node *root_node, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, const unsigned int level);
 
 /**
  * @brief Detects if a node is a leaf in tree.

--- a/rtrlib/pfx/pfx.h
+++ b/rtrlib/pfx/pfx.h
@@ -65,7 +65,7 @@ enum pfxv_state {
  */
 struct pfx_record {
     uint32_t asn;
-    struct ip_addr prefix;
+    struct rtr_ip_addr prefix;
     uint8_t min_len;
     uint8_t max_len;
     const struct rtr_socket *socket;
@@ -139,7 +139,7 @@ int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *s
  * @return PFX_SUCCESS On success.
  * @return PFX_ERROR On error.
  */
-int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
+int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
 
 /**
  * @brief Validates the origin of a BGP-Route and returns a list of pfx_record that decided the result.
@@ -153,7 +153,7 @@ int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const st
  * @return PFX_SUCCESS On success.
  * @return PFX_ERROR On error.
  */
-int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len,  const uint32_t asn, const struct ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
+int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len,  const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
 
 /**
  * @brief Iterates over all IPv4 records in the pfx_table.

--- a/rtrlib/pfx/pfx.h
+++ b/rtrlib/pfx/pfx.h
@@ -65,7 +65,7 @@ enum pfxv_state {
  */
 struct pfx_record {
     uint32_t asn;
-    struct rtr_ip_addr prefix;
+    struct lrtr_ip_addr prefix;
     uint8_t min_len;
     uint8_t max_len;
     const struct rtr_socket *socket;
@@ -139,7 +139,7 @@ int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *s
  * @return PFX_SUCCESS On success.
  * @return PFX_ERROR On error.
  */
-int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
+int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
 
 /**
  * @brief Validates the origin of a BGP-Route and returns a list of pfx_record that decided the result.
@@ -153,7 +153,7 @@ int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const st
  * @return PFX_SUCCESS On success.
  * @return PFX_ERROR On error.
  */
-int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len,  const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
+int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len,  const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
 
 /**
  * @brief Iterates over all IPv4 records in the pfx_table.

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -528,14 +528,14 @@ static void rtr_prefix_pdu_2_pfx_record(const struct rtr_socket *rtr_socket, con
         const struct pdu_ipv4 *ipv4 = pdu;
         pfxr->prefix.u.addr4.addr = ipv4->prefix;
         pfxr->asn = ipv4->asn;
-        pfxr->prefix.ver = IPV4;
+        pfxr->prefix.ver = RTRLIB_IPV4;
         pfxr->min_len = ipv4->prefix_len;
         pfxr->max_len = ipv4->max_prefix_len;
         pfxr->socket = rtr_socket;
     } else if (type == IPV6_PREFIX) {
         const struct pdu_ipv6 *ipv6 = pdu;
         pfxr->asn = ipv6->asn;
-        pfxr->prefix.ver = IPV6;
+        pfxr->prefix.ver = RTRLIB_IPV6;
         memcpy(pfxr->prefix.u.addr6.addr, ipv6->prefix, sizeof(pfxr->prefix.u.addr6.addr));
         pfxr->min_len = ipv6->prefix_len;
         pfxr->max_len = ipv6->max_prefix_len;

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -167,7 +167,7 @@ static inline enum pdu_type rtr_get_pdu_type(const void *pdu)
 
 static int rtr_set_last_update(struct rtr_socket *rtr_socket)
 {
-    if (rtr_get_monotonic_time(&(rtr_socket->last_update)) == -1) {
+    if (lrtr_get_monotonic_time(&(rtr_socket->last_update)) == -1) {
         RTR_DBG1("get_monotonic_time(..) failed ");
         rtr_change_socket_state(rtr_socket, RTR_ERROR_FATAL);
         return RTR_ERROR;
@@ -246,7 +246,7 @@ static void rtr_pdu_footer_to_host_byte_order(void *pdu)
             ntohl(((struct pdu_ipv4 *) pdu)->asn);
         break;
     case IPV6_PREFIX:
-        ipv6_addr_to_host_byte_order(((struct pdu_ipv6 *) pdu)->prefix, addr6);
+        lrtr_ipv6_addr_to_host_byte_order(((struct pdu_ipv6 *) pdu)->prefix, addr6);
         memcpy(((struct pdu_ipv6 *) pdu)->prefix, addr6, sizeof(addr6));
         ((struct pdu_ipv6 *) pdu)->asn = ntohl(((struct pdu_ipv6 *) pdu)->asn);
         break;
@@ -664,7 +664,7 @@ static int rtr_update_pfx_table(struct rtr_socket *rtr_socket, const void *pdu)
 
     if (rtval == PFX_DUPLICATE_RECORD) {
         char ip[INET6_ADDRSTRLEN];
-        ip_addr_to_str(&(pfxr.prefix), ip, INET6_ADDRSTRLEN);
+        lrtr_ip_addr_to_str(&(pfxr.prefix), ip, INET6_ADDRSTRLEN);
         RTR_DBG("Duplicate Announcement for record: %s/%u-%u, ASN: %u, received", ip, pfxr.min_len, pfxr.max_len, pfxr.asn);
         rtr_send_error_pdu(rtr_socket, pdu, pdu_size, DUPLICATE_ANNOUNCEMENT , NULL, 0);
         rtr_change_socket_state(rtr_socket, RTR_ERROR_FATAL);
@@ -950,7 +950,7 @@ int rtr_wait_for_sync(struct rtr_socket *rtr_socket)
     char pdu[RTR_MAX_PDU_LEN];
 
     time_t cur_time;
-    rtr_get_monotonic_time(&cur_time);
+    lrtr_get_monotonic_time(&cur_time);
     time_t wait = (rtr_socket->last_update +rtr_socket->refresh_interval) - cur_time;
     if (wait < 0)
         wait = 0;

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -87,7 +87,7 @@ void rtr_purge_outdated_records(struct rtr_socket *rtr_socket)
     if(rtr_socket->last_update == 0)
         return;
     time_t cur_time;
-    int rtval = rtr_get_monotonic_time(&cur_time);
+    int rtval = lrtr_get_monotonic_time(&cur_time);
     if(rtval == -1 || (rtr_socket->last_update + rtr_socket->expire_interval) < cur_time) {
         if(rtval == -1)
             RTR_DBG1("get_monotic_time(..) failed");

--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -24,8 +24,8 @@
 #include "rtrlib/pfx/pfx.h"
 #include "rtrlib/transport/transport.h"
 
-#define RTR_DBG(fmt, ...) dbg("RTR Socket: " fmt, ## __VA_ARGS__)
-#define RTR_DBG1(a) dbg("RTR Socket: " a)
+#define RTR_DBG(fmt, ...) lrtr_dbg("RTR Socket: " fmt, ## __VA_ARGS__)
+#define RTR_DBG1(a) lrtr_dbg("RTR Socket: " a)
 
 static const uint8_t RTR_PROTOCOL_VERSION_0 = 0;
 static const uint8_t RTR_PROTOCOL_VERSION_1 = 1;

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -16,8 +16,8 @@
 #include <string.h>
 #include "rtrlib/lib/log.h"
 
-#define MGR_DBG(fmt, ...) dbg("RTR_MGR: " fmt, ## __VA_ARGS__)
-#define MGR_DBG1(a) dbg("RTR_MGR: " a)
+#define MGR_DBG(fmt, ...) lrtr_dbg("RTR_MGR: " fmt, ## __VA_ARGS__)
+#define MGR_DBG1(a) lrtr_dbg("RTR_MGR: " a)
 
 static const char *mgr_str_status[] = {
     [RTR_MGR_CLOSED] = "RTR_MGR_CLOSED",
@@ -292,7 +292,7 @@ void rtr_mgr_free(struct rtr_mgr_config *config)
     pthread_mutex_destroy(&(config->mutex));
 }
 
-inline int rtr_mgr_validate(struct rtr_mgr_config *config, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result)
+inline int rtr_mgr_validate(struct rtr_mgr_config *config, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result)
 {
     return pfx_table_validate(config->groups[0].sockets[0]->pfx_table, asn, prefix, mask_len, result);
 }

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -292,7 +292,7 @@ void rtr_mgr_free(struct rtr_mgr_config *config)
     pthread_mutex_destroy(&(config->mutex));
 }
 
-inline int rtr_mgr_validate(struct rtr_mgr_config *config, const uint32_t asn, const struct ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result)
+inline int rtr_mgr_validate(struct rtr_mgr_config *config, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result)
 {
     return pfx_table_validate(config->groups[0].sockets[0]->pfx_table, asn, prefix, mask_len, result);
 }

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -149,7 +149,7 @@ bool rtr_mgr_conf_in_sync(struct rtr_mgr_config *config);
  * @return PFX_SUCCESS On success.
  * @return PFX_ERROR If an error occurred.
  */
-int rtr_mgr_validate(struct rtr_mgr_config *config, const uint32_t asn, const struct ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
+int rtr_mgr_validate(struct rtr_mgr_config *config, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
 
 
 /**

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -149,7 +149,7 @@ bool rtr_mgr_conf_in_sync(struct rtr_mgr_config *config);
  * @return PFX_SUCCESS On success.
  * @return PFX_ERROR If an error occurred.
  */
-int rtr_mgr_validate(struct rtr_mgr_config *config, const uint32_t asn, const struct rtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
+int rtr_mgr_validate(struct rtr_mgr_config *config, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
 
 
 /**

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -17,8 +17,8 @@
 #include "../../lib/utils.h"
 #include "ssh_transport.h"
 
-#define SSH_DBG(fmt, sock, ...) dbg("SSH Transport(%s@%s:%u): " fmt, sock->config.username, sock->config.host, sock->config.port, ## __VA_ARGS__)
-#define SSH_DBG1(a, sock) dbg("SSH Transport(%s@%s:%u): " a, sock->config.username, sock->config.host, sock->config.port)
+#define SSH_DBG(fmt, sock, ...) lrtr_dbg("SSH Transport(%s@%s:%u): " fmt, sock->config.username, sock->config.host, sock->config.port, ## __VA_ARGS__)
+#define SSH_DBG1(a, sock) lrtr_dbg("SSH Transport(%s@%s:%u): " a, sock->config.username, sock->config.host, sock->config.port)
 
 struct tr_ssh_socket {
     ssh_session session;
@@ -173,7 +173,7 @@ int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const 
         return tr_ssh_recv_async(tr_ssh_sock, buf, buf_len);
 
     time_t end_time;
-    rtr_get_monotonic_time(&end_time);
+    lrtr_get_monotonic_time(&end_time);
     end_time += timeout;
     time_t cur_time;
     do {
@@ -185,7 +185,7 @@ int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const 
         }
 
         sleep(1);
-        rtr_get_monotonic_time(&cur_time);
+        lrtr_get_monotonic_time(&cur_time);
     } while((end_time - cur_time) >0);
     return TR_WOULDBLOCK;;
 }

--- a/rtrlib/transport/tcp/tcp_transport.c
+++ b/rtrlib/transport/tcp/tcp_transport.c
@@ -19,8 +19,8 @@
 #include "rtrlib/lib/log.h"
 #include "rtrlib/transport/tcp/tcp_transport.h"
 
-#define TCP_DBG(fmt, sock, ...) dbg("TCP Transport(%s:%s): " fmt, sock->config.host, sock->config.port, ## __VA_ARGS__)
-#define TCP_DBG1(a, sock) dbg("TCP Transport(%s:%s): " a,sock->config.host, sock->config.port)
+#define TCP_DBG(fmt, sock, ...) lrtr_dbg("TCP Transport(%s:%s): " fmt, sock->config.host, sock->config.port, ## __VA_ARGS__)
+#define TCP_DBG1(a, sock) lrtr_dbg("TCP Transport(%s:%s): " a,sock->config.host, sock->config.port)
 
 struct tr_tcp_socket {
     int socket;

--- a/rtrlib/transport/transport.c
+++ b/rtrlib/transport/transport.c
@@ -45,12 +45,12 @@ int tr_send_all(const struct tr_socket *socket, const void *pdu, const size_t le
     unsigned int total_send = 0;
     int rtval = 0;
     time_t end_time;
-    rtr_get_monotonic_time(&end_time);
+    lrtr_get_monotonic_time(&end_time);
     end_time = end_time + timeout;
 
     while(total_send < len) {
         time_t cur_time;
-        rtr_get_monotonic_time(&cur_time);
+        lrtr_get_monotonic_time(&cur_time);
 
         rtval = tr_send(socket, ((char *) pdu) + total_send, (len - total_send), (end_time - cur_time));
         if(rtval < 0)
@@ -65,12 +65,12 @@ int tr_recv_all(const struct tr_socket *socket, const void *pdu, const size_t le
     size_t total_recv = 0;
     int rtval = 0;
     time_t end_time;
-    rtr_get_monotonic_time(&end_time);
+    lrtr_get_monotonic_time(&end_time);
     end_time += timeout;
 
     while(total_recv < len) {
         time_t cur_time;
-        rtr_get_monotonic_time(&cur_time);
+        lrtr_get_monotonic_time(&cur_time);
 
         rtval = tr_recv(socket, ((char *) pdu)+total_recv, (len - total_recv), end_time - cur_time);
         if(rtval < 0)

--- a/tests/test_lpfst.c
+++ b/tests/test_lpfst.c
@@ -33,10 +33,10 @@
 
 static void get_bits_testv4()
 {
-    struct ip_addr addr;
-    addr.ver = IPV4;
+    struct rtr_ip_addr addr;
+    addr.ver = RTRLIB_IPV4;
 
-    struct ip_addr result;
+    struct rtr_ip_addr result;
     addr.u.addr4.addr=0xAABBCC22;
 
     result = ip_addr_get_bits(&addr, 0, 32);
@@ -107,14 +107,14 @@ static void get_bits_testv4()
 
 static void get_bits_testv6()
 {
-    struct ip_addr addr;
-    addr.ver = IPV6;
+    struct rtr_ip_addr addr;
+    addr.ver = RTRLIB_IPV6;
     addr.u.addr6.addr[0] = 0x22AABBCC;
     addr.u.addr6.addr[1] = 0xDDEEFF99;
     addr.u.addr6.addr[2] = 0x33001122;
     addr.u.addr6.addr[3] = 0x33445566;
 
-    struct ip_addr result;
+    struct rtr_ip_addr result;
 
     result = ip_addr_get_bits(&addr, 0, 128);
     assert(result.u.addr6.addr[0] == addr.u.addr6.addr[0] && result.u.addr6.addr[1] == addr.u.addr6.addr[1] && result.u.addr6.addr[2] == addr.u.addr6.addr[2] && result.u.addr6.addr[3] == addr.u.addr6.addr[3]);
@@ -145,7 +145,7 @@ static void get_bits_testv6()
     char buf[INET6_ADDRSTRLEN];
 
     ip_str_to_addr("fe80::862b:2bff:fe9a:f50f", &addr);
-    addr.ver=IPV6;
+    addr.ver= RTRLIB_IPV6;
     assert(addr.u.addr6.addr[0] == 0xfe800000);
     assert(addr.u.addr6.addr[1] == 0);
     assert(addr.u.addr6.addr[2] == 0x862b2bff);
@@ -181,8 +181,8 @@ static void get_bits_testv6()
 
 static void lpfst_test()
 {
-    struct ip_addr addr;
-    addr.ver = IPV4;
+    struct rtr_ip_addr addr;
+    addr.ver = RTRLIB_IPV4;
     struct lpfst_node* result;
     unsigned int lvl = 0;
     //n1

--- a/tests/test_lpfst.c
+++ b/tests/test_lpfst.c
@@ -33,64 +33,64 @@
 
 static void get_bits_testv4()
 {
-    struct rtr_ip_addr addr;
+    struct lrtr_ip_addr addr;
     addr.ver = RTRLIB_IPV4;
 
-    struct rtr_ip_addr result;
+    struct lrtr_ip_addr result;
     addr.u.addr4.addr=0xAABBCC22;
 
-    result = ip_addr_get_bits(&addr, 0, 32);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 32);
     assert(result.u.addr4.addr == 0xAABBCC22);
 
-    result = ip_addr_get_bits(&addr, 0, 1);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 1);
     assert(result.u.addr4.addr == 0x80000000);
 
-    result = ip_addr_get_bits(&addr, 1, 1);
+    result = lrtr_ip_addr_get_bits(&addr, 1, 1);
     assert(result.u.addr4.addr == 0);
 
-    result = ip_addr_get_bits(&addr, 2, 1);
+    result = lrtr_ip_addr_get_bits(&addr, 2, 1);
     assert(result.u.addr4.addr == 0x20000000);
 
-    result = ip_addr_get_bits(&addr, 0, 8);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 8);
     assert(result.u.addr4.addr == 0xAA000000);
 
-    result = ip_addr_get_bits(&addr, 8, 8);
+    result = lrtr_ip_addr_get_bits(&addr, 8, 8);
     assert(result.u.addr4.addr == 0x00BB0000);
 
 
-    ip_str_to_addr("10.10.10.0", &addr);
+    lrtr_ip_str_to_addr("10.10.10.0", &addr);
 
-    result = ip_addr_get_bits(&addr, 0, 8);
-    assert(ip_str_cmp(&result, "10.0.0.0"));
+    result = lrtr_ip_addr_get_bits(&addr, 0, 8);
+    assert(lrtr_ip_str_cmp(&result, "10.0.0.0"));
 
-    result = ip_addr_get_bits(&addr, 0, 16);
-    assert(ip_str_cmp(&result, "10.10.0.0"));
+    result = lrtr_ip_addr_get_bits(&addr, 0, 16);
+    assert(lrtr_ip_str_cmp(&result, "10.10.0.0"));
 
-    result = ip_addr_get_bits(&addr, 8, 8);
-    assert(ip_str_cmp(&result, "0.10.0.0"));
+    result = lrtr_ip_addr_get_bits(&addr, 8, 8);
+    assert(lrtr_ip_str_cmp(&result, "0.10.0.0"));
 
-    result = ip_addr_get_bits(&addr, 8, 24);
-    assert(ip_str_cmp(&result, "0.10.10.0"));
+    result = lrtr_ip_addr_get_bits(&addr, 8, 24);
+    assert(lrtr_ip_str_cmp(&result, "0.10.10.0"));
 
-    result = ip_addr_get_bits(&addr, 31, 1);
+    result = lrtr_ip_addr_get_bits(&addr, 31, 1);
     assert(result.u.addr4.addr == 0);
 
-    result = ip_addr_get_bits(&addr, 0, 1);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 1);
     assert(result.u.addr4.addr == 0);
 
-    result = ip_addr_get_bits(&addr, 3, 3);
-    assert(ip_str_cmp(&result, "8.0.0.0"));
+    result = lrtr_ip_addr_get_bits(&addr, 3, 3);
+    assert(lrtr_ip_str_cmp(&result, "8.0.0.0"));
 
-    assert(ip_str_to_addr("132.200.0.0", &addr) == 0);
-    result = ip_addr_get_bits(&addr, 0, 1);
+    assert(lrtr_ip_str_to_addr("132.200.0.0", &addr) == 0);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 1);
     assert(result.u.addr4.addr == 0x80000000);
 
-    assert(ip_str_to_addr("101.200.0.0", &addr) == 0);
-    result = ip_addr_get_bits(&addr, 0, 1);
+    assert(lrtr_ip_str_to_addr("101.200.0.0", &addr) == 0);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 1);
     assert(result.u.addr4.addr == 0);
 
     addr.u.addr4.addr = 0x6D698000;
-    result = ip_addr_get_bits(&addr, 0, 19);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 19);
     assert(result.u.addr4.addr == 0x6D698000);
     /*
     ip_str_to_addr("109.105.128.0", &addr);
@@ -99,89 +99,89 @@ static void get_bits_testv4()
     */
 
     char buf[INET_ADDRSTRLEN];
-    assert(ip_str_to_addr("10.10.10.5", &addr) == 0);
-    assert(ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
+    assert(lrtr_ip_str_to_addr("10.10.10.5", &addr) == 0);
+    assert(lrtr_ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
     assert(strcmp("10.10.10.5", buf) == 0);
 
 }
 
 static void get_bits_testv6()
 {
-    struct rtr_ip_addr addr;
+    struct lrtr_ip_addr addr;
     addr.ver = RTRLIB_IPV6;
     addr.u.addr6.addr[0] = 0x22AABBCC;
     addr.u.addr6.addr[1] = 0xDDEEFF99;
     addr.u.addr6.addr[2] = 0x33001122;
     addr.u.addr6.addr[3] = 0x33445566;
 
-    struct rtr_ip_addr result;
+    struct lrtr_ip_addr result;
 
-    result = ip_addr_get_bits(&addr, 0, 128);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 128);
     assert(result.u.addr6.addr[0] == addr.u.addr6.addr[0] && result.u.addr6.addr[1] == addr.u.addr6.addr[1] && result.u.addr6.addr[2] == addr.u.addr6.addr[2] && result.u.addr6.addr[3] == addr.u.addr6.addr[3]);
 
-    result = ip_addr_get_bits(&addr, 0, 64);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 64);
     assert(result.u.addr6.addr[0] == addr.u.addr6.addr[0] && result.u.addr6.addr[1] == addr.u.addr6.addr[1] && result.u.addr6.addr[2] == 0 && result.u.addr6.addr[3] == 0);
 
     bzero(&result, sizeof(result));
-    result = ip_addr_get_bits(&addr, 64, 64);
+    result = lrtr_ip_addr_get_bits(&addr, 64, 64);
     assert(result.u.addr6.addr[0] == 0);
     assert(result.u.addr6.addr[1] == 0);
     assert(result.u.addr6.addr[2] == addr.u.addr6.addr[2]);
     assert(result.u.addr6.addr[3] == addr.u.addr6.addr[3]);
 
 
-    result = ip_addr_get_bits(&addr, 0, 8);
+    result = lrtr_ip_addr_get_bits(&addr, 0, 8);
     assert(result.u.addr6.addr[0] == 0x22000000 && result.u.addr6.addr[1] == 0);
 
-    result = ip_addr_get_bits(&addr, 64, 8);
+    result = lrtr_ip_addr_get_bits(&addr, 64, 8);
     assert(result.u.addr6.addr[1] == 0 && result.u.addr6.addr[2] == 0x33000000);
 
-    result = ip_addr_get_bits(&addr, 7, 8);
+    result = lrtr_ip_addr_get_bits(&addr, 7, 8);
     assert(result.u.addr6.addr[0] == 0xAA0000 && result.u.addr6.addr[1] == 0);
 
-    result = ip_addr_get_bits(&addr, 68, 7);
+    result = lrtr_ip_addr_get_bits(&addr, 68, 7);
     assert(result.u.addr6.addr[0] == 0 && result.u.addr6.addr[2] == 0x03000000);
 
     char buf[INET6_ADDRSTRLEN];
 
-    ip_str_to_addr("fe80::862b:2bff:fe9a:f50f", &addr);
+    lrtr_ip_str_to_addr("fe80::862b:2bff:fe9a:f50f", &addr);
     addr.ver= RTRLIB_IPV6;
     assert(addr.u.addr6.addr[0] == 0xfe800000);
     assert(addr.u.addr6.addr[1] == 0);
     assert(addr.u.addr6.addr[2] == 0x862b2bff);
     assert(addr.u.addr6.addr[3] == 0xfe9af50f);
 
-    assert(ip_str_to_addr("2001::", &addr) == 0);
+    assert(lrtr_ip_str_to_addr("2001::", &addr) == 0);
     assert(addr.u.addr6.addr[0] == 0x20010000);
     assert(addr.u.addr6.addr[1] == 0);
     assert(addr.u.addr6.addr[2] == 0);
     assert(addr.u.addr6.addr[3] == 0);
 
-    assert(ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
+    assert(lrtr_ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
     assert(strcmp("2001::", buf) == 0);
 
-    ip_str_to_addr("2001:0db8:85a3:08d3:1319:8a2e:0370:7344", &addr);
-    assert(ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
+    lrtr_ip_str_to_addr("2001:0db8:85a3:08d3:1319:8a2e:0370:7344", &addr);
+    assert(lrtr_ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
     assert(strcmp("2001:db8:85a3:8d3:1319:8a2e:370:7344", buf) == 0);
 
-    result = ip_addr_get_bits(&addr, 0, 16);
-    assert(ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
-    assert(ip_str_cmp(&result, "2001::"));
+    result = lrtr_ip_addr_get_bits(&addr, 0, 16);
+    assert(lrtr_ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
+    assert(lrtr_ip_str_cmp(&result, "2001::"));
 
-    result = ip_addr_get_bits(&addr, 16, 16);
-    assert(ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
-    assert(ip_str_cmp(&result, "0:db8::"));
-    result = ip_addr_get_bits(&addr, 0, 1);
-    assert(ip_str_cmp(&result, "::"));
+    result = lrtr_ip_addr_get_bits(&addr, 16, 16);
+    assert(lrtr_ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
+    assert(lrtr_ip_str_cmp(&result, "0:db8::"));
+    result = lrtr_ip_addr_get_bits(&addr, 0, 1);
+    assert(lrtr_ip_str_cmp(&result, "::"));
 
-    result = ip_addr_get_bits(&addr, 126, 1);
-    assert(ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
-    assert(ip_str_cmp(&result, "::"));
+    result = lrtr_ip_addr_get_bits(&addr, 126, 1);
+    assert(lrtr_ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
+    assert(lrtr_ip_str_cmp(&result, "::"));
 }
 
 static void lpfst_test()
 {
-    struct rtr_ip_addr addr;
+    struct lrtr_ip_addr addr;
     addr.ver = RTRLIB_IPV4;
     struct lpfst_node* result;
     unsigned int lvl = 0;
@@ -192,19 +192,19 @@ static void lpfst_test()
     n1.rchild = NULL;
     n1.parent = NULL;
     n1.data = NULL;
-    ip_str_to_addr( "100.200.0.0", &(n1.prefix));
+    lrtr_ip_str_to_addr( "100.200.0.0", &(n1.prefix));
 
-    ip_str_to_addr( "100.200.0.0", &(addr));
+    lrtr_ip_str_to_addr( "100.200.0.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
-    assert(ip_str_cmp(&(result->prefix), "100.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(result->prefix), "100.200.0.0"));
 
-    ip_str_to_addr( "100.200.30.0", &(addr));
+    lrtr_ip_str_to_addr( "100.200.30.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
-    assert(ip_str_cmp(&(result->prefix), "100.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(result->prefix), "100.200.0.0"));
 
 
     //n2
@@ -214,14 +214,14 @@ static void lpfst_test()
     n2.rchild = NULL;
     n2.parent = NULL;
     n2.data = NULL;
-    ip_str_to_addr("132.200.0.0", &(n2.prefix));
+    lrtr_ip_str_to_addr("132.200.0.0", &(n2.prefix));
     lpfst_insert(&n1, &n2, 0);
 
-    ip_str_to_addr("132.200.0.0", &(addr));
+    lrtr_ip_str_to_addr("132.200.0.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
-    assert(ip_str_cmp(&(result->prefix), "132.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(result->prefix), "132.200.0.0"));
     assert(n1.rchild == &n2);
 
 
@@ -232,14 +232,14 @@ static void lpfst_test()
     n3.rchild = NULL;
     n3.parent = NULL;
     n3.data = NULL;
-    ip_str_to_addr("101.200.0.0", &(n3.prefix));
+    lrtr_ip_str_to_addr("101.200.0.0", &(n3.prefix));
     lpfst_insert(&n1, &n3, 0);
 
-    ip_str_to_addr("101.200.0.0", &(addr));
+    lrtr_ip_str_to_addr("101.200.0.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
-    assert(ip_str_cmp(&(result->prefix), "101.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(result->prefix), "101.200.0.0"));
     assert(n1.lchild == &n3);
 
     //n4
@@ -249,62 +249,62 @@ static void lpfst_test()
     n4.rchild = NULL;
     n4.parent = NULL;
     n4.data = NULL;
-    ip_str_to_addr("132.200.3.0", &(n4.prefix));
+    lrtr_ip_str_to_addr("132.200.3.0", &(n4.prefix));
     lpfst_insert(&n1, &n4, 0);
 
-    ip_str_to_addr("132.200.3.0", &(addr));
+    lrtr_ip_str_to_addr("132.200.3.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 24, &lvl);
     assert(result != NULL);
-    assert(ip_str_cmp(&(result->prefix), "132.200.3.0"));
-    assert(ip_str_cmp(&(n1.prefix), "132.200.3.0"));
+    assert(lrtr_ip_str_cmp(&(result->prefix), "132.200.3.0"));
+    assert(lrtr_ip_str_cmp(&(n1.prefix), "132.200.3.0"));
     assert(n1.len == 24);
-    assert(ip_str_cmp(&(n1.lchild->prefix), "101.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(n1.lchild->prefix), "101.200.0.0"));
     assert(n1.lchild->len == 16);
-    assert(ip_str_cmp(&(n1.rchild->prefix), "132.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(n1.rchild->prefix), "132.200.0.0"));
     assert(n1.rchild->len == 16);
-    assert(ip_str_cmp(&(n1.lchild->rchild->prefix), "100.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(n1.lchild->rchild->prefix), "100.200.0.0"));
     assert(n1.lchild->rchild->len == 16);
 
-    ip_str_to_addr("132.200.0.0", &(addr));
+    lrtr_ip_str_to_addr("132.200.0.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
-    assert(ip_str_cmp(&(result->prefix), "132.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(result->prefix), "132.200.0.0"));
 
-    ip_str_to_addr("132.200.3.0", &(addr));
+    lrtr_ip_str_to_addr("132.200.3.0", &(addr));
     lvl = 0;
     result = lpfst_lookup(&n1, &addr, 16, &lvl);
     assert(result != NULL);
-    assert(ip_str_cmp(&(result->prefix), "132.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(result->prefix), "132.200.0.0"));
 
 
     lvl = 0;
-    ip_str_to_addr("132.0.0.0", &(addr));
+    lrtr_ip_str_to_addr("132.0.0.0", &(addr));
     bool found;
     result = lpfst_lookup_exact(&n1, &addr, 16, &lvl, &found);
     assert(!found);
 
     lvl = 0;
-    ip_str_to_addr("132.200.3.0", &(addr));
+    lrtr_ip_str_to_addr("132.200.3.0", &(addr));
     result = lpfst_lookup_exact(&n1, &addr, 24, &lvl, &found);
     assert(found);
-    assert(ip_str_cmp(&(result->prefix), "132.200.3.0"));
+    assert(lrtr_ip_str_cmp(&(result->prefix), "132.200.3.0"));
 
     result = lpfst_remove(&n1, &addr, 24, 0);
     assert(result != NULL);
-    assert(ip_str_cmp(&(n1.prefix), "132.200.0.0"));
-    assert(ip_str_cmp(&(n1.lchild->prefix), "101.200.0.0"));
-    assert(ip_str_cmp(&(n1.lchild->rchild->prefix), "100.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(n1.prefix), "132.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(n1.lchild->prefix), "101.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(n1.lchild->rchild->prefix), "100.200.0.0"));
     assert(n1.rchild == NULL);
 
-    ip_str_to_addr("101.200.0.0", &(addr));
+    lrtr_ip_str_to_addr("101.200.0.0", &(addr));
     result = lpfst_remove(&n1, &addr, 16, 0);
     assert(result != NULL);
-    assert(ip_str_cmp(&(n1.lchild->prefix), "100.200.0.0"));
+    assert(lrtr_ip_str_cmp(&(n1.lchild->prefix), "100.200.0.0"));
     assert(n1.rchild == NULL);
 
-    ip_str_to_addr("100.200.0.0", &(addr));
+    lrtr_ip_str_to_addr("100.200.0.0", &(addr));
     result = lpfst_remove(&n1, &addr, 16, 0);
     assert(result != NULL);
     assert(n1.lchild == NULL);

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -106,14 +106,14 @@ static void mass_test()
         rec.socket = NULL;
         rec.asn = i;
         rec.prefix.u.addr4.addr = htonl(i);
-        rec.prefix.ver = IPV4;
+        rec.prefix.ver = RTRLIB_IPV4;
         assert(pfx_table_add(&pfxt, &rec) == PFX_SUCCESS);
         rec.asn = i + 1;
         assert(pfx_table_add(&pfxt, &rec) == PFX_SUCCESS);
 
         rec.min_len = 128;
         rec.max_len = 128;
-        rec.prefix.ver = IPV6;
+        rec.prefix.ver = RTRLIB_IPV6;
         ((uint64_t*) rec.prefix.u.addr6.addr)[1] = max_i;
         ((uint64_t*) rec.prefix.u.addr6.addr)[0] = min_i+i;
         assert(pfx_table_add(&pfxt, &rec) == PFX_SUCCESS);
@@ -123,7 +123,7 @@ static void mass_test()
     for(uint32_t i = max_i; i >= min_i; i--) {
         rec.min_len = 32;
         rec.max_len = 32;
-        rec.prefix.ver = IPV4;
+        rec.prefix.ver = RTRLIB_IPV4;
         rec.prefix.u.addr4.addr = htonl(i);
         assert(pfx_table_validate(&pfxt, i, &(rec.prefix), rec.min_len, &res) == PFX_SUCCESS);
         assert(res == BGP_PFXV_STATE_VALID);
@@ -133,7 +133,7 @@ static void mass_test()
 
         rec.min_len = 128;
         rec.max_len = 128;
-        rec.prefix.ver = IPV6;
+        rec.prefix.ver = RTRLIB_IPV6;
         ((uint64_t*) rec.prefix.u.addr6.addr)[1] = max_i;
         ((uint64_t*) rec.prefix.u.addr6.addr)[0] = min_i + i;
 
@@ -147,14 +147,14 @@ static void mass_test()
         rec.min_len = 32;
         rec.max_len = 32;
         rec.asn = i;
-        rec.prefix.ver = IPV4;
+        rec.prefix.ver = RTRLIB_IPV4;
         rec.prefix.u.addr4.addr = htonl(i);
         assert(pfx_table_remove(&pfxt, &rec) == PFX_SUCCESS);
 
         rec.asn = i + 1;
         assert(pfx_table_remove(&pfxt, &rec) == PFX_SUCCESS);
 
-        rec.prefix.ver = IPV6;
+        rec.prefix.ver = RTRLIB_IPV6;
         rec.min_len = 128;
         rec.max_len = 128;
         ((uint64_t*) rec.prefix.u.addr6.addr)[1] = max_i;
@@ -172,7 +172,7 @@ int main()
 
     struct pfx_record pfx;
     pfx.asn = 123;
-    pfx.prefix.ver = IPV4;
+    pfx.prefix.ver = RTRLIB_IPV4;
     ip_str_to_addr("10.10.0.0", &(pfx.prefix));
     pfx.min_len = 16;
     pfx.max_len = 24;
@@ -215,7 +215,7 @@ int main()
 
 
     ip_str_to_addr("2a01:4f8:131::", &(pfx.prefix));
-    pfx.prefix.ver = IPV6;
+    pfx.prefix.ver = RTRLIB_IPV6;
     pfx.min_len = 48;
     pfx.max_len = 48;
     pfx.asn = 124;

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -42,22 +42,22 @@ static void remove_src_test()
 
     pfx.asn = 80;
     pfx.socket = &tr1;
-    ip_str_to_addr("10.11.10.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("10.11.10.0", &(pfx.prefix));
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
     pfx.asn = 90;
     pfx.socket = NULL;
-    ip_str_to_addr("10.11.10.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("10.11.10.0", &(pfx.prefix));
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
     pfx.socket = NULL;
     pfx.min_len = 24;
-    ip_str_to_addr("192.168.0.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("192.168.0.0", &(pfx.prefix));
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
     pfx.socket = &tr1;
     pfx.min_len = 8;
-    ip_str_to_addr("10.0.0.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("10.0.0.0", &(pfx.prefix));
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
     unsigned int len = 0;
@@ -77,7 +77,7 @@ static void remove_src_test()
     enum pfxv_state res;
     assert(pfx_table_validate(&pfxt, 90, &(pfx.prefix), 8, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_NOT_FOUND);
-    ip_str_to_addr("10.11.10.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("10.11.10.0", &(pfx.prefix));
 
     assert(pfx_table_validate(&pfxt, 90, &(pfx.prefix), 32, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_VALID);
@@ -173,7 +173,7 @@ int main()
     struct pfx_record pfx;
     pfx.asn = 123;
     pfx.prefix.ver = RTRLIB_IPV4;
-    ip_str_to_addr("10.10.0.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("10.10.0.0", &(pfx.prefix));
     pfx.min_len = 16;
     pfx.max_len = 24;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
@@ -187,25 +187,25 @@ int main()
     assert(pfx_table_validate(&pfxt, 123, &(pfx.prefix), 24, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_VALID);
 
-    ip_str_to_addr("10.10.10.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("10.10.10.0", &(pfx.prefix));
     assert(pfx_table_validate(&pfxt, 123, &(pfx.prefix), 20, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_VALID);
 
     assert(pfx_table_validate(&pfxt, 123, &(pfx.prefix), 25, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_INVALID);
 
-    ip_str_to_addr("10.11.10.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("10.11.10.0", &(pfx.prefix));
     assert(pfx_table_validate(&pfxt, 123, &(pfx.prefix), 16, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_NOT_FOUND);
 
-    ip_str_to_addr("10.10.0.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("10.10.0.0", &(pfx.prefix));
     pfx.asn = 122;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
     assert(pfx_table_validate(&pfxt, 122, &(pfx.prefix), 18, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_VALID);
 
-    ip_str_to_addr("11.10.0.0", &(pfx.prefix));
+    lrtr_ip_str_to_addr("11.10.0.0", &(pfx.prefix));
     pfx.asn = 22;
     pfx.min_len = 17;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
@@ -214,7 +214,7 @@ int main()
 
 
 
-    ip_str_to_addr("2a01:4f8:131::", &(pfx.prefix));
+    lrtr_ip_str_to_addr("2a01:4f8:131::", &(pfx.prefix));
     pfx.prefix.ver = RTRLIB_IPV6;
     pfx.min_len = 48;
     pfx.max_len = 48;
@@ -223,12 +223,12 @@ int main()
     assert(pfx_table_validate(&pfxt, 124, &(pfx.prefix), 48, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_VALID);
 
-    ip_str_to_addr("2a01:4f8:131:15::", &(pfx.prefix));
+    lrtr_ip_str_to_addr("2a01:4f8:131:15::", &(pfx.prefix));
     assert(pfx_table_validate(&pfxt, 124, &(pfx.prefix), 56, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_INVALID);
 
 
-    assert(ip_str_to_addr("1.0.4.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("1.0.4.0", &(pfx.prefix)) == 0);
     pfx.min_len=22;
     pfx.max_len=22;
     pfx.asn=56203;
@@ -236,7 +236,7 @@ int main()
     assert(pfx_table_validate(&pfxt, pfx.asn, &(pfx.prefix), pfx.min_len, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_VALID);
 
-    assert(ip_str_to_addr("1.8.1.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("1.8.1.0", &(pfx.prefix)) == 0);
     pfx.min_len=24;
     pfx.max_len=24;
     pfx.asn=38345;
@@ -244,7 +244,7 @@ int main()
     assert(pfx_table_validate(&pfxt, pfx.asn, &(pfx.prefix), pfx.min_len, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_VALID);
 
-    assert(ip_str_to_addr("1.8.8.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("1.8.8.0", &(pfx.prefix)) == 0);
     pfx.min_len=24;
     pfx.max_len=24;
     pfx.asn=38345;
@@ -253,7 +253,7 @@ int main()
     assert(res == BGP_PFXV_STATE_VALID);
     pfx_table_free(&pfxt);
 
-    assert(ip_str_to_addr("1.0.65.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("1.0.65.0", &(pfx.prefix)) == 0);
     pfx.min_len=18;
     pfx.max_len=18;
     pfx.asn=18144;
@@ -262,7 +262,7 @@ int main()
     assert(res == BGP_PFXV_STATE_VALID);
     pfx_table_free(&pfxt);
 
-    assert(ip_str_to_addr("10.0.0.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("10.0.0.0", &(pfx.prefix)) == 0);
     pfx.min_len=16;
     pfx.max_len=16;
     pfx.asn=123;
@@ -270,7 +270,7 @@ int main()
     assert(pfx_table_validate(&pfxt, pfx.asn, &(pfx.prefix), pfx.min_len, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_VALID);
 
-    assert(ip_str_to_addr("10.0.5.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("10.0.5.0", &(pfx.prefix)) == 0);
     pfx.min_len=24;
     pfx.max_len=24;
     pfx.asn=124;
@@ -278,39 +278,39 @@ int main()
     assert(res == BGP_PFXV_STATE_INVALID);
 
     pfx_table_free(&pfxt);
-    assert(ip_str_to_addr("109.105.96.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("109.105.96.0", &(pfx.prefix)) == 0);
     //memcpy(&(pfx.prefix.u.addr4.addr),  &i, sizeof(i));
     pfx.min_len=19;
     pfx.max_len=19;
     pfx.asn=123;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
-    assert(ip_str_to_addr("109.105.128.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("109.105.128.0", &(pfx.prefix)) == 0);
     assert(pfx_table_validate(&pfxt, 456, &(pfx.prefix), 20, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_NOT_FOUND);
 
     pfx_table_free(&pfxt);
-    assert(ip_str_to_addr("190.57.224.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("190.57.224.0", &(pfx.prefix)) == 0);
     pfx.min_len=19;
     pfx.max_len=24;
     pfx.asn=123;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
-    assert(ip_str_to_addr("190.57.72.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("190.57.72.0", &(pfx.prefix)) == 0);
     assert(pfx_table_validate(&pfxt, 123, &(pfx.prefix), 21, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_NOT_FOUND);
 
 
     pfx_table_free(&pfxt);
 
-    assert(ip_str_to_addr("80.253.128.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("80.253.128.0", &(pfx.prefix)) == 0);
     pfx.min_len=19;
     pfx.max_len=19;
     pfx.asn=123;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
-    assert(ip_str_to_addr("80.253.144.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("80.253.144.0", &(pfx.prefix)) == 0);
     assert(pfx_table_validate(&pfxt, 123, &(pfx.prefix), 20, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_INVALID);
 
-    assert(ip_str_to_addr("10.10.0.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("10.10.0.0", &(pfx.prefix)) == 0);
     pfx.min_len=16;
     pfx.max_len=16;
     pfx.asn=0;
@@ -318,19 +318,19 @@ int main()
     assert(pfx_table_validate(&pfxt, 123, &(pfx.prefix), 16, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_INVALID);
 
-    assert(ip_str_to_addr("10.0.0.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("10.0.0.0", &(pfx.prefix)) == 0);
     pfx.min_len=8;
     pfx.max_len=15;
     pfx.asn=6;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
-    assert(ip_str_to_addr("10.0.0.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("10.0.0.0", &(pfx.prefix)) == 0);
     pfx.min_len=8;
     pfx.max_len=15;
     pfx.asn=5;
     assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 
-    assert(ip_str_to_addr("10.1.0.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("10.1.0.0", &(pfx.prefix)) == 0);
     pfx.min_len=16;
     pfx.max_len=16;
     pfx.asn=5;
@@ -338,7 +338,7 @@ int main()
 
     struct pfx_record* r = NULL;
     unsigned int r_len = 0;
-    assert(ip_str_to_addr("10.1.0.0", &(pfx.prefix)) == 0);
+    assert(lrtr_ip_str_to_addr("10.1.0.0", &(pfx.prefix)) == 0);
     assert(pfx_table_validate_r(&pfxt, &r, &r_len, 123, &(pfx.prefix), 16, &res) == PFX_SUCCESS);
     assert(res == BGP_PFXV_STATE_INVALID);
     assert(r_len == 3);

--- a/tests/test_pfx_locks.c
+++ b/tests/test_pfx_locks.c
@@ -40,7 +40,7 @@ static void rec_insert(struct pfx_table* pfxt)
     struct pfx_record rec;
     rec.min_len = 32;
     rec.max_len = 32;
-    rec.prefix.ver = IPV4;
+    rec.prefix.ver = RTRLIB_IPV4;
     rec.prefix.u.addr4.addr = 0;
 
 
@@ -52,7 +52,7 @@ static void rec_insert(struct pfx_table* pfxt)
         rec.socket = NULL;
         rec.asn = tid % 2;
         rec.prefix.u.addr4.addr = htonl(i);
-        rec.prefix.ver = IPV4;
+        rec.prefix.ver = RTRLIB_IPV4;
         pfx_table_add(pfxt, &rec);
         //printf("%i: Record inserted\n", tid);
         rec.asn = (tid % 2) + 1;
@@ -61,7 +61,7 @@ static void rec_insert(struct pfx_table* pfxt)
 
         rec.min_len = 128;
         rec.max_len = 128;
-        rec.prefix.ver = IPV6;
+        rec.prefix.ver = RTRLIB_IPV6;
         rec.prefix.u.addr6.addr[1] = min_i + 0xFFFFFFFF;
         rec.prefix.u.addr6.addr[0] = htonl(i) + 0xFFFFFFFF;
         pfx_table_add(pfxt, &rec);
@@ -75,14 +75,14 @@ static void rec_validate(struct pfx_table* pfxt)
     struct pfx_record rec;
     rec.min_len = 32;
     rec.max_len = 32;
-    rec.prefix.ver = IPV4;
+    rec.prefix.ver = RTRLIB_IPV4;
     rec.prefix.u.addr4.addr = 0;
     enum pfxv_state res;
     printf("validating..\n");
     for(uint32_t i = max_i; i >= min_i; i--) {
         rec.min_len = 32;
         rec.max_len = 32;
-        rec.prefix.ver = IPV4;
+        rec.prefix.ver = RTRLIB_IPV4;
         rec.prefix.u.addr4.addr = htonl(i);
         pfx_table_validate(pfxt, (tid % 2), &(rec.prefix), rec.min_len, &res);
         //printf("%i: Record validated,status: ", tid);
@@ -94,7 +94,7 @@ static void rec_validate(struct pfx_table* pfxt)
 
         rec.min_len = 128;
         rec.max_len = 128;
-        rec.prefix.ver = IPV6;
+        rec.prefix.ver = RTRLIB_IPV6;
         rec.prefix.u.addr6.addr[1] = min_i + 0xFFFFFFFF;
         rec.prefix.u.addr6.addr[0] = htonl(i) + 0xFFFFFFFF;
 
@@ -110,7 +110,7 @@ static void rec_remove(struct pfx_table* pfxt)
     struct pfx_record rec;
     rec.min_len = 32;
     rec.max_len = 32;
-    rec.prefix.ver = IPV4;
+    rec.prefix.ver = RTRLIB_IPV4;
     rec.prefix.u.addr4.addr = 0;
     printf("removing records\n");
     for(uint32_t i = max_i; i >= min_i; i--) {
@@ -118,7 +118,7 @@ static void rec_remove(struct pfx_table* pfxt)
         rec.min_len = 32;
         rec.max_len = 32;
         rec.asn = tid %2;
-        rec.prefix.ver = IPV4;
+        rec.prefix.ver = RTRLIB_IPV4;
         rec.prefix.u.addr4.addr = htonl(i);
         pfx_table_remove(pfxt, &rec);
         //printf("%i: Record removed, rtval: ", tid);
@@ -129,7 +129,7 @@ static void rec_remove(struct pfx_table* pfxt)
         //printf("%i: Record removed, rtval: ", tid);
         //print_pfx_rtval(rtval);
 
-        rec.prefix.ver = IPV6;
+        rec.prefix.ver = RTRLIB_IPV6;
         rec.min_len = 128;
         rec.max_len = 128;
         rec.prefix.u.addr6.addr[1] = min_i + 0xFFFFFFFF;

--- a/tools/cli-validator.c
+++ b/tools/cli-validator.c
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
         mask = atoi(inputToken);
         inputToken = strtok(NULL, delims); asn = atoi(inputToken);
 
-        struct ip_addr pref;
+        struct rtr_ip_addr pref;
         ip_str_to_addr(ip, &pref);
         enum pfxv_state result;
         struct pfx_record* reason = NULL;

--- a/tools/cli-validator.c
+++ b/tools/cli-validator.c
@@ -128,8 +128,8 @@ int main(int argc, char *argv[])
         mask = atoi(inputToken);
         inputToken = strtok(NULL, delims); asn = atoi(inputToken);
 
-        struct rtr_ip_addr pref;
-        ip_str_to_addr(ip, &pref);
+        struct lrtr_ip_addr pref;
+        lrtr_ip_str_to_addr(ip, &pref);
         enum pfxv_state result;
         struct pfx_record* reason = NULL;
         unsigned int reason_len = 0;
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
             unsigned int i;
             for (i = 0; i < reason_len; i++) {
                 char tmp[100];
-                ip_addr_to_str(&(reason[i].prefix), tmp, sizeof(tmp));
+                lrtr_ip_addr_to_str(&(reason[i].prefix), tmp, sizeof(tmp));
                 printf("%u %s %u %u",   reason[i].asn, tmp,
                                         reason[i].min_len,
                                         reason[i].max_len);

--- a/tools/rtrclient.c
+++ b/tools/rtrclient.c
@@ -65,7 +65,7 @@ static void update_cb(struct pfx_table* p  __attribute__((unused)), const struct
         printf("+ ");
     else
         printf("- ");
-    ip_addr_to_str(&(rec.prefix), ip, sizeof(ip));
+    lrtr_ip_addr_to_str(&(rec.prefix), ip, sizeof(ip));
     printf("%-40s   %3u - %3u   %10u\n", ip, rec.min_len, rec.max_len, rec.asn);
 }
 


### PR DESCRIPTION
Probably should be beneficial for integrators of RTRLib.

Renaming:
```
struct ip_addr  -> struct rtr_ip_addr
enum ip_version -> rtr_ip_version
IPV6            -> RTRLIB_IPV6
IPV4            -> RTRLIB_IPV4
```

A few symbols were collisional with BIRD namespace, however BIRD will link RTRLib dynamically using dlopen().