### PR TITLE
lib: fix documentation

### DIFF
--- a/rtrlib/lib/ipv4.h
+++ b/rtrlib/lib/ipv4.h
@@ -43,6 +43,7 @@ int lrtr_ipv4_str_to_addr(const char *str, struct lrtr_ipv4_addr *ip);
  * Converts the passed ipv4_addr to string representation.
  * @param[in] ip ipv4_addr
  * @param[out] str Pointer to a string buffer must be at least INET_ADDRSTRLEN bytes long.
+ * @param[in] length of *str
  * @result 0 on success
  * @result -1 on error
 */

--- a/rtrlib/pfx/pfx.h
+++ b/rtrlib/pfx/pfx.h
@@ -61,7 +61,7 @@ enum pfxv_state {
  * @param prefix IP prefix.
  * @param min_len Minimum prefix length.
  * @param max_len Maximum prefix length.
- * @param socket_id unique id of the rtr_socket that received this record.
+ * @param socket The rtr_socket that received this record.
  */
 struct pfx_record {
     uint32_t asn;

--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -96,8 +96,12 @@ typedef void (*rtr_connection_state_fp)(const struct rtr_socket *rtr_socket, con
  * @param request_session_id True, if the rtr_client have to request a new none from the server.
  * @param serial_number Last serial number of the obtained validation records.
  * @param pfx_table pfx_table that stores the validation records obtained from the connected rtr server.
+ * @param thread_id Handle of the thread this socket is running in.
  * @param connection_state_fp A callback function that is executed when the state of the socket changes.
  * @param connection_state_fp_param Parameter that is passed to the connection_state_fp callback.
+ * @param version Protocol version used by this socket
+ * @param has_received_pdus True, if this socket has already recieved PDUs
+ * @param spki_table spki_table that stores the router keys obtaiend from the connected rtr server
  */
 struct rtr_socket {
     struct tr_socket *tr_socket;


### PR DESCRIPTION
add missing parameter in docstring of function lrtr_ipv4_addr_to_str