### PR TITLE
tests: add first unit test

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,6 +9,7 @@ coverage:
 
   ignore:
   - rtrlib/spki/hashtable/tommyds-1.8/.*
+  - tests/*
 
   status: {}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ before_install:
     - sudo apt-get -qq update
     - sudo apt-get -y install cppcheck doxygen libssh-dev
 
+install:
+    - wget https://cmocka.org/files/1.1/cmocka-1.1.0.tar.xz
+    - tar xvf cmocka-1.1.0.tar.xz && pushd cmocka-1.1.0
+    - mkdir build && pushd build
+    - cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug
+    - make
+    - sudo make install
+    - popd && popd
+
 script:
     - scripts/cppcheck.sh
     - scripts/check-coding-style.sh
@@ -14,7 +23,7 @@ script:
     - make
     - make test
     - make clean
-    - cmake -D CMAKE_BUILD_TYPE=Release -DENABLE_COVERAGE=On .
+    - cmake -D CMAKE_BUILD_TYPE=Release -DENABLE_COVERAGE=On -DUNIT_TESTING=On .
     - make
     - make test
     - make gcov

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,14 @@ if(DOXYGEN_FOUND)
 endif(DOXYGEN_FOUND)
 
 add_library(rtrlib SHARED ${RTRLIB_SRC})
-add_library(rtrlib_static STATIC ${RTRLIB_SRC})
 add_coverage(rtrlib)
-add_coverage(rtrlib_static)
 target_link_libraries(rtrlib ${RTRLIB_LINK})
-target_link_libraries(rtrlib_static ${RTRLIB_LINK})
+
+if(UNIT_TESTING)
+    add_library(rtrlib_static STATIC ${RTRLIB_SRC})
+    add_coverage(rtrlib_static)
+    target_link_libraries(rtrlib_static ${RTRLIB_LINK})
+endif(UNIT_TESTING)
 
 ADD_SUBDIRECTORY(tools)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,13 +58,17 @@ if(DOXYGEN_FOUND)
 endif(DOXYGEN_FOUND)
 
 add_library(rtrlib SHARED ${RTRLIB_SRC})
+add_library(rtrlib_static STATIC ${RTRLIB_SRC})
 add_coverage(rtrlib)
+add_coverage(rtrlib_static)
 target_link_libraries(rtrlib ${RTRLIB_LINK})
+target_link_libraries(rtrlib_static ${RTRLIB_LINK})
 
 ADD_SUBDIRECTORY(tools)
 
 ADD_SUBDIRECTORY(doxygen/examples)
 
+include(AddTest)
 ADD_SUBDIRECTORY(tests)
 ENABLE_TESTING()
 ADD_TEST(test_pfx tests/test_pfx)

--- a/README
+++ b/README
@@ -20,6 +20,7 @@ To build the RTRlib, the CMake build system must be installed.
 To establish an SSH connection between RTR-Client and RTR-Server, the
 libssh 0.6.x or higher library must also be installed.
 
+cmocka (optional) is required for unit tests
 Doxygen (optional) is required to create the HTML documentation.
 
 

--- a/cmake/modules/AddTest.cmake
+++ b/cmake/modules/AddTest.cmake
@@ -9,9 +9,7 @@ endfunction (ADD_RTR_TEST)
 
 
 function (ADD_RTR_UNIT_TEST _testName _testSource)
-    add_executable(${_testName} ${_testSource})
-    target_link_libraries(${_testName} ${ARGN})
-    add_test(${_testName} ${CMAKE_CURRENT_BINARY_DIR}/${_testName})
+    add_rtr_test(${_testName} ${_testSource} ${ARGN})
     add_coverage(${_testName})
 endfunction (ADD_RTR_UNIT_TEST)
 
@@ -24,7 +22,9 @@ function (WRAP_FUNCTIONS _testName)
     endforeach()
 
     get_target_property(temp ${_testName} COMPILE_FLAGS)
-    string(CONCAT linkopts ${temp} ${linkopts})
+    if (temp)
+        string(CONCAT linkopts ${temp} ${linkopts})
+    endif()
     set_target_properties(${_testName}
                       PROPERTIES
                       LINK_FLAGS ${linkopts})

--- a/cmake/modules/AddTest.cmake
+++ b/cmake/modules/AddTest.cmake
@@ -1,0 +1,31 @@
+enable_testing()
+include(CTest)
+
+function (ADD_RTR_TEST _testName _testSource)
+    add_executable(${_testName} ${_testSource})
+    target_link_libraries(${_testName} ${ARGN})
+    add_test(${_testName} ${CMAKE_CURRENT_BINARY_DIR}/${_testName})
+endfunction (ADD_RTR_TEST)
+
+
+function (ADD_RTR_UNIT_TEST _testName _testSource)
+    add_executable(${_testName} ${_testSource})
+    target_link_libraries(${_testName} ${ARGN})
+    add_test(${_testName} ${CMAKE_CURRENT_BINARY_DIR}/${_testName})
+    add_coverage(${_testName})
+endfunction (ADD_RTR_UNIT_TEST)
+
+
+function (WRAP_FUNCTIONS _testName)
+    set(template " -Wl,--wrap=")
+    set(linkopts "")
+    foreach(f ${ARGN})
+        string(CONCAT linkopts ${linkopts} ${template} ${f})
+    endforeach()
+
+    get_target_property(temp ${_testName} COMPILE_FLAGS)
+    string(CONCAT linkopts ${temp} ${linkopts})
+    set_target_properties(${_testName}
+                      PROPERTIES
+                      LINK_FLAGS ${linkopts})
+endfunction (WRAP_FUNCTIONS)

--- a/rtrlib/rtr/packets.h
+++ b/rtrlib/rtr/packets.h
@@ -19,7 +19,7 @@ static const unsigned int RTR_MAX_PDU_LEN = 3248; //error pdu: header(8) + len(4
 static const unsigned int RTR_RECV_TIMEOUT = 60;
 static const unsigned int RTR_SEND_TIMEOUT = 60;
 
-void rtr_change_socket_state(struct rtr_socket *rtr_socket, const enum rtr_socket_state new_state);
+void __attribute__((weak)) rtr_change_socket_state(struct rtr_socket *rtr_socket, const enum rtr_socket_state new_state);
 int rtr_sync(struct rtr_socket *rtr_socket);
 int rtr_wait_for_sync(struct rtr_socket *rtr_socket);
 int rtr_send_serial_query(struct rtr_socket *rtr_socket);

--- a/scripts/check-coding-files.txt
+++ b/scripts/check-coding-files.txt
@@ -10,5 +10,6 @@ tests/test_lpfst.c
 tests/test_pfx.c
 tests/test_pfx_locks.c
 tests/unittests/test_packets_static.c
+tests/unittests/test_packets.c
 tools/cli-validator.c
 tools/rtrclient.c

--- a/scripts/check-coding-files.txt
+++ b/scripts/check-coding-files.txt
@@ -9,5 +9,6 @@ tests/test_live_validation.c
 tests/test_lpfst.c
 tests/test_pfx.c
 tests/test_pfx_locks.c
+tests/unittests/test_packets_static.c
 tools/cli-validator.c
 tools/rtrclient.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,3 +14,10 @@ add_executable(test_live_validation test_live_validation.c)
 target_link_libraries(test_live_validation rtrlib)
 add_executable(test_ipaddr test_ipaddr.c)
 target_link_libraries(test_ipaddr rtrlib)
+
+
+if(UNIT_TESTING)
+    find_package(CMocka REQUIRED)
+    add_subdirectory(unittests)
+endif(UNIT_TESTING)
+

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -4,4 +4,4 @@ add_rtr_unit_test(test_packets_static test_packets_static.c rtrlib_static cmocka
 wrap_functions(test_packets_static lrtr_get_monotonic_time)
 
 add_rtr_unit_test(test_packets test_packets.c rtrlib_static cmocka)
-wrap_functions(test_packets rtr_send_pdu rtr_change_socket_state tr_send_all)
+wrap_functions(test_packets rtr_change_socket_state tr_send_all)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+
+add_rtr_unit_test(test_packets_static test_packets_static.c rtrlib_static cmocka)
+wrap_functions(test_packets_static lrtr_get_monotonic_time)
+
+add_rtr_unit_test(test_packets test_packets.c rtrlib_static cmocka)
+wrap_functions(test_packets rtr_send_pdu rtr_change_socket_state tr_send_all)

--- a/tests/unittests/rtrlib_unittests.h
+++ b/tests/unittests/rtrlib_unittests.h
@@ -1,0 +1,16 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website; http://rtrlib.realmv6.org/
+ */
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#define UNUSED(x) (void)(x)

