### PR TITLE
Timing params handling

### DIFF
--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -66,7 +66,8 @@ int main(){
     //create a rtr_mgr_config struct that stores the group
 
     //initialize all rtr_sockets in the server pool with the same settings
-    struct rtr_mgr_config *conf = rtr_mgr_init(groups, 2, 240, 520, NULL, NULL, NULL, NULL);
+    struct rtr_mgr_config *conf;
+    int ret = rtr_mgr_init(&conf ,groups, 2, 30, 600, 600, NULL, NULL, NULL, NULL);
 
     //start the connection manager
     rtr_mgr_start(conf);

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -56,11 +56,16 @@ void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr, struct pfx_ta
 {
     if(tr != NULL)
         rtr_socket->tr_socket = tr;
-    if(refresh_interval == 0 || rtr_socket->refresh_interval > 86400) {
+    if(refresh_interval == 0 || refresh_interval > 86400) {
         rtr_socket->refresh_interval = 3600;
+    } else {
+        rtr_socket->refresh_interval = refresh_interval;
     }
-    if (rtr_socket->expire_interval == 0 || rtr_socket->expire_interval > 172800) {
+
+    if (expire_interval == 0 || expire_interval > 172800) {
         rtr_socket->expire_interval = rtr_socket->refresh_interval * 2;
+    } else {
+        rtr_socket->expire_interval = expire_interval;
     }
 
     rtr_socket->retry_interval = 600;

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -57,11 +57,16 @@ void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr, struct pfx_ta
     if(tr != NULL)
         rtr_socket->tr_socket = tr;
     assert(refresh_interval <= 3600);
-    if(refresh_interval == 0)
+    if(refresh_interval == 0) {
         rtr_socket->refresh_interval = 300;
-    else
-        rtr_socket->refresh_interval = (refresh_interval > (3600 - RTR_RECV_TIMEOUT) ? (3600 - RTR_RECV_TIMEOUT) : refresh_interval);
-    rtr_socket->expire_interval = (expire_interval == 0 ? (rtr_socket->refresh_interval / 2) : expire_interval);
+    }
+    else {
+        rtr_socket->refresh_interval =
+            (refresh_interval > (3600 - RTR_RECV_TIMEOUT) ?
+            (3600 - RTR_RECV_TIMEOUT) : refresh_interval);
+    }
+    rtr_socket->expire_interval = (expire_interval == 0) ?
+        (rtr_socket->refresh_interval * 2) : expire_interval;
     rtr_socket->retry_interval = 600;
     rtr_socket->state = RTR_SHUTDOWN;
     rtr_socket->request_session_id = true;

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -56,17 +56,13 @@ void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr, struct pfx_ta
 {
     if(tr != NULL)
         rtr_socket->tr_socket = tr;
-    assert(refresh_interval <= 3600);
-    if(refresh_interval == 0) {
-        rtr_socket->refresh_interval = 300;
+    if(refresh_interval == 0 || rtr_socket->refresh_interval > 86400) {
+        rtr_socket->refresh_interval = 3600;
     }
-    else {
-        rtr_socket->refresh_interval =
-            (refresh_interval > (3600 - RTR_RECV_TIMEOUT) ?
-            (3600 - RTR_RECV_TIMEOUT) : refresh_interval);
+    if (rtr_socket->expire_interval == 0 || rtr_socket->expire_interval > 172800) {
+        rtr_socket->expire_interval = rtr_socket->refresh_interval * 2;
     }
-    rtr_socket->expire_interval = (expire_interval == 0) ?
-        (rtr_socket->refresh_interval * 2) : expire_interval;
+
     rtr_socket->retry_interval = 600;
     rtr_socket->state = RTR_SHUTDOWN;
     rtr_socket->request_session_id = true;

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -52,7 +52,13 @@ static int install_sig_handler()
     return sigaction(SIGUSR1, &sa, NULL);
 }
 
-void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr, struct pfx_table *pfx_table, struct spki_table *spki_table, const unsigned int refresh_interval, const unsigned int expire_interval, rtr_connection_state_fp fp, void *fp_param)
+void rtr_init(struct rtr_socket *rtr_socket,
+              struct tr_socket *tr,
+              struct pfx_table *pfx_table,
+              struct spki_table *spki_table,
+              const unsigned int refresh_interval,
+              const unsigned int expire_interval,
+              rtr_connection_state_fp fp, void *fp_param)
 {
     if(tr != NULL)
         rtr_socket->tr_socket = tr;
@@ -62,7 +68,8 @@ void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr, struct pfx_ta
         rtr_socket->refresh_interval = refresh_interval;
     }
 
-    if (expire_interval == 0 || expire_interval > 172800) {
+    if (expire_interval == 0 || expire_interval > 172800
+            || expire_interval < rtr_socket->refresh_interval) {
         rtr_socket->expire_interval = rtr_socket->refresh_interval * 2;
     } else {
         rtr_socket->expire_interval = expire_interval;

--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -35,7 +35,8 @@ static const uint8_t RTR_PROTOCOL_MAX_SUPPORTED_VERSION = 1;
 
 enum rtr_rtvals {
     RTR_SUCCESS = 0,
-    RTR_ERROR = -1
+    RTR_ERROR = -1,
+    RTR_INVALID_PARAM = -2
 };
 
 /**
@@ -124,13 +125,23 @@ struct rtr_socket {
  * the rtr_socket won't be changed.
  * @param[in] pfx_table pfx_table that stores the validation records obtained from the connected rtr server.
  * @param[in] spki_table spki_table that stores the router keys obtained from the connected rtr server.
- * @param[in] refresh_interval Interval in seconds between serial queries that are sent to the server. Must be <= 3600
- * @param[in] expire_interval Stored validation records will be deleted if cache was unable to refresh data for this period.\n
- * The default value is twice the refresh_interval.
+ * @param[in] refresh_interval Interval in seconds between serial queries that are sent to the server. Must be >= 1 and <= 86400 (one day),
+ * recommended default is 3600s (one hour).
+ * @param[in] expire_interval Stored validation records will be deleted if cache was unable to refresh data for this period.
+ * The value should be twice the refresh_interval. The value must be >= 600 (ten minutes) and <= 172800 (two days).
+ * The recommanded default is 7200s (two hours).
+ * @param[in] retry_interval This parameter tells the router how long to wait (in seconds) before retrying
+ * a failed Serial Query or Reset Query. The value must be >= 1s and <= 7200s (two hours).
+ * The recommanded default is 600 seconds (ten minutes).
  * @param[in] fp A callback function that is executed when the state of the socket changes.
  * @param[in] fp_data Parameter that is passed to the connection_state_fp callback.
+ * @return RTR_INVALID_PARAM If the refresh_interval or the expire_interval is not valid.
+ * @return RTR_SUCCESS On success.
  */
-void rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr_socket, struct pfx_table *pfx_table, struct spki_table *spki_table, const unsigned int refresh_interval, const unsigned int expire_interval, rtr_connection_state_fp fp, void *fp_data);
+int rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr_socket, struct pfx_table *pfx_table,
+             struct spki_table *spki_table, const unsigned int refresh_interval,
+             const unsigned int expire_interval, const unsigned int retry_interval,
+             rtr_connection_state_fp fp, void *fp_data);
 
 /**
  * @brief Starts the RTR protocol state machine in a pthread. Connection to the rtr_server will be established and the

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -92,10 +92,10 @@ struct rtr_mgr_config {
  *		     be unique in the group array. More than one rtr_mgr_group
  *		     with the same preference value isn't allowed.
  * @param[in] groups_len Number of elements in the groups array.
- * @param[in] refresh_interval Interval in seconds between serial queries that are sent to the server. Must be <= 3600.
- * If 0 is specified the refresh_interval is set to 300 seconds.
+ * @param[in] refresh_interval Interval in seconds between serial queries that are sent to the server.
+ * The maximum value is 86400 seconds (one day). If 0 is specified the refresh_interval is set to 3600 seconds.
  * @param[in] expire_interval Time period in seconds. Received pfx_records are deleted if the client was unable to refresh data for this time period.
- * If 0 is specified, the expire_interval will be half the refresh_interval.
+ * The maximum value is 172800 seconds (two days). If 0 is specified, the expire_interval is twice as large as refresh_interval.
  * The default value is twice the refresh_interval.
  * @param[in] update_fp A Pointer to a pfx_update_fp callback, that is executed for every added and removed pfx_record.
  * @param[in] spki_update_fp A Pointer to a spki_update_fp callback, that is executed for every added and removed spki_record.

--- a/tools/cli-validator.c
+++ b/tools/cli-validator.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
     groups[0].sockets[0] = &rtr_tcp;
     groups[0].preference = 1;
 
-    conf = rtr_mgr_init(groups, 1, 30, 520, NULL, NULL,
+    int ret = rtr_mgr_init(&conf, groups, 1, 30, 600, 600, NULL, NULL,
                         &connectionStatusCallback, NULL);
     rtr_mgr_start(conf);
 

--- a/tools/rtrclient.c
+++ b/tools/rtrclient.c
@@ -211,7 +211,13 @@ int main(int argc, char** argv)
     groups[0].sockets[0] = &rtr;
     groups[0].preference = 1;
 
-    conf = rtr_mgr_init(groups, 1, 30, 520, pfx_update_fp, spki_update_fp, status_fp, NULL);
+    int ret = rtr_mgr_init(&conf, groups, 1, 30, 600, 600, pfx_update_fp, spki_update_fp, status_fp, NULL);
+    if (ret == RTR_ERROR) {
+        printf("Error in rtr_mgr_init!\n");
+    } else if (ret == RTR_INVALID_PARAM) {
+        printf("Invalid params passed to rtr_mgr_init\n");
+    }
+
     if (conf == NULL)
         return EXIT_FAILURE;
     rtr_mgr_start(conf);


### PR DESCRIPTION
This PR adds error codes that will be returned if a user of the rtrlib uses 
illegal values for the retry/refresh/expire intervals.
Furthermore the user is now able to set the retry interval.