### PR TITLE
ci: fail on style issues, check level issues are ignored

### DIFF
--- a/scripts/check-coding-style.sh
+++ b/scripts/check-coding-style.sh
@@ -15,6 +15,7 @@ READLINK=$(which greadlink)
 }
 SCRIPT_DIR=$(dirname "$($READLINK -f "$0")")
 SCRIPT_FILE="$SCRIPT_DIR/check-coding-files.txt"
+EXIT_CODE=0
 if [ -z "$1" ] ; then
 	if [ -f "$SCRIPT_FILE" ]; then
 		CHECKSOURCE=$(cat "$SCRIPT_FILE")
@@ -30,4 +31,10 @@ for i in $CHECKSOURCE; do
 	echo "> check coding style of $i ..."
 	$SCRIPT_DIR/checkpatch.pl -f --strict --no-tree --terse --show-types \
 		--ignore PREFER_KERNEL_TYPES $i
+
+	if [ $? -ne "0" ]; then
+		EXIT_CODE=1
+	fi
 done
+
+exit $EXIT_CODE

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -1735,6 +1735,10 @@ sub report {
 
 	push(our @report, $output);
 
+	if ($level eq 'CHECK') {
+		return 0;
+	}
+
 	return 1;
 }
 


### PR DESCRIPTION
checkpatch does not differentiate between the check levels in the return code, as soon as one fails it returns with 1.
I patched it to ignore "check" level issues regarding the return code, they are still printed, to prevent ci fails over stuff that is outside of our control.