### PR TITLE
Fixes some bugs and improve RTR Manager status callback behavior

### DIFF
--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -77,6 +77,9 @@ void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr, struct pfx_ta
 
 int rtr_start(struct rtr_socket *rtr_socket)
 {
+    if(rtr_socket->thread_id)
+        return RTR_ERROR;
+
     int rtval = pthread_create(&(rtr_socket->thread_id), NULL, (void* ( *)(void *)) &rtr_fsm_start, rtr_socket);
     if(rtval == 0)
         return RTR_SUCCESS;
@@ -196,6 +199,7 @@ void rtr_fsm_start(struct rtr_socket *rtr_socket)
             rtr_socket->last_update = 0;
             pfx_table_src_remove(rtr_socket->pfx_table, rtr_socket);
             spki_table_src_remove(rtr_socket->spki_table, rtr_socket);
+            rtr_socket->thread_id = 0;
             pthread_exit(NULL);
         }
     }

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -82,7 +82,9 @@ static void rtr_mgr_close_all_groups_except_one(const struct rtr_socket *sock, s
     for(unsigned int i = 0; i < config->len; i++) {
         if(config->groups[i].status != RTR_MGR_CLOSED && i != except_group_ind) {
             for(unsigned int j = 0; j < config->groups[i].sockets_len; j++) {
+                pthread_mutex_unlock(&(config->mutex));
                 rtr_stop(config->groups[i].sockets[j]);
+                pthread_mutex_lock(&(config->mutex));
             }
             set_status(config, &config->groups[i], RTR_MGR_CLOSED, sock);
         }

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -131,6 +131,9 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
                 set_status(config, &config->groups[ind], RTR_MGR_ESTABLISHED, sock);
                 rtr_mgr_close_less_preferable_groups(sock, config, ind);
             }
+            else {
+                set_status(config, &config->groups[ind], RTR_MGR_ERROR, sock);
+            }
         }
     } else if(state == RTR_CONNECTING) {
         if (config->groups[ind].status == RTR_MGR_ERROR)

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -49,6 +49,7 @@ static int rtr_mgr_start_sockets(struct rtr_mgr_group *group)
             return RTR_ERROR;
         }
     }
+    group->status = RTR_MGR_CONNECTING;
     return RTR_SUCCESS;
 }
 

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -150,7 +150,7 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
         int next_config = ind + 1;
         bool found = false;
 
-        //find group with lower preference value; the lower the value, the more preferred.
+        //find group with lower preference value, more preferred
         for(int i = ind - 1; (i > - 1) && (!found); i--) {
             if(config->groups[i].status == RTR_MGR_CLOSED) {
                 found = true;
@@ -158,8 +158,8 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
             }
         }
         if(!found) {
-          //find next group with higher preference value
-          for(unsigned int i = ind + 1; (i < config->len) && !found; i++) {
+            //find group with higher preference value, less preferred
+            for(unsigned int i = ind + 1; (i < config->len) && !found; i++) {
                 if(config->groups[i].status == RTR_MGR_CLOSED) {
                     found = true;
                     next_config = i;

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -118,8 +118,7 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
                         for(unsigned int j = 0; j < config->groups[i].sockets_len; j++) {
                             rtr_stop(config->groups[i].sockets[j]);
                         }
-                        set_status(config, &config->groups[i],
-                                   RTR_MGR_ESTABLISHED, sock);
+                        set_status(config, &config->groups[i], RTR_MGR_CLOSED, sock);
                     }
                 }
             }

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -128,6 +128,9 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
                 set_status(config, &config->groups[ind], RTR_MGR_ESTABLISHED, sock);
                 rtr_mgr_close_all_groups_except_one(sock, config, ind);
             }
+            else {
+                set_status(config, &config->groups[ind], RTR_MGR_CONNECTING, sock);
+            }
         } else if(config->groups[ind].status == RTR_MGR_ERROR) {
             //if previous state was ERROR, only change state to ESTABLISHED if all other socket groups are also in error or SHUTDOWN state
             bool all_error = true;
@@ -140,6 +143,11 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
                 rtr_mgr_close_all_groups_except_one(sock, config, ind);
             }
         }
+    } else if(state == RTR_CONNECTING) {
+        if (config->groups[ind].status == RTR_MGR_ERROR)
+            set_status(config, &config->groups[ind], RTR_MGR_ERROR, sock);
+        else
+            set_status(config, &config->groups[ind], RTR_MGR_CONNECTING, sock);
     } else if(state == RTR_ERROR_FATAL || state == RTR_ERROR_TRANSPORT || state == RTR_ERROR_NO_DATA_AVAIL) {
         set_status(config, &config->groups[ind], RTR_MGR_ERROR, sock);
 
@@ -176,6 +184,8 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
         }
         if(next_config >= 0)
             rtr_mgr_start_sockets(&(config->groups[next_config]));
+    } else {
+        set_status(config, &config->groups[ind], config->groups[ind].status, sock);
     }
 
 out:

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -101,22 +101,6 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
 
     pthread_mutex_lock(&(config->mutex));
 
-    if(config->len == 1) {
-        if (state == RTR_CONNECTING)
-            set_status(config, &config->groups[ind], RTR_MGR_CONNECTING, sock);
-        else if (state == RTR_ESTABLISHED)
-            set_status(config, &config->groups[ind], RTR_MGR_ESTABLISHED, sock);
-        else if(state == RTR_ERROR_FATAL || state == RTR_ERROR_TRANSPORT ||
-                state == RTR_ERROR_NO_DATA_AVAIL)
-            set_status(config, &config->groups[ind], RTR_MGR_ERROR, sock);
-        else if (state == RTR_SHUTDOWN)
-            set_status(config, &config->groups[ind], RTR_MGR_CLOSED, sock);
-        else
-            set_status(config, &config->groups[ind],
-                       config->groups[ind].status, sock);
-        goto out;
-    }
-
     if(state == RTR_SHUTDOWN)
         goto out;
 

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -181,15 +181,6 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
             else
                 MGR_DBG1("No other inactive groups found");
         }
-    } else if(state == RTR_ERROR_NO_INCR_UPDATE_AVAIL) {
-        set_status(config, &config->groups[ind], RTR_MGR_ERROR, sock);
-        //find a group with a lower preference value, if no other group exists do nothing
-        int next_config = ind - 1;
-        while(next_config >= 0 && config->groups[next_config].status != RTR_MGR_CLOSED) {
-            next_config--;
-        }
-        if(next_config >= 0)
-            rtr_mgr_start_sockets(&(config->groups[next_config]));
     } else {
         set_status(config, &config->groups[ind], config->groups[ind].status, sock);
     }


### PR DESCRIPTION
This fixes handling the status callbacks while using more than one ```rtr_mgr_group```. It should call status callbacks in the same manner like using only one ```rtr_mgr_group```.

(Hot)Fixes issue https://github.com/rtrlib/rtrlib/issues/37: deadlock caused by mutex double locking. But I am not sure if the solution is proper.

It adds feature https://github.com/rtrlib/rtrlib/issues/40: Go back to the better-preferred group without waiting for actual established group goes to troubles.