### PR TITLE
[cmake] disable check g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(rtrlib)
+project(rtrlib C)
 
 cmake_minimum_required(VERSION 2.6)
 


### PR DESCRIPTION
By default cmake enables C and CXX but we only need a C compiler.