### PR TITLE
rtrlib/rtr: add range checks for interval values in packets.c

### DIFF
--- a/rtrlib/rtr/packets.h
+++ b/rtrlib/rtr/packets.h
@@ -24,5 +24,13 @@ int rtr_sync(struct rtr_socket *rtr_socket);
 int rtr_wait_for_sync(struct rtr_socket *rtr_socket);
 int rtr_send_serial_query(struct rtr_socket *rtr_socket);
 int rtr_send_reset_query(struct rtr_socket *rtr_socket);
-
+int rtr_check_interval_range(uint32_t interval, uint32_t minimum,
+			     uint32_t maximum);
+void apply_interval_value(struct rtr_socket *rtr_socket,
+			  uint32_t interval,
+			  enum interval_type type);
+int rtr_check_interval_option(struct rtr_socket *rtr_socket,
+			      int interval_mode,
+			      uint32_t interval,
+			      enum interval_type type);
 #endif

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -59,29 +59,24 @@ int rtr_init(struct rtr_socket *rtr_socket,
               const unsigned int refresh_interval,
               const unsigned int expire_interval,
               const unsigned int retry_interval,
+	      enum interval_mode iv_mode,
               rtr_connection_state_fp fp, void *fp_param_config,
 	      void *fp_param_group)
 {
     if(tr != NULL)
         rtr_socket->tr_socket = tr;
 
-    if(refresh_interval > 86400 || refresh_interval < 1) {
+    // Check if one of the intervals is not in range of the predefined values.
+    if(rtr_check_interval_range(refresh_interval, RTR_REFRESH_MIN, RTR_REFRESH_MAX) != INSIDE_INTERVAL_RANGE ||
+       rtr_check_interval_range(expire_interval, RTR_EXPIRATION_MIN, RTR_EXPIRATION_MAX) != INSIDE_INTERVAL_RANGE ||
+       rtr_check_interval_range(retry_interval, RTR_RETRY_MIN, RTR_RETRY_MAX) != INSIDE_INTERVAL_RANGE) {
+        RTR_DBG("Interval value not in range.");
         return RTR_INVALID_PARAM;
-    } else {
-        rtr_socket->refresh_interval = refresh_interval;
     }
-
-    if ((expire_interval < 600) || (expire_interval > 172800)) {
-        return RTR_INVALID_PARAM;
-    } else {
-        rtr_socket->expire_interval = expire_interval;
-    }
-
-    if ((retry_interval > 7200) || (retry_interval < 1)) {
-        return RTR_INVALID_PARAM;
-    } else {
-        rtr_socket->retry_interval = retry_interval;
-    }
+    rtr_socket->refresh_interval = refresh_interval;
+    rtr_socket->expire_interval = expire_interval;
+    rtr_socket->retry_interval = retry_interval;
+    rtr_socket->iv_mode = iv_mode;
 
     rtr_socket->state = RTR_CLOSED;
     rtr_socket->request_session_id = true;

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -270,6 +270,13 @@ void rtr_mgr_for_each_ipv4_record(struct rtr_mgr_config *config,
 void rtr_mgr_for_each_ipv6_record(struct rtr_mgr_config *config,
 				  pfx_for_each_fp fp,
 				  void *data);
+/**
+ * @brief Set the interval option to the desired one. It's either IGNORE_ANY,
+ * APPLY_ANY, DEFAULT_MIN_MAX or IGNORE_ON_FAILURE.
+ * @param[in] rtr_socket The target socket.
+ * @param[in] option The new interval option that should be applied.
+ */
+void set_interval_mode(struct rtr_socket *rtr_socket, int option);
 
 /**
  * @brief Returns the first, thus active group.
@@ -282,5 +289,11 @@ int rtr_mgr_for_each_group(struct rtr_mgr_config *config,
 			   void (*fp)(const struct rtr_mgr_group *group,
 				      void *data),
 			   void *data);
+/**
+ * @brief Get the current interval mode.
+ * @param[in] rtr_socket The target socket.
+ * @return The value of the interval_option variable.
+ */
+int get_interval_mode(struct rtr_socket *rtr_socket);
 #endif
 /* @} */

--- a/tests/unittests/test_packets_static.c
+++ b/tests/unittests/test_packets_static.c
@@ -353,6 +353,144 @@ static void test_rtr_send_error_pdu(void **state)
 	assert_int_equal(ret, RTR_ERROR);
 }
 
+static void test_rtr_pdu_check_interval(void **state)
+{
+	UNUSED(state);
+
+	struct rtr_socket *rtr_socket = malloc(1024);
+	struct pdu_end_of_data_v1 *pdu_eod = malloc(1024);
+
+	int retval;
+
+	rtr_socket->refresh_interval = 0;
+	rtr_socket->retry_interval = 0;
+	rtr_socket->expire_interval = 0;
+
+	pdu_eod->refresh_interval = 1;
+	pdu_eod->retry_interval = 2;
+	pdu_eod->expire_interval = 601;
+
+	/* test appliance of interval values to the rtr_socket */
+	apply_interval_value(rtr_socket, pdu_eod->refresh_interval, REFRESH);
+	assert_int_equal(rtr_socket->refresh_interval,
+			 pdu_eod->refresh_interval);
+
+	apply_interval_value(rtr_socket, pdu_eod->retry_interval, RETRY);
+	assert_int_equal(rtr_socket->retry_interval, pdu_eod->retry_interval);
+
+	apply_interval_value(rtr_socket, pdu_eod->expire_interval, EXPIRATION);
+	assert_int_equal(rtr_socket->expire_interval, pdu_eod->expire_interval);
+
+	/* test checks that determine if value is inside range */
+	retval = rtr_check_interval_range(pdu_eod->refresh_interval,
+					  RTR_REFRESH_MIN, RTR_REFRESH_MAX);
+	assert_int_equal(retval, INSIDE_INTERVAL_RANGE);
+
+	retval = rtr_check_interval_range(pdu_eod->retry_interval,
+					  RTR_RETRY_MIN, RTR_RETRY_MAX);
+	assert_int_equal(retval, INSIDE_INTERVAL_RANGE);
+
+	retval = rtr_check_interval_range(pdu_eod->expire_interval,
+					  RTR_EXPIRATION_MIN,
+					  RTR_EXPIRATION_MAX);
+	assert_int_equal(retval, INSIDE_INTERVAL_RANGE);
+
+	/* test checks that determine if value is below range */
+	pdu_eod->refresh_interval = RTR_REFRESH_MIN - 1;
+	pdu_eod->retry_interval = RTR_RETRY_MIN - 1;
+	pdu_eod->expire_interval = RTR_EXPIRATION_MIN - 1;
+
+	retval = rtr_check_interval_range(pdu_eod->refresh_interval,
+					  RTR_REFRESH_MIN, RTR_REFRESH_MAX);
+	assert_int_equal(retval, BELOW_INTERVAL_RANGE);
+
+	retval = rtr_check_interval_range(pdu_eod->retry_interval,
+					  RTR_RETRY_MIN, RTR_RETRY_MAX);
+	assert_int_equal(retval, BELOW_INTERVAL_RANGE);
+
+	retval = rtr_check_interval_range(pdu_eod->expire_interval,
+					  RTR_EXPIRATION_MIN,
+					  RTR_EXPIRATION_MAX);
+	assert_int_equal(retval, BELOW_INTERVAL_RANGE);
+
+	/* test checks that determine if value is above range */
+	pdu_eod->refresh_interval = RTR_REFRESH_MAX + 1;
+	pdu_eod->retry_interval = RTR_RETRY_MAX + 1;
+	pdu_eod->expire_interval = RTR_EXPIRATION_MAX + 1;
+
+	retval = rtr_check_interval_range(pdu_eod->refresh_interval,
+					  RTR_REFRESH_MIN, RTR_REFRESH_MAX);
+	assert_int_equal(retval, ABOVE_INTERVAL_RANGE);
+
+	retval = rtr_check_interval_range(pdu_eod->retry_interval,
+					  RTR_RETRY_MIN, RTR_RETRY_MAX);
+	assert_int_equal(retval, ABOVE_INTERVAL_RANGE);
+
+	retval = rtr_check_interval_range(pdu_eod->expire_interval,
+					  RTR_EXPIRATION_MIN,
+					  RTR_EXPIRATION_MAX);
+	assert_int_equal(retval, ABOVE_INTERVAL_RANGE);
+
+	/* test the different interval options the user can choose */
+	rtr_socket->refresh_interval = 0;
+	pdu_eod->refresh_interval = 42;
+	retval = rtr_check_interval_option(rtr_socket, ACCEPT_ANY,
+					   pdu_eod->refresh_interval, REFRESH);
+	assert_int_equal(retval, RTR_SUCCESS);
+	assert_int_equal(rtr_socket->refresh_interval,
+			 pdu_eod->refresh_interval);
+
+	rtr_socket->refresh_interval = 0;
+	pdu_eod->refresh_interval = RTR_REFRESH_MAX + 1;
+	retval = rtr_check_interval_option(rtr_socket, DEFAULT_MIN_MAX,
+					   pdu_eod->refresh_interval, REFRESH);
+	assert_int_equal(retval, RTR_SUCCESS);
+	assert_int_equal(rtr_socket->refresh_interval, RTR_REFRESH_MAX);
+
+	rtr_socket->refresh_interval = 0;
+	pdu_eod->refresh_interval = RTR_REFRESH_MIN - 1;
+	retval = rtr_check_interval_option(rtr_socket, DEFAULT_MIN_MAX,
+					   pdu_eod->refresh_interval, REFRESH);
+	assert_int_equal(retval, RTR_SUCCESS);
+	assert_int_equal(rtr_socket->refresh_interval, RTR_REFRESH_MIN);
+
+	rtr_socket->refresh_interval = 42;
+	pdu_eod->refresh_interval = RTR_REFRESH_MIN - 1;
+	retval = rtr_check_interval_option(rtr_socket, IGNORE_ON_FAILURE,
+					   pdu_eod->refresh_interval, REFRESH);
+	assert_int_equal(retval, RTR_SUCCESS);
+	assert_int_equal(rtr_socket->refresh_interval, 42);
+
+	rtr_socket->refresh_interval = 0;
+	pdu_eod->refresh_interval = RTR_REFRESH_MAX + 1;
+	retval = rtr_check_interval_option(rtr_socket, ACCEPT_ANY,
+					   pdu_eod->refresh_interval, REFRESH);
+	assert_int_equal(retval, RTR_SUCCESS);
+	assert_int_equal(rtr_socket->refresh_interval, RTR_REFRESH_MAX + 1);
+}
+
+static void test_set_interval_option(void **state)
+{
+	UNUSED(state);
+
+	struct rtr_socket *rtr_socket = malloc(1024);
+
+	set_interval_mode(rtr_socket, IGNORE_ANY);
+	assert_int_equal(get_interval_mode(rtr_socket), IGNORE_ANY);
+
+	set_interval_mode(rtr_socket, ACCEPT_ANY);
+	assert_int_equal(get_interval_mode(rtr_socket), ACCEPT_ANY);
+
+	set_interval_mode(rtr_socket, DEFAULT_MIN_MAX);
+	assert_int_equal(get_interval_mode(rtr_socket), DEFAULT_MIN_MAX);
+
+	set_interval_mode(rtr_socket, IGNORE_ON_FAILURE);
+	assert_int_equal(get_interval_mode(rtr_socket), IGNORE_ON_FAILURE);
+
+	set_interval_mode(rtr_socket, 4);
+	assert(get_interval_mode(rtr_socket) != 4);
+}
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
@@ -362,6 +500,8 @@ int main(void)
 		cmocka_unit_test(test_pdu_to_host_byte_order),
 		cmocka_unit_test(test_rtr_pdu_check_size),
 		cmocka_unit_test(test_rtr_send_error_pdu),
+		cmocka_unit_test(test_rtr_pdu_check_interval),
+		cmocka_unit_test(test_set_interval_option),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Closes issue #81
Uses same if-statements used in rtr.c
There still are return values for failed checks needed, suggestions are welcome.
