### PR TITLE
reduce warnings

### DIFF
--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -185,7 +185,6 @@ static void rtr_mgr_cb(const struct rtr_socket *sock, const enum rtr_socket_stat
         set_status(config, &config->groups[ind], config->groups[ind].status, sock);
     }
 
-out:
     pthread_mutex_unlock(&(config->mutex));
     return;
 }

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -69,12 +69,6 @@ struct rtr_mgr_group {
 
 typedef void (*rtr_mgr_status_fp)(const struct rtr_mgr_group *, enum rtr_mgr_status, const struct rtr_socket *, void *);
 
-
-/**
- * Type alias \c pfx_for_each_fp for function signature: \code (*)(const struct pfx_record *pfx_record, void *data) \endcode
- */
-typedef void (*pfx_for_each_fp)(const struct pfx_record *pfx_record, void *data);
-
 struct rtr_mgr_config {
     struct rtr_mgr_group *groups;
     unsigned int len;

--- a/rtrlib/spki/hashtable/ht-spkitable.c
+++ b/rtrlib/spki/hashtable/ht-spkitable.c
@@ -14,12 +14,12 @@
 #include <pthread.h>
 
 struct key_entry {
-	uint8_t ski[SKI_SIZE];
-	uint32_t asn;
-	uint8_t spki[SPKI_SIZE];
-	const struct rtr_socket *socket;
-	tommy_node hash_node;
-	tommy_node list_node;
+    uint8_t ski[SKI_SIZE];
+    uint32_t asn;
+    uint8_t spki[SPKI_SIZE];
+    const struct rtr_socket *socket;
+    tommy_node hash_node;
+    tommy_node list_node;
 };
 
 /**
@@ -31,39 +31,39 @@ struct key_entry {
  */
 static int key_entry_cmp(const void *arg, const void *obj)
 {
-	const struct key_entry *param = arg;
-	const struct key_entry *entry = obj;
+    const struct key_entry *param = arg;
+    const struct key_entry *entry = obj;
 
-	if (param->asn != entry->asn)
-		return 1;
-	if (memcmp(param->ski, entry->ski, sizeof(entry->ski)))
-		return 1;
-	if (memcmp(param->spki, entry->spki, sizeof(entry->spki)))
-		return 1;
-	if (param->socket != entry->socket)
-		return 1;
+    if (param->asn != entry->asn)
+        return 1;
+    if (memcmp(param->ski, entry->ski, sizeof(entry->ski)))
+        return 1;
+    if (memcmp(param->spki, entry->spki, sizeof(entry->spki)))
+        return 1;
+    if (param->socket != entry->socket)
+        return 1;
 
-	return 0;
+    return 0;
 }
 
 /* Copying the content, target struct must already be allocated */
 static void key_entry_to_spki_record(struct key_entry *key_e,
-				    struct spki_record *spki_r)
+                                     struct spki_record *spki_r)
 {
-	spki_r->asn = key_e->asn;
-	spki_r->socket = key_e->socket;
-	memcpy(spki_r->ski, key_e->ski, sizeof(key_e->ski));
-	memcpy(spki_r->spki, key_e->spki, sizeof(key_e->spki));
+    spki_r->asn = key_e->asn;
+    spki_r->socket = key_e->socket;
+    memcpy(spki_r->ski, key_e->ski, sizeof(key_e->ski));
+    memcpy(spki_r->spki, key_e->spki, sizeof(key_e->spki));
 }
 
 /* Copying the content, target struct must already be allocated */
 static void spki_record_to_key_entry(struct spki_record *spki_r,
-				    struct key_entry *key_e)
+                                     struct key_entry *key_e)
 {
-	key_e->asn = spki_r->asn;
-	key_e->socket = spki_r->socket;
-	memcpy(key_e->ski, spki_r->ski, sizeof(spki_r->ski));
-	memcpy(key_e->spki, spki_r->spki, sizeof(spki_r->spki));
+    key_e->asn = spki_r->asn;
+    key_e->socket = spki_r->socket;
+    memcpy(key_e->ski, spki_r->ski, sizeof(spki_r->ski));
+    memcpy(key_e->spki, spki_r->spki, sizeof(spki_r->spki));
 }
 
 /**
@@ -73,212 +73,213 @@ static void spki_record_to_key_entry(struct spki_record *spki_r,
  * @param[in] added True means record was added, False means removed
  */
 static void spki_table_notify_clients(struct spki_table *spki_table,
-				      const struct spki_record *record,
-				      const bool added)
+                                      const struct spki_record *record,
+                                      const bool added)
 {
-	if (spki_table->update_fp != NULL)
-		spki_table->update_fp(spki_table, *record, added);
+    if (spki_table->update_fp != NULL)
+        spki_table->update_fp(spki_table, *record, added);
 }
 
 void spki_table_init(struct spki_table *spki_table, spki_update_fp update_fp)
 {
-	tommy_hashlin_init(&spki_table->hashtable);
-	tommy_list_init(&spki_table->list);
-	pthread_rwlock_init(&spki_table->lock, NULL);
-	spki_table->cmp_fp = key_entry_cmp;
-	spki_table->update_fp = update_fp;
+    tommy_hashlin_init(&spki_table->hashtable);
+    tommy_list_init(&spki_table->list);
+    pthread_rwlock_init(&spki_table->lock, NULL);
+    spki_table->cmp_fp = key_entry_cmp;
+    spki_table->update_fp = update_fp;
 }
 
 void spki_table_free(struct spki_table *spki_table)
 {
-	pthread_rwlock_wrlock(&spki_table->lock);
+    pthread_rwlock_wrlock(&spki_table->lock);
 
-	tommy_list_foreach(&spki_table->list, free);
-	tommy_hashlin_done(&spki_table->hashtable);
+    tommy_list_foreach(&spki_table->list, free);
+    tommy_hashlin_done(&spki_table->hashtable);
 
-	pthread_rwlock_unlock(&spki_table->lock);
-	pthread_rwlock_destroy(&spki_table->lock);
+    pthread_rwlock_unlock(&spki_table->lock);
+    pthread_rwlock_destroy(&spki_table->lock);
 }
 
 int spki_table_add_entry(struct spki_table *spki_table,
-			 struct spki_record *spki_record)
+                         struct spki_record *spki_record)
 {
-	uint32_t hash;
-	struct key_entry *entry;
+    uint32_t hash;
+    struct key_entry *entry;
 
-	entry = malloc(sizeof(*entry));
-	if (entry == NULL)
-		return SPKI_ERROR;
+    entry = malloc(sizeof(*entry));
+    if (entry == NULL)
+        return SPKI_ERROR;
 
-	spki_record_to_key_entry(spki_record, entry);
-	hash = tommy_inthash_u32(spki_record->asn);
+    spki_record_to_key_entry(spki_record, entry);
+    hash = tommy_inthash_u32(spki_record->asn);
 
-	pthread_rwlock_wrlock(&spki_table->lock);
-	if (tommy_hashlin_search(&spki_table->hashtable, spki_table->cmp_fp,
-				 entry, hash)) {
-		free(entry);
-		pthread_rwlock_unlock(&spki_table->lock);
-		return SPKI_DUPLICATE_RECORD;
-	}
+    pthread_rwlock_wrlock(&spki_table->lock);
+    if (tommy_hashlin_search(&spki_table->hashtable,
+                             spki_table->cmp_fp,
+                             entry, hash)) {
+        free(entry);
+        pthread_rwlock_unlock(&spki_table->lock);
+        return SPKI_DUPLICATE_RECORD;
+    }
 
-	/* Insert into hashtable and list */
-	tommy_hashlin_insert(&spki_table->hashtable, &entry->hash_node,
-			     entry, hash);
-	tommy_list_insert_tail(&spki_table->list, &entry->list_node,
-			       entry);
-	pthread_rwlock_unlock(&spki_table->lock);
-	spki_table_notify_clients(spki_table, spki_record, true);
-	return SPKI_SUCCESS;
+    /* Insert into hashtable and list */
+    tommy_hashlin_insert(&spki_table->hashtable,
+                         &entry->hash_node,
+                         entry, hash);
+    tommy_list_insert_tail(&spki_table->list,
+                           &entry->list_node,
+                           entry);
+    pthread_rwlock_unlock(&spki_table->lock);
+    spki_table_notify_clients(spki_table, spki_record, true);
+    return SPKI_SUCCESS;
 }
 
 int spki_table_get_all(struct spki_table *spki_table, uint32_t asn,
-		       uint8_t *ski, struct spki_record **result,
-		       unsigned int *result_size)
+                       uint8_t *ski, struct spki_record **result,
+                       unsigned int *result_size)
 {
-	uint32_t hash = tommy_inthash_u32(asn);
-	tommy_node *result_bucket;
-	struct key_entry *element;
-	void *tmp;
+    uint32_t hash = tommy_inthash_u32(asn);
+    tommy_node *result_bucket;
+    struct key_entry *element;
+    void *tmp;
 
-	*result = NULL;
-	*result_size = 0;
+    *result = NULL;
+    *result_size = 0;
 
-	pthread_rwlock_rdlock(&spki_table->lock);
+    pthread_rwlock_rdlock(&spki_table->lock);
 
-	/**
-	 * A tommy node contains its storing key_entry (->data) as well as
-	 * next and prev pointer to accomodate multiple results.
-	 * The bucket is guaranteed to contain ALL the elements
-	 * with the specified hash, but it can contain also others.
-	 */
-	result_bucket = tommy_hashlin_bucket(&spki_table->hashtable, hash);
+    /**
+     * A tommy node contains its storing key_entry (->data) as well as
+     * next and prev pointer to accomodate multiple results.
+     * The bucket is guaranteed to contain ALL the elements
+     * with the specified hash, but it can contain also others.
+     */
+    result_bucket = tommy_hashlin_bucket(&spki_table->hashtable, hash);
 
-	if (!result_bucket) {
-		pthread_rwlock_unlock(&spki_table->lock);
-		return SPKI_SUCCESS;
-	}
+    if (!result_bucket) {
+        pthread_rwlock_unlock(&spki_table->lock);
+        return SPKI_SUCCESS;
+    }
 
-	/* Build the result array */
-	while (result_bucket) {
-		element = result_bucket->data;
-		if (element->asn == asn &&
-		    memcmp(element->ski, ski, sizeof(element->ski)) == 0) {
-			(*result_size)++;
-			tmp = realloc(*result, *result_size * sizeof(**result));
-			if (tmp == NULL) {
-				free(*result);
-				pthread_rwlock_unlock(&spki_table->lock);
-				return SPKI_ERROR;
-			}
-			*result = tmp;
-			key_entry_to_spki_record(element,
-						 *result + *result_size-1);
-		}
-		result_bucket = result_bucket->next;
-	}
+    /* Build the result array */
+    while (result_bucket) {
+        element = result_bucket->data;
+        if (element->asn == asn &&
+            memcmp(element->ski, ski, sizeof(element->ski)) == 0) {
+            (*result_size)++;
+            tmp = realloc(*result, *result_size * sizeof(**result));
+            if (tmp == NULL) {
+                free(*result);
+                pthread_rwlock_unlock(&spki_table->lock);
+                return SPKI_ERROR;
+            }
+            *result = tmp;
+            key_entry_to_spki_record(element,
+                         *result + *result_size-1);
+        }
+        result_bucket = result_bucket->next;
+    }
 
-	pthread_rwlock_unlock(&spki_table->lock);
-	return SPKI_SUCCESS;
+    pthread_rwlock_unlock(&spki_table->lock);
+    return SPKI_SUCCESS;
 }
 
 int spki_table_search_by_ski(struct spki_table *spki_table, uint8_t *ski,
-			     struct spki_record **result,
-			     unsigned int *result_size)
+                             struct spki_record **result,
+                             unsigned int *result_size)
 {
-	struct key_entry *current_entry;
-	tommy_node *current_node;
-	void *tmp;
-	*result = NULL;
-	*result_size = 0;
+    struct key_entry *current_entry;
+    tommy_node *current_node;
+    void *tmp;
+    *result = NULL;
+    *result_size = 0;
 
-	pthread_rwlock_rdlock(&spki_table->lock);
+    pthread_rwlock_rdlock(&spki_table->lock);
 
-	current_node = tommy_list_head(&spki_table->list);
-	while (current_node) {
-		current_entry = (struct key_entry *)current_node->data;
+    current_node = tommy_list_head(&spki_table->list);
+    while (current_node) {
+        current_entry = (struct key_entry *)current_node->data;
 
-		if (memcmp(current_entry->ski, ski,
-			   sizeof(current_entry->ski)) == 0) {
-			(*result_size)++;
-			tmp = realloc(*result,
-				      sizeof(**result) * (*result_size));
-			if (tmp == NULL) {
-				free(*result);
-				pthread_rwlock_unlock(&spki_table->lock);
-				return SPKI_ERROR;
-			}
-			*result = tmp;
-			key_entry_to_spki_record(current_entry,
-						 *result + (*result_size-1));
-		}
-		current_node = current_node->next;
-	}
-	pthread_rwlock_unlock(&spki_table->lock);
-	return SPKI_SUCCESS;
+        if (memcmp(current_entry->ski, ski, sizeof(current_entry->ski)) == 0) {
+            (*result_size)++;
+            tmp = realloc(*result,
+                      sizeof(**result) * (*result_size));
+            if (tmp == NULL) {
+                free(*result);
+                pthread_rwlock_unlock(&spki_table->lock);
+                return SPKI_ERROR;
+            }
+            *result = tmp;
+            key_entry_to_spki_record(current_entry, *result+(*result_size-1));
+        }
+        current_node = current_node->next;
+    }
+    pthread_rwlock_unlock(&spki_table->lock);
+    return SPKI_SUCCESS;
 }
 
 int spki_table_remove_entry(struct spki_table *spki_table,
-			    struct spki_record *spki_record)
+                            struct spki_record *spki_record)
 {
-	uint32_t hash;
-	struct key_entry entry;
-	struct key_entry *rmv_elem;
-	int rtval;
+    uint32_t hash;
+    struct key_entry entry;
+    struct key_entry *rmv_elem;
+    int rtval = SPKI_ERROR;
 
-	spki_record_to_key_entry(spki_record, &entry);
-	hash = tommy_inthash_u32(spki_record->asn);
+    spki_record_to_key_entry(spki_record, &entry);
+    hash = tommy_inthash_u32(spki_record->asn);
 
-	pthread_rwlock_wrlock(&spki_table->lock);
+    pthread_rwlock_wrlock(&spki_table->lock);
 
-	if (!tommy_hashlin_search(&spki_table->hashtable, spki_table->cmp_fp,
-				  &entry, hash)) {
-		rtval = SPKI_RECORD_NOT_FOUND;
-		goto out;
-	}
-
-	/* Remove from hashtable and list */
-	rmv_elem = tommy_hashlin_remove(&spki_table->hashtable,
-					spki_table->cmp_fp, &entry, hash);
-	if (rmv_elem && tommy_list_remove_existing(&spki_table->list,
-						   &rmv_elem->list_node)) {
-		free(rmv_elem);
-		spki_table_notify_clients(spki_table, spki_record, false);
-		rtval = SPKI_SUCCESS;
-	}
-
-out:
-	pthread_rwlock_unlock(&spki_table->lock);
-	return rtval;
+    if (!tommy_hashlin_search(&spki_table->hashtable,
+                              spki_table->cmp_fp,
+                              &entry, hash)) {
+        rtval = SPKI_RECORD_NOT_FOUND;
+    }
+    else {
+        /* Remove from hashtable and list */
+        rmv_elem = tommy_hashlin_remove(&spki_table->hashtable,
+                                        spki_table->cmp_fp,
+                                        &entry, hash);
+        if (rmv_elem && tommy_list_remove_existing(&spki_table->list,
+                                                   &rmv_elem->list_node)) {
+            free(rmv_elem);
+            spki_table_notify_clients(spki_table, spki_record, false);
+            rtval = SPKI_SUCCESS;
+        }
+    }
+    pthread_rwlock_unlock(&spki_table->lock);
+    return rtval;
 }
 
 int spki_table_src_remove(struct spki_table *spki_table,
-			  const struct rtr_socket *socket)
+                          const struct rtr_socket *socket)
 {
-	struct key_entry *entry;
-	tommy_node *current_node;
+    struct key_entry *entry;
+    tommy_node *current_node;
 
-	pthread_rwlock_wrlock(&spki_table->lock);
+    pthread_rwlock_wrlock(&spki_table->lock);
 
-	current_node = tommy_list_head(&spki_table->list);
-	while (current_node) {
-		entry = current_node->data;
-		if (entry->socket == socket) {
-			current_node = current_node->next;
-			if (!tommy_list_remove_existing(&spki_table->list,
-							&entry->list_node)) {
-				pthread_rwlock_unlock(&spki_table->lock);
-				return SPKI_ERROR;
-			}
-			if (!tommy_hashlin_remove_existing(&spki_table->hashtable,
-							   &entry->hash_node)) {
-				pthread_rwlock_unlock(&spki_table->lock);
-				return SPKI_ERROR;
-			}
-			free(entry);
-		} else {
-			current_node = current_node->next;
-		}
-	}
-	pthread_rwlock_unlock(&spki_table->lock);
-	return SPKI_SUCCESS;
+    current_node = tommy_list_head(&spki_table->list);
+    while (current_node) {
+        entry = current_node->data;
+        if (entry->socket == socket) {
+            current_node = current_node->next;
+            if (!tommy_list_remove_existing(&spki_table->list,
+                                            &entry->list_node)) {
+                pthread_rwlock_unlock(&spki_table->lock);
+                return SPKI_ERROR;
+            }
+            if (!tommy_hashlin_remove_existing(&spki_table->hashtable,
+                                               &entry->hash_node)) {
+                pthread_rwlock_unlock(&spki_table->lock);
+                return SPKI_ERROR;
+            }
+            free(entry);
+        } else {
+            current_node = current_node->next;
+        }
+    }
+    pthread_rwlock_unlock(&spki_table->lock);
+    return SPKI_SUCCESS;
 }