--- a/tests/unittests/test_packets.c
+++ b/tests/unittests/test_packets.c
@@ -1,0 +1,48 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "rtrlib/rtr/packets.h"
+
+void rtr_change_socket_state(struct rtr_socket *rtr_socket, const enum rtr_socket_state new_state)
+{
+	;
+}
+
+
+int __wrap_tr_send_all(const struct tr_socket *socket,
+                       const void *pdu, const size_t len,
+                       const time_t timeout)
+{
+	return (int) mock();
+}
+
+
+void test_rtr_send_reset_query(void **state)
+{
+	struct rtr_socket socket;
+
+	will_return(__wrap_tr_send_all, 0);
+	assert_int_equal(rtr_send_reset_query(&socket), RTR_ERROR);
+
+	will_return(__wrap_tr_send_all, 10);
+	assert_int_equal(rtr_send_reset_query(&socket), RTR_SUCCESS);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_rtr_send_reset_query),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unittests/test_packets.c
+++ b/tests/unittests/test_packets.c
@@ -7,29 +7,33 @@
  * Website: http://rtrlib.realmv6.org/
  */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
-#include <cmocka.h>
+#include "rtrlib_unittests.h"
 #include "rtrlib/rtr/packets.h"
+#include "test_packets.h"
 
 int __wrap_tr_send_all(const struct tr_socket *socket,
 		       const void *pdu, const size_t len,
 		       const time_t timeout)
 {
+	UNUSED(socket);
+	UNUSED(pdu);
+	UNUSED(len);
+	UNUSED(timeout);
 	return (int)mock();
 }
 
 void __wrap_rtr_change_socket_state(struct rtr_socket *rtr_socket,
 				    const enum rtr_socket_state new_state)
 {
-	;
+	UNUSED(rtr_socket);
+	UNUSED(new_state);
 }
 
