### PR TITLE
doxygen/examples: fixes outdated host and port.

### DIFF
--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include "rtrlib/rtrlib.h"
 
@@ -20,8 +21,8 @@ int main(){
 
     //create a TCP transport socket
     struct tr_socket tr_tcp1;
-	char tcp1_host[]	= "rpki.realmv6.org";
-	char tcp1_port[]	= "42420";
+	char tcp1_host[]	= "rpki-validator.realmv6.org";
+	char tcp1_port[]	= "8282";
 
     struct tr_tcp_config tcp_config1 = {
 	tcp1_host,	//IP
@@ -31,6 +32,7 @@ int main(){
     tr_tcp_init(&tcp_config1, &tr_tcp1);
 
     //create another TCP transport socket
+    //this one requires a locally running rpki-validator
     struct tr_socket tr_tcp2;
 	char tcp2_host[]	= "localhost";
 	char tcp2_port[]	= "8282";
@@ -75,12 +77,33 @@ int main(){
     //wait till at least one rtr_mgr_group is fully synchronized with the server
     while(!rtr_mgr_conf_in_sync(conf))
         sleep(1);
-
+    
     //validate the BGP-Route 10.10.0.0/24, origin ASN: 12345
     struct lrtr_ip_addr pref;
     lrtr_ip_str_to_addr("10.10.0.0", &pref);
     enum pfxv_state result;
-    rtr_mgr_validate(conf, 12345, &pref, 24, &result);
+    const uint8_t mask = 24;
+    rtr_mgr_validate(conf, 12345, &pref, mask, &result);
+    
+    //output the result of the prefix validation above
+    //to showcase the returned states.
+    char buffer[INET_ADDRSTRLEN];
+    lrtr_ip_addr_to_str(&pref, buffer, sizeof(buffer));
+
+    printf("RESULT: The prefix %s/%i ", buffer, mask);
+    switch(result) {
+        case BGP_PFXV_STATE_VALID:
+            printf("is valid.\n");
+            break;
+        case BGP_PFXV_STATE_INVALID:
+            printf("is invalid.\n");
+            break;
+        case BGP_PFXV_STATE_NOT_FOUND:
+            printf("was not found.\n");
+            break;
+        default:
+            break;
+    }
 
     rtr_mgr_stop(conf);
     rtr_mgr_free(conf);


### PR DESCRIPTION
Also outputs the result of the checked prefix using printf.
Adds the hint that a local rpki-validator is required to open the second TCP transport socket. If the local validator is not present the program may be compiled, it will not run without errors though.