--- a/tools/cli-validator.c
+++ b/tools/cli-validator.c
@@ -22,8 +22,8 @@ int connectionError(enum rtr_mgr_status status)
         // Wait for input before printing error to avoid "broken pipe" error while communicating
         // with the Python program.
         char input[256];
-        int inputLength;
-        fgets(input, 256, stdin);
+        if(fgets(input, 256, stdin))
+            ;;
 
         printf("error\n");
         fflush(stdout);
@@ -57,8 +57,10 @@ int main(int argc, char *argv[])
     groups[0].sockets[0] = &rtr_tcp;
     groups[0].preference = 1;
 
-    int ret = rtr_mgr_init(&conf, groups, 1, 30, 600, 600, NULL, NULL,
-                        &connectionStatusCallback, NULL);
+    if( rtr_mgr_init(&conf, groups, 1, 30, 600, 600, NULL, NULL,
+                        &connectionStatusCallback, NULL) < 0) {
+        return(EXIT_FAILURE);
+    }
     rtr_mgr_start(conf);
 
     char input[256];
@@ -75,7 +77,8 @@ int main(int argc, char *argv[])
         if (sleepCounter >= connection_timeout) {
             // Wait for input before printing "timeout",to avoid "broken pipe"
             // error while communicating with the Python program
-            fgets(input, 256, stdin);
+            if(fgets(input, 256, stdin))
+                ;;
             printf("timeout\n");
             fflush(stdout);
             return(EXIT_FAILURE);

--- a/tools/rtrclient.c
+++ b/tools/rtrclient.c
@@ -106,7 +106,7 @@ static void update_spki(struct spki_table* s __attribute__((unused)), const stru
 
 int main(int argc, char** argv)
 {
-    enum mode_t { TCP, SSH } mode;
+    enum mode_t { TCP, SSH } mode = TCP;
     char* host = NULL;
     char* port = NULL;
     spki_update_fp spki_update_fp = NULL;
@@ -127,6 +127,10 @@ int main(int argc, char** argv)
     }
     else if(strncasecmp(argv[1], "ssh", strlen(argv[1])) == 0){
         mode = SSH;
+    }
+    else {
+        print_usage(argv);
+        return(EXIT_FAILURE);
     }
 
     //Optional args
@@ -170,12 +174,6 @@ int main(int argc, char** argv)
             hostkey = NULL;
         }
 #endif
-    else {
-        print_usage(argv);
-        return(EXIT_FAILURE);
-    }
-
-
 
     struct tr_socket tr_sock;
     struct tr_tcp_config tcp_config;


### PR DESCRIPTION
This pull request addresses issue #55 

It fixes all warnings on OSX with clang, but on Linux with GCC some _strict aliasing_ warnings remain.