-void test_rtr_send_reset_query(void)
+static void test_rtr_send_reset_query(void **state)
 {
 	struct rtr_socket socket;
+
+	UNUSED(state);
 
 	socket.connection_state_fp = NULL;
 
@@ -40,9 +44,11 @@ void test_rtr_send_reset_query(void)
 	assert_int_equal(rtr_send_reset_query(&socket), RTR_SUCCESS);
 }
 
-void test_rtr_change_socket_state(void)
+static void test_rtr_change_socket_state(void **state)
 {
 	struct rtr_socket socket;
+
+	UNUSED(state);
 
 	socket.connection_state_fp = NULL;
 	socket.state = RTR_RESET;

--- a/tests/unittests/test_packets.c
+++ b/tests/unittests/test_packets.c
@@ -14,23 +14,24 @@
 #include <cmocka.h>
 #include "rtrlib/rtr/packets.h"
 
-void rtr_change_socket_state(struct rtr_socket *rtr_socket, const enum rtr_socket_state new_state)
+int __wrap_tr_send_all(const struct tr_socket *socket,
+		       const void *pdu, const size_t len,
+		       const time_t timeout)
+{
+	return (int)mock();
+}
+
+void __wrap_rtr_change_socket_state(struct rtr_socket *rtr_socket,
+				    const enum rtr_socket_state new_state)
 {
 	;
 }
 
-
-int __wrap_tr_send_all(const struct tr_socket *socket,
-                       const void *pdu, const size_t len,
-                       const time_t timeout)
-{
-	return (int) mock();
-}
-
-
-void test_rtr_send_reset_query(void **state)
+void test_rtr_send_reset_query(void)
 {
 	struct rtr_socket socket;
+
+	socket.connection_state_fp = NULL;
 
 	will_return(__wrap_tr_send_all, 0);
 	assert_int_equal(rtr_send_reset_query(&socket), RTR_ERROR);
@@ -39,10 +40,31 @@ void test_rtr_send_reset_query(void **state)
 	assert_int_equal(rtr_send_reset_query(&socket), RTR_SUCCESS);
 }
 
+void test_rtr_change_socket_state(void)
+{
+	struct rtr_socket socket;
+
+	socket.connection_state_fp = NULL;
+	socket.state = RTR_RESET;
+
+	__real_rtr_change_socket_state(&socket, RTR_SYNC);
+	assert_int_equal(socket.state, RTR_SYNC);
+
+	__real_rtr_change_socket_state(&socket, RTR_SYNC);
+	assert_int_equal(socket.state, RTR_SYNC);
+
+	__real_rtr_change_socket_state(&socket, RTR_SHUTDOWN);
+	assert_int_equal(socket.state, RTR_SHUTDOWN);
+
+	__real_rtr_change_socket_state(&socket, RTR_ESTABLISHED);
+	assert_int_equal(socket.state, RTR_SHUTDOWN);
+}
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_rtr_send_reset_query),
+		cmocka_unit_test(test_rtr_change_socket_state)
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unittests/test_packets.h
+++ b/tests/unittests/test_packets.h
@@ -1,0 +1,16 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website; http://rtrlib.realmv6.org/
+ */
+
+void __real_rtr_change_socket_state(struct rtr_socket *rtr_socket,
+				    const enum rtr_socket_state new_state);
+int __wrap_tr_send_all(const struct tr_socket *socket,
+		       const void *pdu, const size_t len,
+		       const time_t timeout);
+void __wrap_rtr_change_socket_state(struct rtr_socket *rtr_socket,
+				    const enum rtr_socket_state new_state);

