### PR TITLE
rtrlib/transport: change port from int to char in ssh transport

### DIFF
--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -17,14 +17,14 @@
 #include "../../lib/utils.h"
 #include "ssh_transport.h"
 
-#define SSH_DBG(fmt, sock, ...) lrtr_dbg("SSH Transport(%s@%s:%u): " fmt, (sock)->config.username, (sock)->config.host, (sock)->config.port, ## __VA_ARGS__)
-#define SSH_DBG1(a, sock) lrtr_dbg("SSH Transport(%s@%s:%u): " a, (sock)->config.username, (sock)->config.host, (sock)->config.port)
+#define SSH_DBG(fmt, sock, ...) lrtr_dbg("SSH Transport(%s@%s:%s): " fmt, (sock)->config.username, (sock)->config.host, (sock)->config.port, ## __VA_ARGS__)
+#define SSH_DBG1(a, sock) lrtr_dbg("SSH Transport(%s@%s:%s): " a, (sock)->config.username, (sock)->config.host, (sock)->config.port)
 
 struct tr_ssh_socket {
-    ssh_session session;
-    ssh_channel channel;
-    struct tr_ssh_config config;
-    char *ident;
+        ssh_session session;
+        ssh_channel channel;
+        struct tr_ssh_config config;
+        char *ident;
 };
 
 static int tr_ssh_open(void *tr_ssh_sock);
@@ -52,7 +52,7 @@ int tr_ssh_open(void *socket)
     ssh_options_set(ssh_socket->session, SSH_OPTIONS_LOG_VERBOSITY, &verbosity);
 
     ssh_options_set(ssh_socket->session, SSH_OPTIONS_HOST, config->host);
-    ssh_options_set(ssh_socket->session, SSH_OPTIONS_PORT, &(config->port));
+    ssh_options_set(ssh_socket->session, SSH_OPTIONS_PORT_STR, &(config->port));
     ssh_options_set(ssh_socket->session, SSH_OPTIONS_BINDADDR, config->bindaddr);
     ssh_options_set(ssh_socket->session, SSH_OPTIONS_USER, config->username);
 
@@ -184,7 +184,7 @@ const char *tr_ssh_ident(void *tr_ssh_sock)
     sock->ident = malloc(len);
     if (sock->ident == NULL)
         return NULL;
-    snprintf(sock->ident, len, "%s@%s:%u", sock->config.username,
+    snprintf(sock->ident, len, "%s@%s:%s", sock->config.username,
              sock->config.host, sock->config.port);
     return sock->ident;
 }

--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -35,17 +35,17 @@
  *		   determination by OS.
  * @param username Username for authentication.
  * @param server_hostkey_path Path to public SSH key of the server or NULL to
-                              don't verify host authenticity.
+ *                            don't verify host authenticity.
  * @param client_privkey_path Path to private key of the authentication keypair
  *                            or NULL to use ~/.ssh/id_rsa.
  */
 struct tr_ssh_config {
-    char *host;
-    unsigned int port;
-    char *bindaddr;
-    char *username;
-    char *server_hostkey_path;
-    char *client_privkey_path;
+	char *host;
+	char *port;
+	char *bindaddr;
+	char *username;
+	char *server_hostkey_path;
+	char *client_privkey_path;
 };
 
 /**

--- a/scripts/check-coding-files.txt
+++ b/scripts/check-coding-files.txt
@@ -2,6 +2,7 @@ rtrlib/rtr_mgr.h
 rtrlib/rtr_mgr.c
 rtrlib/pfx/lpfst/lpfst.h
 rtrlib/pfx/lpfst/lpfst.c
+rtrlib/transport/ssh/ssh_transport.h
 tests/test_ht_spkitable.c
 tests/test_ht_spkitable_locks.c
 tests/test_live_validation.c

--- a/tools/rtrclient.c
+++ b/tools/rtrclient.c
@@ -187,11 +187,9 @@ int main(int argc, char **argv)
 	}
 	#ifdef RTRLIB_HAVE_LIBSSH
 	else {
-		unsigned int iport = atoi(port);
-
 		ssh_config = (struct tr_ssh_config) {
 			host,
-			iport,
+			port,
 			NULL,
 			user,
 			hostkey,


### PR DESCRIPTION
This addresses #80 and applies comment by @shaddeus so that both `struct tr_tcp_config` and `struct tr_ssh_config` handle port as `char *`. However, now the tcp config is just a subset of ssh config, and hence somewhat redundant. Maybe we should have a `struct tr_config` and for SSH some extend struct?!

Note: this PR makes `ssh_transport.h`  kernel coding style compliant, this file is added for testing too.