### PR TITLE
add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*.{c,h}]
+indent_style = tab
+tab_width = 8
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+[{.travis.yml,CMakeLists.txt}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This PR provides a _convenience_ feature by adding `.editorconfig` file, to automatically configure indention for certain file types. This is supported by many editors and IDEs either build-in or by software plug-in, e.g., for [Atom](https://atom.io/packages/editorconfig). 

For `rtrlib` we agreed to comply with the kernel coding style using tabs and indent of 8; however, for other projects I prefer different settings, i.e., spaces and indent of 4. See [here](http://editorconfig.org) for further details.