--- a/tests/unittests/test_packets_static.c
+++ b/tests/unittests/test_packets_static.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "rtrlib/rtr/packets.c"
+
+int __wrap_lrtr_get_monotonic_time(time_t *seconds)
+{
+	return mock_type(int);
+}
+
+void test_set_last_update(void **state)
+{
+	struct rtr_socket socket;
+
+	socket.connection_state_fp = NULL;
+
+	will_return(__wrap_lrtr_get_monotonic_time, RTR_ERROR);
+	assert_int_equal(rtr_set_last_update(&socket), RTR_ERROR);
+
+	will_return(__wrap_lrtr_get_monotonic_time, RTR_SUCCESS);
+	assert_int_equal(rtr_set_last_update(&socket), RTR_SUCCESS);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_set_last_update),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unittests/test_packets_static.c
+++ b/tests/unittests/test_packets_static.c
@@ -4,7 +4,7 @@
  * This file is subject to the terms and conditions of the MIT license.
  * See the file LICENSE in the top level directory for more details.
  *
- * Website: http://rtrlib.realmv6.org/
+ * Website; http://rtrlib.realmv6.org/
  */
 
 #include <stdlib.h>
@@ -19,7 +19,7 @@ int __wrap_lrtr_get_monotonic_time(time_t *seconds)
 	return mock_type(int);
 }
 
