### PR TITLE
add missing va_end

### DIFF
--- a/rtrlib/lib/log.c
+++ b/rtrlib/lib/log.c
@@ -38,6 +38,7 @@ void lrtr_dbg(const char *frmt, ...)
 
     vprintf(frmt, argptr);
     printf("\n");
+    va_end(argptr);
 #endif
     return;
 }


### PR DESCRIPTION
This fixes a missing ```va_end(argptr)``` in [rtrlib/lib/log.c](https://github.com/rtrlib/rtrlib/blob/master/rtrlib/lib/log.c) found using ```cppcheck```.