### PR TITLE
fix license header

### DIFF
--- a/rtrlib/lib/ip.c
+++ b/rtrlib/lib/ip.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <stdbool.h>
 #include <string.h>

--- a/rtrlib/lib/ip.h
+++ b/rtrlib/lib/ip.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #ifndef LRTR_IP_H
 #define LRTR_IP_H

--- a/rtrlib/lib/ipv4.c
+++ b/rtrlib/lib/ipv4.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include "rtrlib/lib/ipv4.h"
 #include "rtrlib/lib/utils.h"

--- a/rtrlib/lib/ipv4.h
+++ b/rtrlib/lib/ipv4.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #ifndef LRTR_IPV4_H
 #define LRTR_IPV4_H

--- a/rtrlib/lib/ipv6.c
+++ b/rtrlib/lib/ipv6.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include "rtrlib/lib/ipv6.h"
 #include "rtrlib/lib/ipv4.h"

--- a/rtrlib/lib/ipv6.h
+++ b/rtrlib/lib/ipv6.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #ifndef LRTR_IPV6_H
 #define LRTR_IPV6_H

--- a/rtrlib/lib/log.c
+++ b/rtrlib/lib/log.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <arpa/inet.h>
 #include <stdarg.h>

--- a/rtrlib/lib/log.h
+++ b/rtrlib/lib/log.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #ifndef LRTR_LOG_H
 #define LRTR_LOG_H

--- a/rtrlib/lib/utils.c
+++ b/rtrlib/lib/utils.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <arpa/inet.h>
 #include <assert.h>

--- a/rtrlib/lib/utils.h
+++ b/rtrlib/lib/utils.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #ifndef LRTR_UTILS_H
 #define LRTR_UTILS_H

--- a/rtrlib/pfx/lpfst/lpfst-pfx.c
+++ b/rtrlib/pfx/lpfst/lpfst-pfx.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include "rtrlib/pfx/lpfst/lpfst-pfx.h"
 #include <assert.h>

--- a/rtrlib/pfx/lpfst/lpfst-pfx.h
+++ b/rtrlib/pfx/lpfst/lpfst-pfx.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 /**
  * @defgroup mod_lpfst_pfx_h Longest prefix first search tree

--- a/rtrlib/pfx/lpfst/lpfst.c
+++ b/rtrlib/pfx/lpfst/lpfst.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <stdlib.h>
 #include <assert.h>

--- a/rtrlib/pfx/lpfst/lpfst.h
+++ b/rtrlib/pfx/lpfst/lpfst.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #ifndef RTR_LPFST
 #define RTR_LPFST

--- a/rtrlib/pfx/pfx.h
+++ b/rtrlib/pfx/pfx.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 /**
  * @defgroup mod_pfx_h Prefix validation table
@@ -81,7 +81,7 @@ typedef void (*pfx_update_fp)(struct pfx_table *pfx_table, const struct pfx_reco
 
 /**
  * @brief A function pointer that is called for each record in the pfx_table.
- * @param pfx_record 
+ * @param pfx_record
  * @param data forwarded data which the user has passed to pfx_table_for_each_ipv4_record() or
  * pfx_table_for_each_ipv6_record()
  */

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <stdlib.h>
 #include <string.h>
@@ -747,7 +747,7 @@ static int rtr_store_prefix_pdu(struct rtr_socket *rtr_socket, const void *pdu, 
     return RTR_SUCCESS;
 }
 
-static int rtr_store_router_key_pdu(struct rtr_socket *rtr_socket, const void *pdu, const unsigned int pdu_size, 
+static int rtr_store_router_key_pdu(struct rtr_socket *rtr_socket, const void *pdu, const unsigned int pdu_size,
 				    struct pdu_router_key **ary, unsigned int *ind, unsigned int *size)
 {
     assert(rtr_get_pdu_type(pdu) == ROUTER_KEY);

--- a/rtrlib/rtr/packets.h
+++ b/rtrlib/rtr/packets.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #ifndef RTR_PACKETS_H
 #define RTR_PACKETS_H

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <assert.h>
 #include <pthread.h>

--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 
 /**

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include "rtrlib/rtr_mgr.h"
 #include "rtrlib/pfx/lpfst/lpfst-pfx.h"

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 /**
  * @defgroup mod_rtr_mgr_h RTR connection manager

--- a/rtrlib/rtrlib.h.cmake
+++ b/rtrlib/rtrlib.h.cmake
@@ -1,22 +1,10 @@
 /*
  * This file is part of RTRlib.
  *
- * RTRlib is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or (at your
- * option) any later version.
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
  *
- * RTRlib is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
- * License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with RTRlib; see the file COPYING.LESSER.
- *
- * INET group, Hamburg University of Applied Sciences,
- * CST group, Freie Universitaet Berlin
- * Website: http://rpki.realmv6.org/
+ * Website: http://rtrlib.realmv6.org/
  */
 
 #ifndef RTRLIB_H

--- a/rtrlib/spki/hashtable/ht-spkitable.c
+++ b/rtrlib/spki/hashtable/ht-spkitable.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include "rtrlib/spki/hashtable/ht-spkitable.h"
 

--- a/rtrlib/spki/hashtable/ht-spkitable.h
+++ b/rtrlib/spki/hashtable/ht-spkitable.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 #ifndef RTR_HT_SPKITABLE_H
 #define RTR_HT_SPKITABLE_H
 

--- a/rtrlib/spki/spkitable.h
+++ b/rtrlib/spki/spkitable.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 /**
  * @defgroup mod_spki_h Subject Public Key Info table

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <assert.h>
 #include <stdbool.h>

--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 /**
  * @defgroup mod_ssh_transport_h SSH transport socket

--- a/rtrlib/transport/tcp/tcp_transport.c
+++ b/rtrlib/transport/tcp/tcp_transport.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <assert.h>
 #include <errno.h>

--- a/rtrlib/transport/tcp/tcp_transport.h
+++ b/rtrlib/transport/tcp/tcp_transport.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 /**
  * @defgroup mod_tcp_transport_h TCP transport socket

--- a/rtrlib/transport/transport.c
+++ b/rtrlib/transport/transport.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include "rtrlib/transport/transport.h"
 #include "rtrlib/lib/utils.h"

--- a/rtrlib/transport/transport.h
+++ b/rtrlib/transport/transport.h
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 /**
  * @defgroup mod_transport_h Transport sockets

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tests/test_lpfst.c
+++ b/tests/test_lpfst.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tests/test_pfx_locks.c
+++ b/tests/test_pfx_locks.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tools/cli-validator.c
+++ b/tools/cli-validator.c
@@ -5,7 +5,7 @@
  * See the file LICENSE in the top level directory for more details.
  *
  * Website: http://rtrlib.realmv6.org/
-*/
+ */
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
This resolves issue #63, it corrects last comment line of license header and add correct license header to the rtrlib.h.cmake template.