-void test_set_last_update(void **state)
+void test_set_last_update(void)
 {
 	struct rtr_socket socket;
 
@@ -32,10 +32,193 @@ void test_set_last_update(void **state)
 	assert_int_equal(rtr_set_last_update(&socket), RTR_SUCCESS);
 }
 
+void test_rtr_get_pdu_type(void)
+{
+	struct pdu_header pdu;
+
+	pdu.type = SERIAL_NOTIFY;
+	assert_int_equal(rtr_get_pdu_type(&pdu), SERIAL_NOTIFY);
+
+	pdu.type = SERIAL_QUERY;
+	assert_int_equal(rtr_get_pdu_type(&pdu), SERIAL_QUERY);
+
+	pdu.type = RESET_QUERY;
+	assert_int_equal(rtr_get_pdu_type(&pdu), RESET_QUERY);
+
+	pdu.type = CACHE_RESPONSE;
+	assert_int_equal(rtr_get_pdu_type(&pdu), CACHE_RESPONSE);
+
+	pdu.type = RESERVED;
+	assert_int_equal(rtr_get_pdu_type(&pdu), RESERVED);
+
+	pdu.type = IPV6_PREFIX;
+	assert_int_equal(rtr_get_pdu_type(&pdu), IPV6_PREFIX);
+
+	pdu.type = EOD;
+	assert_int_equal(rtr_get_pdu_type(&pdu), EOD);
+
+	pdu.type = CACHE_RESET;
+	assert_int_equal(rtr_get_pdu_type(&pdu), CACHE_RESET);
+
+	pdu.type = ROUTER_KEY;
+	assert_int_equal(rtr_get_pdu_type(&pdu), ROUTER_KEY);
+
+	pdu.type = ERROR;
+	assert_int_equal(rtr_get_pdu_type(&pdu), ERROR);
+}
+
+void test_pdu_to_network_byte_order(void)
+{
+	struct pdu_serial_query pdu;
+
+	pdu.ver = 0;
+	pdu.type = SERIAL_QUERY;
+	pdu.session_id = 0x32A5;
+	pdu.len = 0xC;
+	pdu.sn = 0xCC56E9BB;
+
+	rtr_pdu_to_network_byte_order(&pdu);
+
+	assert_int_equal(pdu.ver, 0);
+	assert_int_equal(pdu.type, SERIAL_QUERY);
+	assert_int_equal(pdu.session_id, 0xA532);
+	assert_int_equal(pdu.len, 0x0C000000);
+	assert_int_equal(pdu.sn, 0xBBE956CC);
+}
+
+void test_pdu_to_host_byte_order(void)
+{
+	struct pdu_serial_notify pdu_serial;
+	struct pdu_end_of_data_v1 pdu_eod;
+
+	pdu_serial.ver = 1;
+	pdu_serial.type = SERIAL_NOTIFY;
+	pdu_serial.session_id = 0xDDFF;
+	pdu_serial.len = 0xC;
+	pdu_serial.sn = 0xDF;
+
+	rtr_pdu_footer_to_host_byte_order(&pdu_serial);
+	rtr_pdu_header_to_host_byte_order(&pdu_serial);
+
+	assert_int_equal(pdu_serial.ver, 1);
+	assert_int_equal(pdu_serial.type, SERIAL_NOTIFY);
+	assert_int_equal(pdu_serial.len, 0xC000000);
+	assert_int_equal(pdu_serial.sn, 0xDF000000);
+
+	pdu_eod.ver = 1;
+	pdu_eod.type = EOD;
+	pdu_eod.session_id = 0xFDDF;
+	pdu_eod.len = 0x18;
+	pdu_eod.sn = 0xFEDCBA;
+	pdu_eod.refresh_interval = 0xAF;
+	pdu_eod.retry_interval = 0xDC;
+	pdu_eod.expire_interval = 0xCCF;
+
+	rtr_pdu_header_to_host_byte_order(&pdu_eod);
+	rtr_pdu_footer_to_host_byte_order(&pdu_eod);
+
+	assert_int_equal(pdu_eod.ver, 1);
+	assert_int_equal(pdu_eod.type, EOD);
+	assert_int_equal(pdu_eod.session_id, 0xDFFD);
+	assert_int_equal(pdu_eod.len, 0x18000000);
+	assert_int_equal(pdu_eod.sn, 0xBADCFE00);
+	assert_int_equal(pdu_eod.refresh_interval, 0xAF000000);
+	assert_int_equal(pdu_eod.retry_interval, 0xDC000000);
+	assert_int_equal(pdu_eod.expire_interval, 0xCF0C0000);
+}
+
+void test_rtr_pdu_check_size(void)
+{
+	struct pdu_header pdu;
+	struct pdu_error *error = malloc(30);
+
+	memset(error, 0, 30);
+
+	pdu.type = SERIAL_NOTIFY;
+	pdu.len = 20;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 12;
+	assert_true(rtr_pdu_check_size(&pdu));
+
+	pdu.type = CACHE_RESPONSE;
+	pdu.len = 5;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 8;
+	assert_true(rtr_pdu_check_size(&pdu));
+
+	pdu.type = IPV4_PREFIX;
+	pdu.len = 25;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 20;
+	assert_true(rtr_pdu_check_size(&pdu));
+
+	pdu.type = IPV6_PREFIX;
+	pdu.len = 15;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 32;
+	assert_true(rtr_pdu_check_size(&pdu));
+
+	pdu.type = CACHE_RESET;
+	pdu.len = 10;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 8;
+	assert_true(rtr_pdu_check_size(&pdu));
+
+	pdu.type = SERIAL_QUERY;
+	pdu.len = 14;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 12;
+	assert_true(rtr_pdu_check_size(&pdu));
+
+	pdu.type = RESET_QUERY;
+	pdu.len = 10;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 8;
+	assert_true(rtr_pdu_check_size(&pdu));
+
+	pdu.type = RESERVED;
+	pdu.len = 0;
+	assert_false(rtr_pdu_check_size(&pdu));
+
+	pdu.type = EOD;
+	pdu.ver = RTR_PROTOCOL_VERSION_1;
+	pdu.len = 12;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 24;
+	assert_true(rtr_pdu_check_size(&pdu));
+	pdu.ver = RTR_PROTOCOL_VERSION_0;
+	pdu.len = 18;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 12;
+	assert_true(rtr_pdu_check_size(&pdu));
+
+	/* Test error pdu size checks */
+	error->type = ERROR;
+	error->len = 14;
+	error->len_enc_pdu = 0;
+	assert_false(rtr_pdu_check_size(error));
+	error->len = 20;
+	error->len_enc_pdu = 0x8000000;
+	assert_false(rtr_pdu_check_size(error));
+	error->len = 24;
+	error->rest[11] = 0xA;
+	assert_false(rtr_pdu_check_size(error));
+
+	/* test error pdu error string termination test */
+	error->len = 25;
+	error->rest[11] = 0x1;
+	error->rest[12] = 0x20;
+	assert_false(rtr_pdu_check_size(error));
+}
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_set_last_update),
+		cmocka_unit_test(test_rtr_get_pdu_type),
+		cmocka_unit_test(test_pdu_to_network_byte_order),
+		cmocka_unit_test(test_pdu_to_host_byte_order),
+		cmocka_unit_test(test_rtr_pdu_check_size),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unittests/test_packets_static.c
+++ b/tests/unittests/test_packets_static.c
@@ -7,21 +7,21 @@
  * Website; http://rtrlib.realmv6.org/
  */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
