### PR TITLE
debian: build deb w/o ssh dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -14,7 +14,7 @@ librtr0 (0.3.6-1) stable; urgency=low
   * Improve debugging and status values
   * Update SSH transport to new LibSSH API
 
--- Matthias Waehlisch <waehlisch@ieee.org>  Tue,  5 Apr 2016 12:55:56 -0700
+ -- Matthias Waehlisch <waehlisch@ieee.org>  Tue,  5 Apr 2016 12:55:56 -0700
 
 librtr0 (0.3.5-1) stable; urgency=low
 
@@ -27,7 +27,7 @@ librtr0 (0.3.5-1) stable; urgency=low
   * Add support for OS X (10.10)
   * Add new tool cli-validator
 
--- Matthias Waehlisch <waehlisch@ieee.org>  Thu, 20 Aug 2015 04:05:48 -0700
+ -- Matthias Waehlisch <waehlisch@ieee.org>  Thu, 20 Aug 2015 04:05:48 -0700
 
 librtr0 (0.3.0-1) stable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: librtr0
 Section: libs
 Priority: optional
 Maintainer: Fabian Holler <mail@fholler.de>
-Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev (>= 0.6.0), doxygen
+Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev (>= 0.6.0) <!nossh>, doxygen
 Standards-Version: 3.9.4
 Vcs-Git: git://github.com/rtrlib/rtrlib.git
 Vcs-Browser: https://github.com/rtrlib/rtrlib
@@ -12,7 +12,7 @@ Package: librtr0
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}, libssh-4 (>= 0.6.0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libssh-4 (>= 0.6.0) <!nossh>
 Description: Small extensible RPKI-RTR-Client C library.
  RTRlib is an open-source C implementation of the  RPKI/Router Protocol
  client. The library allows one to fetch and store validated prefix origin data
@@ -69,7 +69,7 @@ Description: Small extensible RPKI-RTR-Client C library. Documentation files
 Package: rtrclient
 Section: utils
 Architecture: any
-Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libssh-4 (>= 0.6.0)
+Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libssh-4 (>= 0.6.0) <!nossh>
 Description: RPKI-RTR command line tool
  Rtrclient is command line that connects to an RPKI-RTR server and prints
  protocol information and information about the fetched ROAs to the console.
@@ -90,7 +90,7 @@ Description: RPKI-RTR command line tool
 Package: cli-validator
 Section: utils
 Architecture: any
-Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libssh-4 (>= 0.6.0)
+Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
 Description: RPKI-RTR command line tool
  Cli-validator is a command line tool that connects to an RPKI-RTR server and
  allows to validate given IP prefixes and origin ASes.

--- a/debian/rules
+++ b/debian/rules
@@ -7,10 +7,16 @@ include /usr/share/dpkg/buildflags.mk
 CFLAGS+=$(CPPFLAGS)
 CXXFLAGS+=$(CPPFLAGS)
 
+CBT = "Release"
+
+ifneq (,$(filter nossh,$(DEB_BUILD_PROFILES)))
+    CBT = "NoSSH"
+endif
+
 override_dh_installchangelogs:
 	dh_installchangelogs CHANGELOG
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_SKIP_RPATH=True
+	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=$(CBT) -DCMAKE_SKIP_RPATH=True
 override_dh_strip:
 	dh_strip -prtrclient --dbg-package=rtrclient-dbg
 	dh_strip -pcli-validator --dbg-package=cli-validator-dbg
@@ -18,4 +24,4 @@ override_dh_strip:
 override_dh_auto_test:
 
 %:
-	dh $@ 
+	dh $@


### PR DESCRIPTION
 - (optional) build deb package without libssh dependency
 - add build profile 'nossh'
 - requires dpkg version >= 1.7.14
 - command: dpkg-buildpackage -Pnossh [-us -uc]
 - fix wrong lines in debian/changelog

This PR fixes issue #73. 

_Note_: the build profile disables SSH (dependency on libssh) during deb package build even if the library is installed!