### PR TITLE
Add simple linking troubleshooting

### DIFF
--- a/README
+++ b/README
@@ -75,7 +75,7 @@ occurs, the location of the library can be passed explicitly as a parameter
 
     -L<path_to_librtr.so>
 
-eg.,
+e.g.,
     -L/usr/local/lib64/
 
 

--- a/README
+++ b/README
@@ -66,6 +66,18 @@ pass the following parameter to gcc:
 
     -lrtr
 
+In case an error such as
+
+    -/usr/bin/ld: cannot find -lrtr
+    -collect2: error: ld returned 1 exit status
+
+occurs, the location of the library can be passed explicitly as a parameter
+
+    -L<path_to_librtr.so>
+
+eg.,
+    -L/usr/local/lib64/
+
 
 API Documentation
 -----------------


### PR DESCRIPTION
On some systems the path to the rtrlib.so must be passed to gcc using -L,
else the compiler complains about not finding lrtr.