-#include <cmocka.h>
+#include "rtrlib_unittests.h"
 #include "rtrlib/rtr/packets.c"
+#include "test_packets_static.h"
 
 int __wrap_lrtr_get_monotonic_time(time_t *seconds)
 {
+	UNUSED(seconds);
 	return mock_type(int);
 }
 
-void test_set_last_update(void)
+static void test_set_last_update(void **state)
 {
 	struct rtr_socket socket;
+
+	UNUSED(state);
 
 	socket.connection_state_fp = NULL;
 
@@ -32,9 +32,11 @@ void test_set_last_update(void)
 	assert_int_equal(rtr_set_last_update(&socket), RTR_SUCCESS);
 }
 
-void test_rtr_get_pdu_type(void)
+static void test_rtr_get_pdu_type(void **state)
 {
 	struct pdu_header pdu;
+
+	UNUSED(state);
 
 	pdu.type = SERIAL_NOTIFY;
 	assert_int_equal(rtr_get_pdu_type(&pdu), SERIAL_NOTIFY);
@@ -67,9 +69,11 @@ void test_rtr_get_pdu_type(void)
 	assert_int_equal(rtr_get_pdu_type(&pdu), ERROR);
 }
 
-void test_pdu_to_network_byte_order(void)
+static void test_pdu_to_network_byte_order(void **state)
 {
 	struct pdu_serial_query pdu;
+
+	UNUSED(state);
 
 	pdu.ver = 0;
 	pdu.type = SERIAL_QUERY;
@@ -86,10 +90,12 @@ void test_pdu_to_network_byte_order(void)
 	assert_int_equal(pdu.sn, 0xBBE956CC);
 }
 
-void test_pdu_to_host_byte_order(void)
+static void test_pdu_to_host_byte_order(void **state)
 {
 	struct pdu_serial_notify pdu_serial;
 	struct pdu_end_of_data_v1 pdu_eod;
+
+	UNUSED(state);
 
 	pdu_serial.ver = 1;
 	pdu_serial.type = SERIAL_NOTIFY;
@@ -127,10 +133,12 @@ void test_pdu_to_host_byte_order(void)
 	assert_int_equal(pdu_eod.expire_interval, 0xCF0C0000);
 }
 
-void test_rtr_pdu_check_size(void)
+static void test_rtr_pdu_check_size(void **state)
 {
 	struct pdu_header pdu;
 	struct pdu_error *error = malloc(30);
+
+	UNUSED(state);
 
 	memset(error, 0, 30);
 
@@ -196,19 +204,19 @@ void test_rtr_pdu_check_size(void)
 	error->type = ERROR;
 	error->len = 14;
 	error->len_enc_pdu = 0;
-	assert_false(rtr_pdu_check_size(error));
+	assert_false(rtr_pdu_check_size((struct pdu_header *)error));
 	error->len = 20;
 	error->len_enc_pdu = 0x8000000;
-	assert_false(rtr_pdu_check_size(error));
+	assert_false(rtr_pdu_check_size((struct pdu_header *)error));
 	error->len = 24;
 	error->rest[11] = 0xA;
-	assert_false(rtr_pdu_check_size(error));
+	assert_false(rtr_pdu_check_size((struct pdu_header *)error));
 
 	/* test error pdu error string termination test */
 	error->len = 25;
 	error->rest[11] = 0x1;
 	error->rest[12] = 0x20;
-	assert_false(rtr_pdu_check_size(error));
+	assert_false(rtr_pdu_check_size((struct pdu_header *)error));
 }
 
 int main(void)

--- a/tests/unittests/test_packets_static.h
+++ b/tests/unittests/test_packets_static.h
@@ -1,0 +1,10 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website; http://rtrlib.realmv6.org/
+ */
+
+int __wrap_lrtr_get_monotonic_time(time_t *seconds);


### PR DESCRIPTION
this commit adds the first basic unit test to show what is possible
with cmocka. Additionally the build system is adjusted to ease adding
tests.

Fixes #93 
