### PR TITLE
Add 'trie' data structure as alternative to lpfst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ project(rtrlib C)
 
 cmake_minimum_required(VERSION 2.6)
 
+#set(RTRLIB_USE_LPFST 1)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=gnu99 -fstack-protector-all")
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
@@ -24,7 +25,7 @@ endif(NOT APPLE)
 include(UseMultiArch) # needed for debian packaging
 
 set(RTRLIB_SRC rtrlib/rtr_mgr.c rtrlib/lib/utils.c rtrlib/lib/ip.c rtrlib/lib/ipv4.c rtrlib/lib/ipv6.c rtrlib/lib/log.c
-    rtrlib/pfx/lpfst/lpfst.c rtrlib/pfx/lpfst/lpfst-pfx.c rtrlib/transport/transport.c
+    rtrlib/pfx/trie/trie.c rtrlib/pfx/trie/trie-pfx.c rtrlib/transport/transport.c
     rtrlib/transport/tcp/tcp_transport.c rtrlib/rtr/rtr.c rtrlib/rtr/packets.c rtrlib/spki/hashtable/ht-spkitable.c rtrlib/spki/hashtable/tommyds-1.8/tommy.c)
 set(RTRLIB_LINK ${RT_LIB} ${CMAKE_THREAD_LIBS_INIT})
 
@@ -75,7 +76,11 @@ include(AddTest)
 ADD_SUBDIRECTORY(tests)
 ENABLE_TESTING()
 ADD_TEST(test_pfx tests/test_pfx)
-ADD_TEST(test_lpfst tests/test_lpfst)
+if(RTRLIB_USE_LPFST)
+    ADD_TEST(test_lpfst tests/test_lpfst)
+else()
+    ADD_TEST(test_trie tests/test_trie)
+endif(RTRLIB_USE_LPFST)
 #ADD_TEST(test_pfx_locks tests/test_pfx_locks)
 
 ADD_TEST(test_ht_spkitable tests/test_ht_spkitable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,16 @@ if(NOT APPLE)
 endif(NOT APPLE)
 include(UseMultiArch) # needed for debian packaging
 
-set(RTRLIB_SRC rtrlib/rtr_mgr.c rtrlib/lib/utils.c rtrlib/lib/ip.c rtrlib/lib/ipv4.c rtrlib/lib/ipv6.c rtrlib/lib/log.c
-    rtrlib/pfx/trie/trie.c rtrlib/pfx/trie/trie-pfx.c rtrlib/transport/transport.c
-    rtrlib/transport/tcp/tcp_transport.c rtrlib/rtr/rtr.c rtrlib/rtr/packets.c rtrlib/spki/hashtable/ht-spkitable.c rtrlib/spki/hashtable/tommyds-1.8/tommy.c)
+if(RTRLIB_USE_LPFST)
+	set(RTRLIB_SRC rtrlib/rtr_mgr.c rtrlib/lib/utils.c rtrlib/lib/ip.c rtrlib/lib/ipv4.c rtrlib/lib/ipv6.c rtrlib/lib/log.c
+    	rtrlib/pfx/lpfst/lpfst.c rtrlib/pfx/lpfst/lpfst-pfx.c rtrlib/transport/transport.c
+    	rtrlib/transport/tcp/tcp_transport.c rtrlib/rtr/rtr.c rtrlib/rtr/packets.c rtrlib/spki/hashtable/ht-spkitable.c rtrlib/spki/hashtable/tommyds-1.8/tommy.c)
+else()
+	set(RTRLIB_SRC rtrlib/rtr_mgr.c rtrlib/lib/utils.c rtrlib/lib/ip.c rtrlib/lib/ipv4.c rtrlib/lib/ipv6.c rtrlib/lib/log.c
+    	rtrlib/pfx/trie/trie.c rtrlib/pfx/trie/trie-pfx.c rtrlib/transport/transport.c
+    	rtrlib/transport/tcp/tcp_transport.c rtrlib/rtr/rtr.c rtrlib/rtr/packets.c rtrlib/spki/hashtable/ht-spkitable.c rtrlib/spki/hashtable/tommyds-1.8/tommy.c)
+endif(RTRLIB_USE_LPFST)
+
 set(RTRLIB_LINK ${RT_LIB} ${CMAKE_THREAD_LIBS_INIT})
 
 find_package(LibSSH 0.6.0 QUIET)

--- a/rtrlib/pfx/trie/trie-pfx.c
+++ b/rtrlib/pfx/trie/trie-pfx.c
@@ -366,9 +366,9 @@ int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const st
 
 int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *socket)
 {
+    pthread_rwlock_wrlock(&(pfx_table->lock));
     for(unsigned int i = 0; i < 2; i++) {
         struct trie_node **root = (i == 0 ? &(pfx_table->ipv4) : &(pfx_table->ipv6));
-        pthread_rwlock_wrlock(&(pfx_table->lock));
         if(*root != NULL) {
             int rtval = pfx_table_remove_id(pfx_table, root, *root, socket, 0);
             if(rtval == PFX_ERROR) {
@@ -376,8 +376,8 @@ int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *s
                 return PFX_ERROR;
             }
         }
-        pthread_rwlock_unlock(&pfx_table->lock);
     }
+    pthread_rwlock_unlock(&pfx_table->lock);
     return PFX_SUCCESS;
 }
 

--- a/rtrlib/pfx/trie/trie-pfx.c
+++ b/rtrlib/pfx/trie/trie-pfx.c
@@ -1,0 +1,472 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include "rtrlib/pfx/trie/trie-pfx.h"
+#include <assert.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct data_elem {
+    uint32_t asn;
+    uint8_t max_len;
+    const struct rtr_socket *socket;
+};
+
+struct node_data {
+    unsigned int len;
+    struct data_elem *ary;
+};
+
+static struct trie_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum lrtr_ip_version ver);
+static int pfx_table_del_elem(struct node_data *data, const unsigned int index);
+static int pfx_table_create_node(struct trie_node **node, const struct pfx_record *record);
+static int pfx_table_append_elem(struct node_data *data, const struct pfx_record *record);
+static struct data_elem *pfx_table_find_elem(const struct node_data *data, const struct pfx_record *record, unsigned int *index);
+static bool pfx_table_elem_matches(struct node_data *data, const uint32_t asn, const uint8_t prefix_len);
+static void pfx_table_notify_clients(struct pfx_table *pfx_table, const struct pfx_record *record, const bool added);
+static int pfx_table_remove_id(struct pfx_table *pfx_table, struct trie_node **root, struct trie_node *node, const struct rtr_socket *socket, const unsigned int level);
+static int pfx_table_node2pfx_record(struct trie_node *node, struct pfx_record records[], const unsigned int ary_len);
+static void pfx_table_free_reason(struct pfx_record **reason, unsigned int *reason_len);
+
+
+void pfx_table_notify_clients(struct pfx_table *pfx_table, const struct pfx_record *record, const bool added)
+{
+    if(pfx_table->update_fp != NULL)
+        pfx_table->update_fp(pfx_table, *record, added);
+}
+
+void pfx_table_init(struct pfx_table *pfx_table, pfx_update_fp update_fp)
+{
+    pfx_table->ipv4 = NULL;
+    pfx_table->ipv6 = NULL;
+    pfx_table->update_fp = update_fp;
+    pthread_rwlock_init(&(pfx_table->lock), NULL);
+}
+
+void pfx_table_free(struct pfx_table *pfx_table)
+{
+    for(int i = 0; i < 2; i++) {
+        struct trie_node *root = (i == 0 ? pfx_table->ipv4 : pfx_table->ipv6);
+        if(root != NULL) {
+            struct trie_node *rm_node;
+
+            pthread_rwlock_wrlock(&(pfx_table->lock));
+            do {
+                struct node_data *data = (struct node_data *) (root->data);
+                for(unsigned int i = 0; i < data->len; i++) {
+                    struct pfx_record record = { data->ary[i].asn, (root->prefix), root->len, data->ary[i].max_len, data->ary[i].socket};
+                    pfx_table_notify_clients(pfx_table, &record, false);
+                }
+                rm_node = (trie_remove(root, &(root->prefix), root->len, 0));
+                assert(rm_node != NULL);
+                free(((struct node_data *) rm_node->data)->ary);
+                free(rm_node->data);
+                free(rm_node);
+            } while(rm_node != root);
+            if(i == 0)
+                pfx_table->ipv4 = NULL;
+            else
+                pfx_table->ipv6 = NULL;
+
+            pthread_rwlock_unlock(&(pfx_table->lock));
+        }
+    }
+    pthread_rwlock_destroy(&(pfx_table->lock));
+}
+
+int pfx_table_append_elem(struct node_data *data, const struct pfx_record *record)
+{
+    data->len++;
+    data->ary = realloc(data->ary, sizeof(struct data_elem) * data->len);
+    if(data->ary == NULL)
+        return PFX_ERROR;
+    data->ary[data->len - 1].asn = record->asn;
+    data->ary[data->len - 1].max_len = record->max_len;
+    data->ary[data->len - 1].socket = record->socket;
+    return PFX_SUCCESS;
+}
+
+int pfx_table_create_node(struct trie_node **node, const struct pfx_record *record)
+{
+    *node = malloc(sizeof(struct trie_node));
+    if(*node == NULL)
+        return PFX_ERROR;
+    (*node)->prefix = record->prefix;
+    (*node)->len = record->min_len;
+    (*node)->lchild = NULL;
+    (*node)->rchild = NULL;
+    (*node)->parent = NULL;
+
+    (*node)->data = malloc(sizeof(struct node_data));
+    if((*node)->data == NULL)
+        return PFX_ERROR;
+    ((struct node_data *) (*node)->data)->len = 0;
+    ((struct node_data *) (*node)->data)->ary = NULL;
+
+    return pfx_table_append_elem(((struct node_data *) (*node)->data), record);
+}
+
+struct data_elem *pfx_table_find_elem(const struct node_data *data, const struct pfx_record *record, unsigned int *index)
+{
+    for(unsigned int i = 0; i < data->len; i++) {
+        if(data->ary[i].asn == record->asn && data->ary[i].max_len == record->max_len && data->ary[i].socket == record->socket) {
+            if(index != NULL)
+                *index = i;
+            return &(data->ary[i]);
+        }
+    }
+    return NULL;
+}
+
+//returns pfx_table->ipv4 if record version is LRTR_IPV4 else pfx_table->ipv6
+inline struct trie_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum lrtr_ip_version ver)
+{
+    return ver == LRTR_IPV4 ? pfx_table->ipv4 : pfx_table->ipv6;
+}
+
+int pfx_table_del_elem(struct node_data *data, const unsigned int index)
+{
+    //if index is not the last elem in the list, move all other elems backwards in the array
+    if(index != data->len - 1) {
+        for(unsigned int i = index; i < data->len - 1; i++) {
+            data->ary[i] = data->ary[i+1];
+        }
+    }
+    data->len--;
+    data->ary = realloc(data->ary, sizeof(struct data_elem) * data->len);
+    if(data->len != 0 && data->ary == NULL)
+        return PFX_ERROR;
+    else if(data->len == 0)
+        data->ary = NULL;
+
+    return PFX_SUCCESS;
+}
+
+int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *record)
+{
+    pthread_rwlock_wrlock(&(pfx_table->lock));
+
+    struct trie_node *root = pfx_table_get_root(pfx_table, record->prefix.ver);
+    unsigned int lvl = 0;
+    if(root != NULL) {
+        bool found;
+        struct trie_node *node = trie_lookup_exact(root, &(record->prefix), record->min_len, &lvl, &found);
+        if(found) { //node with prefix exists
+            if(pfx_table_find_elem(node->data, record, NULL) != NULL) {
+                pthread_rwlock_unlock(&pfx_table->lock);
+                return PFX_DUPLICATE_RECORD;
+            }
+            //append record to note_data array
+            int rtval = pfx_table_append_elem(node->data, record);
+            pthread_rwlock_unlock(&pfx_table->lock);
+            pfx_table_notify_clients(pfx_table, record, true);
+            return rtval;
+        } else {
+            //no node with same prefix and prefix_len found
+            struct trie_node *new_node = NULL;
+            if(pfx_table_create_node(&new_node, record) == PFX_ERROR) {
+                pthread_rwlock_unlock(&pfx_table->lock);
+                return PFX_ERROR;
+            }
+            trie_insert(node, new_node, lvl);
+            pthread_rwlock_unlock(&pfx_table->lock);
+            pfx_table_notify_clients(pfx_table, record, true);
+            return PFX_SUCCESS;
+        }
+    } else {
+        //tree is empty, record will be the root_node
+        struct trie_node *new_node = NULL;
+        if(pfx_table_create_node(&new_node, record) == PFX_ERROR) {
+            pthread_rwlock_unlock(&pfx_table->lock);
+            return PFX_ERROR;
+        }
+        if(record->prefix.ver == LRTR_IPV4)
+            pfx_table->ipv4 = new_node;
+        else
+            pfx_table->ipv6 = new_node;
+
+        pthread_rwlock_unlock(&pfx_table->lock);
+        pfx_table_notify_clients(pfx_table, record, true);
+    }
+    return PFX_SUCCESS;
+}
+
+int pfx_table_remove(struct pfx_table *pfx_table, const struct pfx_record *record)
+{
+    pthread_rwlock_wrlock(&(pfx_table->lock));
+    struct trie_node *root = pfx_table_get_root(pfx_table, record->prefix.ver);
+
+    unsigned int lvl = 0; //tree depth were node was found
+    bool found;
+    struct trie_node *node = trie_lookup_exact(root, &(record->prefix), record->min_len, &lvl, &found);
+    if(!found) {
+        pthread_rwlock_unlock(&pfx_table->lock);
+        return PFX_RECORD_NOT_FOUND;
+    }
+
+    unsigned int index;
+    struct data_elem *elem = pfx_table_find_elem(node->data, record, &index);
+    if(elem == NULL) {
+        pthread_rwlock_unlock(&pfx_table->lock);
+        return PFX_RECORD_NOT_FOUND;
+    }
+
+    struct node_data *ndata = (struct node_data *) node->data;
+
+    if(pfx_table_del_elem(ndata, index) == PFX_ERROR) {
+        pthread_rwlock_unlock(&pfx_table->lock);
+        return PFX_ERROR;
+    }
+
+    if(ndata->len == 0) {
+        node = trie_remove(node, &(record->prefix), record->min_len, lvl);
+        assert(node != NULL);
+
+        if(node == root) {
+            if(record->prefix.ver == LRTR_IPV4)
+                pfx_table->ipv4 = NULL;
+            else
+                pfx_table->ipv6 = NULL;
+        }
+        assert(((struct node_data *) node->data)->len == 0);
+        free(node->data);
+        free(node);
+    }
+    pthread_rwlock_unlock(&pfx_table->lock);
+
+    pfx_table_notify_clients(pfx_table, record, false);
+
+    return PFX_SUCCESS;
+}
+
+bool pfx_table_elem_matches(struct node_data *data, const uint32_t asn, const uint8_t prefix_len)
+{
+    for(unsigned int i = 0; i < data->len; i++) {
+        if(data->ary[i].asn != 0 && data->ary[i].asn == asn && prefix_len <= data->ary[i].max_len)
+            return true;
+    }
+    return false;
+}
+
+int pfx_table_node2pfx_record(struct trie_node *node, struct pfx_record *records, const unsigned int ary_len)
+{
+    struct node_data *data = node->data;
+    if(ary_len < data->len)
+        return PFX_ERROR;
+
+    for(unsigned int i = 0; i < data->len; i++) {
+        records[i].asn =  data->ary[i].asn;
+        records[i].prefix = node->prefix;
+        records[i].min_len = node->len;
+        records[i].max_len = data->ary[i].max_len;
+        records[i].socket = data->ary[i].socket;
+    }
+    return data->len;
+}
+
+inline void pfx_table_free_reason(struct pfx_record **reason, unsigned int *reason_len)
+{
+    if(reason != NULL) {
+        free(*reason);
+        *reason = NULL;
+    }
+    if(reason_len != NULL)
+        *reason_len = 0;
+}
+
+int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason, unsigned int *reason_len, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
+{
+    //assert(reason_len == NULL || *reason_len  == 0);
+    //assert(reason == NULL || *reason == NULL);
+
+    pthread_rwlock_rdlock(&(pfx_table->lock));
+    struct trie_node *root = pfx_table_get_root(pfx_table, prefix->ver);
+    if(root == NULL) {
+        pthread_rwlock_unlock(&pfx_table->lock);
+        *result = BGP_PFXV_STATE_NOT_FOUND;
+        pfx_table_free_reason(reason, reason_len);
+        return PFX_SUCCESS;
+    }
+
+    unsigned int lvl = 0;
+    struct trie_node *node = trie_lookup_first_match(root, prefix, prefix_len, &lvl);
+    if(node == NULL) {
+        pthread_rwlock_unlock(&pfx_table->lock);
+        *result = BGP_PFXV_STATE_NOT_FOUND;
+        pfx_table_free_reason(reason, reason_len);
+        return PFX_SUCCESS;
+    }
+
+    if(reason_len != NULL && reason != NULL) {
+        *reason_len = ((struct node_data *) node->data)->len;
+        *reason = realloc(*reason, *reason_len * sizeof(struct pfx_record));
+        if(*reason == NULL) {
+            pthread_rwlock_unlock(&pfx_table->lock);
+            pfx_table_free_reason(reason, reason_len);
+            return PFX_ERROR;
+        }
+        if(pfx_table_node2pfx_record(node, *reason, *reason_len) == PFX_ERROR) {
+            pthread_rwlock_unlock(&pfx_table->lock);
+            pfx_table_free_reason(reason, reason_len);
+            return PFX_ERROR;
+        }
+    }
+
+    while(!pfx_table_elem_matches(node->data, asn, prefix_len)) {
+        if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, lvl++, 1))) //post-incr lvl, trie_lookup is performed on child_nodes => parent lvl + 1
+            node = trie_lookup_first_match(node->lchild, prefix, prefix_len, &lvl);
+        else
+            node = trie_lookup_first_match(node->rchild, prefix, prefix_len, &lvl);
+
+        if(node == NULL) {
+            pthread_rwlock_unlock(&pfx_table->lock);
+            *result = BGP_PFXV_STATE_INVALID;
+            return PFX_SUCCESS;
+        }
+
+        if(reason_len != NULL && reason != NULL) {
+            unsigned int r_len_old = *reason_len;
+            *reason_len += ((struct node_data *) node->data)->len;
+            *reason = realloc(*reason, *reason_len * sizeof(struct pfx_record));
+            struct pfx_record *start = *reason + r_len_old;
+            if(*reason == NULL) {
+                pthread_rwlock_unlock(&pfx_table->lock);
+                pfx_table_free_reason(reason, reason_len);
+                return PFX_ERROR;
+            }
+            if(pfx_table_node2pfx_record(node, start, ((struct node_data *) node->data)->len) == PFX_ERROR) {
+                pthread_rwlock_unlock(&pfx_table->lock);
+                pfx_table_free_reason(reason, reason_len);
+                return PFX_ERROR;
+            }
+        }
+    }
+
+    pthread_rwlock_unlock(&pfx_table->lock);
+    *result = BGP_PFXV_STATE_VALID;
+    return PFX_SUCCESS;
+}
+
+int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
+{
+    return pfx_table_validate_r(pfx_table, NULL, NULL, asn, prefix, prefix_len, result);
+}
+
+int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *socket)
+{
+    for(unsigned int i = 0; i < 2; i++) {
+        struct trie_node **root = (i == 0 ? &(pfx_table->ipv4) : &(pfx_table->ipv6));
+        pthread_rwlock_wrlock(&(pfx_table->lock));
+        if(*root != NULL) {
+            int rtval = pfx_table_remove_id(pfx_table, root, *root, socket, 0);
+            if(rtval == PFX_ERROR) {
+                pthread_rwlock_unlock(&pfx_table->lock);
+                return PFX_ERROR;
+            }
+        }
+        pthread_rwlock_unlock(&pfx_table->lock);
+    }
+    return PFX_SUCCESS;
+}
+
+int pfx_table_remove_id(struct pfx_table *pfx_table, struct trie_node **root, struct trie_node *node, const struct rtr_socket *socket, const unsigned int level)
+{
+    assert(node != NULL);
+    assert(root != NULL);
+    assert(*root != NULL);
+    bool check_node = true;
+
+    while(check_node) { //data from removed node are replaced from data from child nodes (if children exists), same node must be checked again if it was replaced with previous child node data
+        struct node_data *data = node->data;
+        for(unsigned int i = 0; i < data->len; i++) {
+            while(data->len > i && data->ary[i].socket == socket) {
+                struct pfx_record record = { data->ary[i].asn, node->prefix, node->len, data->ary[i].max_len, data->ary[i].socket };
+                if(pfx_table_del_elem(data, i) == PFX_ERROR) {
+                    return PFX_ERROR;
+                }
+                pfx_table_notify_clients(pfx_table, &record, false);
+            }
+        }
+        if(data->len == 0) {
+            struct trie_node *rm_node = trie_remove(node, &(node->prefix), node->len, level);
+            assert(rm_node != NULL);
+            assert(((struct node_data *) rm_node->data)->len == 0);
+            free(((struct node_data *) rm_node->data));
+            free(rm_node);
+
+            if(rm_node == *root) {
+                *root = NULL;
+                return PFX_SUCCESS;
+            } else if(rm_node == node)
+                return PFX_SUCCESS;
+        } else
+            check_node = false;
+    }
+
+    if(node->lchild != NULL) {
+        if(pfx_table_remove_id(pfx_table, root, node->lchild, socket, level + 1) == PFX_ERROR)
+            return PFX_ERROR;
+    }
+    if(node->rchild != NULL)
+        return pfx_table_remove_id(pfx_table, root, node->rchild, socket, level + 1);
+    return PFX_SUCCESS;
+}
+
+static void pfx_table_for_each_rec(struct trie_node *n, pfx_for_each_fp fp,
+                                   void *data)
+{
+    struct pfx_record pfxr;
+    struct node_data *nd;
+
+    assert(n != NULL);
+    assert(fp != NULL);
+
+    nd = (struct node_data *) n->data;
+    assert(nd != NULL);
+
+    if (n->lchild != NULL)
+        pfx_table_for_each_rec(n->lchild, fp, data);
+
+    for (unsigned int i = 0; i < nd->len; i++) {
+        pfxr.asn =  nd->ary[i].asn;
+        pfxr.prefix = n->prefix;
+        pfxr.min_len = n->len;
+        pfxr.max_len = nd->ary[i].max_len;
+        pfxr.socket = nd->ary[i].socket;
+        fp(&pfxr, data);
+    }
+
+    if (n->rchild != NULL)
+        pfx_table_for_each_rec(n->rchild, fp, data);
+}
+
+void pfx_table_for_each_ipv4_record(struct pfx_table *pfx_table, pfx_for_each_fp fp, void *data)
+{
+    assert(pfx_table != NULL);
+
+    if (pfx_table->ipv4 == NULL)
+        return;
+
+    pthread_rwlock_rdlock(&(pfx_table->lock));
+    pfx_table_for_each_rec(pfx_table->ipv4, fp, data);
+    pthread_rwlock_unlock(&pfx_table->lock);
+}
+
+void pfx_table_for_each_ipv6_record(struct pfx_table *pfx_table, pfx_for_each_fp fp, void *data)
+{
+    assert(pfx_table != NULL);
+
+    if (pfx_table->ipv6 == NULL)
+        return;
+
+    pthread_rwlock_rdlock(&(pfx_table->lock));
+    pfx_table_for_each_rec(pfx_table->ipv6, fp, data);
+    pthread_rwlock_unlock(&pfx_table->lock);
+}

--- a/rtrlib/pfx/trie/trie-pfx.c
+++ b/rtrlib/pfx/trie/trie-pfx.c
@@ -301,7 +301,7 @@ int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason
     }
 
     unsigned int lvl = 0;
-    struct trie_node *node = trie_lookup_first_match(root, prefix, prefix_len, &lvl);
+    struct trie_node *node = trie_lookup(root, prefix, prefix_len, &lvl);
     if(node == NULL) {
         pthread_rwlock_unlock(&pfx_table->lock);
         *result = BGP_PFXV_STATE_NOT_FOUND;
@@ -326,9 +326,9 @@ int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason
 
     while(!pfx_table_elem_matches(node->data, asn, prefix_len)) {
         if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, lvl++, 1))) //post-incr lvl, trie_lookup is performed on child_nodes => parent lvl + 1
-            node = trie_lookup_first_match(node->lchild, prefix, prefix_len, &lvl);
+            node = trie_lookup(node->lchild, prefix, prefix_len, &lvl);
         else
-            node = trie_lookup_first_match(node->rchild, prefix, prefix_len, &lvl);
+            node = trie_lookup(node->rchild, prefix, prefix_len, &lvl);
 
         if(node == NULL) {
             pthread_rwlock_unlock(&pfx_table->lock);

--- a/rtrlib/pfx/trie/trie-pfx.c
+++ b/rtrlib/pfx/trie/trie-pfx.c
@@ -83,10 +83,11 @@ void pfx_table_free(struct pfx_table *pfx_table)
 
 int pfx_table_append_elem(struct node_data *data, const struct pfx_record *record)
 {
-    data->len++;
-    data->ary = realloc(data->ary, sizeof(struct data_elem) * data->len);
-    if(data->ary == NULL)
+    struct data_elem *tmp  = realloc(data->ary, sizeof(struct data_elem) * ((data->len) + 1));
+    if(tmp == NULL)
         return PFX_ERROR;
+    data->len++;
+    data->ary = tmp;
     data->ary[data->len - 1].asn = record->asn;
     data->ary[data->len - 1].max_len = record->max_len;
     data->ary[data->len - 1].socket = record->socket;
@@ -105,8 +106,10 @@ int pfx_table_create_node(struct trie_node **node, const struct pfx_record *reco
     (*node)->parent = NULL;
 
     (*node)->data = malloc(sizeof(struct node_data));
-    if((*node)->data == NULL)
+    if((*node)->data == NULL) {
+        free(*node);
         return PFX_ERROR;
+    }
     ((struct node_data *) (*node)->data)->len = 0;
     ((struct node_data *) (*node)->data)->ary = NULL;
 
@@ -141,8 +144,10 @@ int pfx_table_del_elem(struct node_data *data, const unsigned int index)
     }
     data->len--;
     data->ary = realloc(data->ary, sizeof(struct data_elem) * data->len);
-    if(data->len != 0 && data->ary == NULL)
+    if(data->len != 0 && data->ary == NULL) {
+        free(&data->ary[data->len]);
         return PFX_ERROR;
+    }
     else if(data->len == 0)
         data->ary = NULL;
 

--- a/rtrlib/pfx/trie/trie-pfx.h
+++ b/rtrlib/pfx/trie/trie-pfx.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+/**
+ * @defgroup mod_trie_pfx_h Prefix trie
+ * @ingroup mod_pfx_h
+ * @brief An implementation of a \ref mod_pfx_h "pfx_table" data structure
+ * using a trie for storing @ref pfx_record "pfx_records".
+ * @details This implementation uses two separate tries, one for IPv4
+ * validation records and one for IPv6 records.\n
+ * See \ref mod_pfx_h "pfx_table" for a list of supported operations of
+ * this data structure.\n
+ *
+ * @{
+ */
+
+#ifndef RTR_LPFST_PFX
+#define RTR_LPFST_PFX
+#include "rtrlib/pfx/pfx.h"
+#include "rtrlib/pfx/trie/trie.h"
+
+/**
+ * @brief pfx_table.
+ * @param ipv4
+ * @param ipv6
+ * @param update_fp
+ * @param lock
+ */
+struct pfx_table {
+    struct trie_node *ipv4;
+    struct trie_node *ipv6;
+    pfx_update_fp update_fp;
+    pthread_rwlock_t lock;
+};
+
+#endif
+/* @} */

--- a/rtrlib/pfx/trie/trie.c
+++ b/rtrlib/pfx/trie/trie.c
@@ -1,0 +1,293 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include "rtrlib/pfx/trie/trie.h"
+
+static void swap_nodes(struct trie_node *a, struct trie_node *b)
+{
+	struct trie_node tmp;
+
+	tmp.prefix = a->prefix;
+	tmp.len = a->len;
+	tmp.data = a->data;
+
+	a->prefix = b->prefix;
+	a->len = b->len;
+	a->data = b->data;
+
+	b->prefix = tmp.prefix;
+	b->len = tmp.len;
+	b->data = tmp.data;
+}
+
+enum child_node_rel {
+	LEFT,
+	RIGHT
+};
+
+static void add_child_node(struct trie_node *parent, struct trie_node *child,
+			   enum child_node_rel rel)
+{
+	assert(rel == LEFT || rel == RIGHT);
+
+	if (rel == LEFT)
+		parent->lchild = child;
+	else
+		parent->rchild = child;
+
+	child->parent = parent;
+}
+
+static inline bool is_left_child(const struct lrtr_ip_addr *addr,
+				 unsigned int lvl)
+{
+	/* A node must be inserted as left child if bit <lvl> of the IP address
+	 * is 0 otherwise as right child
+	 */
+	return lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(addr, lvl, 1));
+}
+
+void trie_insert(struct trie_node *root, struct trie_node *new,
+		  const unsigned int lvl)
+{
+	if (new->len < root->len)
+		swap_nodes(root, new);
+
+	if (is_left_child(&new->prefix, lvl)) {
+		if (!root->lchild)
+			return add_child_node(root, new, LEFT);
+
+		return trie_insert(root->lchild, new, lvl + 1);
+	}
+
+	if (!root->rchild)
+		return add_child_node(root, new, RIGHT);
+
+	trie_insert(root->rchild, new, lvl + 1);
+}
+
+struct trie_node *trie_lookup_first_match(const struct trie_node *root,
+					    const struct lrtr_ip_addr *prefix,
+					    const uint8_t mask_len,
+					    unsigned int *lvl)
+{
+	if (!root)
+		return NULL;
+
+	if (root->len <= mask_len && lrtr_ip_addr_equal(lrtr_ip_addr_get_bits(
+							&root->prefix, 0,
+							root->len),
+							lrtr_ip_addr_get_bits(
+							prefix, 0, root->len)))
+		return (struct trie_node *)root;
+
+	if (is_left_child(prefix, *lvl)) {
+		(*lvl)++;
+		return trie_lookup_first_match(root->lchild, prefix, mask_len,
+						lvl);
+	}
+	(*lvl)++;
+	return trie_lookup_first_match(root->rchild, prefix, mask_len, lvl);
+}
+
+struct trie_node *trie_lookup(const struct trie_node *root,
+				const struct lrtr_ip_addr *prefix,
+				const uint8_t mask_len, unsigned int *lvl)
+{
+	unsigned int my_lvl = *lvl;
+
+	if (!root)
+		return NULL;
+
+	bool is_match = false;
+	struct trie_node *better_match = NULL;
+
+	if (root->len <= mask_len && lrtr_ip_addr_equal(lrtr_ip_addr_get_bits(
+							&root->prefix, 0,
+							root->len),
+							lrtr_ip_addr_get_bits(
+							prefix, 0, root->len)))
+		is_match = true;
+	if (is_left_child(prefix, *lvl)) {
+		(*lvl)++;
+		better_match = trie_lookup(root->lchild, prefix, mask_len,
+					    lvl);
+	} else {
+		(*lvl)++;
+		better_match = trie_lookup(root->rchild, prefix, mask_len,
+					    lvl);
+	}
+	if (!better_match && is_match) {
+		*lvl = my_lvl;
+		return (struct trie_node *)root;
+	} else {
+		return better_match;
+	}
+}
+
+struct trie_node *trie_lookup_exact(struct trie_node *root_node,
+				      const struct lrtr_ip_addr *prefix,
+				      const uint8_t mask_len,
+				      unsigned int *lvl, bool *found)
+{
+	*found = false;
+
+	while (root_node) {
+		if (*lvl > 0 && root_node->len > mask_len) {
+			(*lvl)--;
+			return root_node->parent;
+		}
+
+		if (root_node->len == mask_len &&
+		    lrtr_ip_addr_equal(root_node->prefix, *prefix)) {
+			*found = true;
+			return root_node;
+		}
+
+		if (is_left_child(prefix, *lvl)) {
+			if (!root_node->lchild)
+				return root_node;
+			root_node = root_node->lchild;
+		} else {
+			if (!root_node->rchild)
+				return root_node;
+			root_node = root_node->rchild;
+		}
+
+		(*lvl)++;
+	}
+	return NULL;
+}
+
+static void deref_node(struct trie_node *n)
+{
+	if (!n->parent)
+		return;
+
+	if (n->parent->lchild == n) {
+		n->parent->lchild = NULL;
+		return;
+	}
+
+	n->parent->rchild = NULL;
+}
+
+static inline bool prefix_is_same(const struct trie_node *n,
+				  const struct lrtr_ip_addr *p,
+				  uint8_t mask_len)
+{
+	return n->len == mask_len && lrtr_ip_addr_equal(n->prefix, *p);
+}
+
+static void replace_node_data(struct trie_node *a, struct trie_node *b)
+{
+	a->prefix = b->prefix;
+	a->len = b->len;
+	a->data = b->data;
+}
+
+struct trie_node *trie_remove(struct trie_node *root,
+				const struct lrtr_ip_addr *prefix,
+				const uint8_t mask_len,
+				const unsigned int lvl)
+{
+	/* If the node has no children we can simply remove it
+	 * If the node has children, we swap the node with the child that
+	 * has the shorter prefix length and remove the child.
+	 */
+	if (prefix_is_same(root, prefix, mask_len)) {
+		void *tmp;
+
+		if (trie_is_leaf(root)) {
+			deref_node(root);
+			return root;
+		}
+
+		/* swap with the left child and remove the child */
+		if (root->lchild && (!root->rchild ||
+				     root->lchild->len < root->rchild->len)) {
+			tmp = root->data;
+			replace_node_data(root, root->lchild);
+			root->lchild->data = tmp;
+
+			return trie_remove(root->lchild,
+					    &root->lchild->prefix,
+					    root->lchild->len, lvl + 1);
+		}
+
+		/* swap with the right child and remove the child */
+		tmp = root->data;
+		replace_node_data(root, root->rchild);
+		root->rchild->data = tmp;
+
+		return trie_remove(root->rchild,
+				    &root->rchild->prefix,
+				    root->rchild->len, lvl + 1);
+	}
+
+	if (is_left_child(prefix, lvl)) {
+		if (!root->lchild)
+			return NULL;
+		return trie_remove(root->lchild, prefix, mask_len, lvl + 1);
+	}
+
+	if (!root->rchild)
+		return NULL;
+	return trie_remove(root->rchild, prefix, mask_len, lvl + 1);
+}
+
+static int append_node_to_array(struct trie_node ***ary,
+				unsigned int *len,
+				struct trie_node *n)
+{
+	struct trie_node **new;
+
+	new = realloc(*ary, *len * sizeof(n));
+	if (!new)
+		return -1;
+
+	*ary = new;
+	(*ary)[*len - 1] = n;
+	return 0;
+}
+
+int trie_get_children(const struct trie_node *root_node,
+		       struct trie_node ***array, unsigned int *len)
+{
+	if (root_node->lchild) {
+		*len += 1;
+		if (append_node_to_array(array, len, root_node->lchild))
+			goto err;
+
+		if (trie_get_children(root_node->lchild, array, len) == -1)
+			goto err;
+	}
+
+	if (root_node->rchild) {
+		*len += 1;
+		if (append_node_to_array(array, len, root_node->rchild))
+			goto err;
+
+		if (trie_get_children(root_node->rchild, array, len) == -1)
+			goto err;
+	}
+
+	return 0;
+
+err:
+	free(*array);
+	return -1;
+}
+
+inline bool trie_is_leaf(const struct trie_node *node)
+{
+	return !node->lchild && !node->rchild;
+}

--- a/rtrlib/pfx/trie/trie.c
+++ b/rtrlib/pfx/trie/trie.c
@@ -74,7 +74,7 @@ void trie_insert(struct trie_node *root, struct trie_node *new,
 	trie_insert(root->rchild, new, lvl + 1);
 }
 
-struct trie_node *trie_lookup_first_match(const struct trie_node *root,
+struct trie_node *trie_lookup(const struct trie_node *root,
 					    const struct lrtr_ip_addr *prefix,
 					    const uint8_t mask_len,
 					    unsigned int *lvl)
@@ -91,46 +91,11 @@ struct trie_node *trie_lookup_first_match(const struct trie_node *root,
 
 	if (is_left_child(prefix, *lvl)) {
 		(*lvl)++;
-		return trie_lookup_first_match(root->lchild, prefix, mask_len,
+		return trie_lookup(root->lchild, prefix, mask_len,
 						lvl);
 	}
 	(*lvl)++;
-	return trie_lookup_first_match(root->rchild, prefix, mask_len, lvl);
-}
-
-struct trie_node *trie_lookup(const struct trie_node *root,
-				const struct lrtr_ip_addr *prefix,
-				const uint8_t mask_len, unsigned int *lvl)
-{
-	unsigned int my_lvl = *lvl;
-
-	if (!root)
-		return NULL;
-
-	bool is_match = false;
-	struct trie_node *better_match = NULL;
-
-	if (root->len <= mask_len && lrtr_ip_addr_equal(lrtr_ip_addr_get_bits(
-							&root->prefix, 0,
-							root->len),
-							lrtr_ip_addr_get_bits(
-							prefix, 0, root->len)))
-		is_match = true;
-	if (is_left_child(prefix, *lvl)) {
-		(*lvl)++;
-		better_match = trie_lookup(root->lchild, prefix, mask_len,
-					    lvl);
-	} else {
-		(*lvl)++;
-		better_match = trie_lookup(root->rchild, prefix, mask_len,
-					    lvl);
-	}
-	if (!better_match && is_match) {
-		*lvl = my_lvl;
-		return (struct trie_node *)root;
-	} else {
-		return better_match;
-	}
+	return trie_lookup(root->rchild, prefix, mask_len, lvl);
 }
 
 struct trie_node *trie_lookup_exact(struct trie_node *root_node,

--- a/rtrlib/pfx/trie/trie.h
+++ b/rtrlib/pfx/trie/trie.h
@@ -52,23 +52,6 @@ void trie_insert(struct trie_node *root, struct trie_node *new_node,
  * @returns NULL if no node that matches the passed prefix and prefix length
  *	    could be found.
  */
-struct trie_node *trie_lookup_first_match(const struct trie_node *root_node,
-					    const struct lrtr_ip_addr *prefix,
-					    const uint8_t mask_len,
-					    unsigned int *level);
-/**
- * @brief Searches for the node with the longest prefix, matching the passed ip
- *	  prefix and prefix length.
- * @param[in] root_node Node were the lookup process starts.
- * @param[in] lrtr_ip_addr IP-Prefix.
- * @param[in] mask_len Length of the network mask of the prefix.
- * @param[in,out] level of the the node root in the tree. Is set to the level of
- *		  the node that is returned.
- * @returns The trie_node with the longest prefix in the tree matching the
- *	    passed ip prefix and prefix length.
- * @returns NULL if no node that matches the passed prefix and prefix length
- *	    could be found.
- */
 struct trie_node *trie_lookup(const struct trie_node *root_node,
 				const struct lrtr_ip_addr *prefix,
 				const uint8_t mask_len, unsigned int *level);

--- a/rtrlib/pfx/trie/trie.h
+++ b/rtrlib/pfx/trie/trie.h
@@ -1,0 +1,119 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#ifndef RTR_LPFST
+#define RTR_LPFST
+#include <inttypes.h>
+#include "rtrlib/lib/ip.h"
+
+/**
+ * @brief trie_node
+ * @param prefix
+ * @param rchild
+ * @param lchild
+ * @param parent
+ * @param data
+ * @param len number of elements in data array
+ */
+struct trie_node {
+	struct lrtr_ip_addr prefix;
+	struct trie_node *rchild;
+	struct trie_node *lchild;
+	struct trie_node *parent;
+	void *data;
+	uint8_t len;
+};
+
+/**
+ * @brief Inserts new_node in the tree.
+ * @param[in] root Root node of the tree for the inserting process.
+ * @param[in] new_node Node that will be inserted.
+ * @param[in] level Level of the the root node in the tree.
+ */
+void trie_insert(struct trie_node *root, struct trie_node *new_node,
+		  const unsigned int level);
+
+/**
+ * @brief Searches for the node with the shortest prefix, matching the passed ip
+ *	  prefix and prefix length.
+ * @param[in] root_node Node were the lookup process starts.
+ * @param[in] lrtr_ip_addr IP-Prefix.
+ * @param[in] mask_len Length of the network mask of the prefix.
+ * @param[in,out] level of the the node root in the tree. Is set to the level of
+ *		  the node that is returned.
+ * @returns The trie_node with the shortest prefix in the tree matching the
+ *	    passed ip prefix and prefix length.
+ * @returns NULL if no node that matches the passed prefix and prefix length
+ *	    could be found.
+ */
+struct trie_node *trie_lookup_first_match(const struct trie_node *root_node,
+					    const struct lrtr_ip_addr *prefix,
+					    const uint8_t mask_len,
+					    unsigned int *level);
+/**
+ * @brief Searches for the node with the longest prefix, matching the passed ip
+ *	  prefix and prefix length.
+ * @param[in] root_node Node were the lookup process starts.
+ * @param[in] lrtr_ip_addr IP-Prefix.
+ * @param[in] mask_len Length of the network mask of the prefix.
+ * @param[in,out] level of the the node root in the tree. Is set to the level of
+ *		  the node that is returned.
+ * @returns The trie_node with the longest prefix in the tree matching the
+ *	    passed ip prefix and prefix length.
+ * @returns NULL if no node that matches the passed prefix and prefix length
+ *	    could be found.
+ */
+struct trie_node *trie_lookup(const struct trie_node *root_node,
+				const struct lrtr_ip_addr *prefix,
+				const uint8_t mask_len, unsigned int *level);
+
+/**
+ * @brief Search for a node with the same prefix and prefix length.
+ * @param[in] root_node Node were the lookup process starts.
+ * @param[in] lrtr_ip_addr IP-Prefix.
+ * @param[in] mask_len Length of the network mask of the prefix.
+ * @param[in,out] level of the the node root in the tree. Is set to the level of
+ *		  the node that is returned.
+ * @param[in] found Is true if a node which matches could be found else found is
+ *	            set to false.
+ * @return A node which matches the passed parameter (found==true).
+ * @return The parent of the node where the lookup operation
+ *	   stopped (found==false).
+ * @return NULL if root_node is NULL.
+*/
+struct trie_node *trie_lookup_exact(struct trie_node *root_node,
+				      const struct lrtr_ip_addr *prefix,
+				      const uint8_t mask_len,
+				      unsigned int *level, bool *found);
+
+/**
+ * @brief Removes the node with the passed IP prefix and mask_len from the tree.
+ * @param[in] root Node were the inserting process starts.
+ * @param[in] prefix Prefix that will removed from the tree.
+ * @param[in] mask_len Length of the network mask of the prefix.
+ * @param[in] level Level of the root node in the tree.
+ * @returns Node that was removed from the tree. The caller has to free it.
+ * @returns NULL If the Prefix could'nt be found in the tree.
+ */
+struct trie_node *trie_remove(struct trie_node *root_node,
+				const struct lrtr_ip_addr *prefix,
+				const uint8_t mask_len,
+				const unsigned int level);
+
+/**
+ * @brief Detects if a node is a leaf in the tree.
+ * @param[in] node
+ * @returns true if node is a leaf.
+ * @returns false if node isn't a leaf.
+ */
+bool trie_is_leaf(const struct trie_node *node);
+
+int trie_get_children(const struct trie_node *root_node,
+		       struct trie_node ***array, unsigned int *len);
+#endif

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -8,7 +8,13 @@
  */
 
 #include "rtrlib/rtr_mgr.h"
+
+#ifdef RTRLIB_USE_LPFST
 #include "rtrlib/pfx/lpfst/lpfst-pfx.h"
+#else
+#include "rtrlib/pfx/trie/trie-pfx.h"
+#endif
+
 #include "rtrlib/spki/hashtable/ht-spkitable.h"
 #include <stdlib.h>
 #include <pthread.h>

--- a/rtrlib/rtrlib.h.cmake
+++ b/rtrlib/rtrlib.h.cmake
@@ -18,7 +18,13 @@
 #include "rtrlib/transport/transport.h"
 #include "rtrlib/transport/tcp/tcp_transport.h"
 #include "rtrlib/rtr_mgr.h"
+
+#ifdef RTRLIB_USE_LPFST
 #include "rtrlib/pfx/lpfst/lpfst-pfx.h"
+#else
+#include "rtrlib/pfx/trie/trie-pfx.h"
+#endif
+
 #include "rtrlib/rtr/rtr.h"
 #include "rtrlib/lib/utils.h"
 #ifdef RTRLIB_HAVE_LIBSSH

--- a/scripts/check-coding-files.txt
+++ b/scripts/check-coding-files.txt
@@ -1,5 +1,7 @@
 rtrlib/rtr_mgr.h
 rtrlib/rtr_mgr.c
+rtrlib/pfx/trie/trie.h
+rtrlib/pfx/trie/trie.c
 rtrlib/pfx/lpfst/lpfst.h
 rtrlib/pfx/lpfst/lpfst.c
 tests/test_ht_spkitable.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,15 @@
 set(CMAKE_BUILD_TYPE Debug)
 
+
+if(RTRLIB_USE_LPFST)
+    add_executable(test_lpfst test_lpfst.c)
+    target_link_libraries(test_lpfst rtrlib)
+else()
+    add_executable(test_trie test_trie.c)
+    target_link_libraries(test_trie rtrlib)
+endif(RTRLIB_USE_LPFST)
 add_executable(test_pfx test_pfx.c)
 target_link_libraries(test_pfx rtrlib)
-add_executable(test_lpfst test_lpfst.c)
-target_link_libraries(test_lpfst rtrlib)
 add_executable(test_pfx_locks test_pfx_locks.c)
 target_link_libraries(test_pfx_locks rtrlib)
 add_executable(test_ht_spkitable test_ht_spkitable.c)

--- a/tests/test_pfx_locks.c
+++ b/tests/test_pfx_locks.c
@@ -17,7 +17,11 @@
 #include <pthread.h>
 #include <time.h>
 #include "rtrlib/lib/ip.h"
+#ifdef RTRLIB_USE_LPFST
 #include "rtrlib/pfx/lpfst/lpfst-pfx.h"
+#else
+#include "rtrlib/pfx/trie/trie-pfx.h"
+#endif
 
 uint32_t min_i = 0xFF000000;
 uint32_t max_i = 0xFFFFFFF0;

--- a/tests/test_trie.c
+++ b/tests/test_trie.c
@@ -1,0 +1,333 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <assert.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include "rtrlib/lib/ipv6.h"
+#include "rtrlib/lib/log.h"
+#include "rtrlib/lib/utils.h"
+#include "rtrlib/pfx/trie/trie.c"
+
+/*
+ * @brief Test IPv4 address bit operations required by trie
+ */
+static void get_bits_testv4(void)
+{
+	struct lrtr_ip_addr addr;
+	struct lrtr_ip_addr result;
+
+	addr.ver = LRTR_IPV4;
+	addr.u.addr4.addr = 0xAABBCC22;
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 32);
+	assert(result.u.addr4.addr == 0xAABBCC22);
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 1);
+	assert(result.u.addr4.addr == 0x80000000);
+
+	result = lrtr_ip_addr_get_bits(&addr, 1, 1);
+	assert(result.u.addr4.addr == 0);
+
+	result = lrtr_ip_addr_get_bits(&addr, 2, 1);
+	assert(result.u.addr4.addr == 0x20000000);
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 8);
+	assert(result.u.addr4.addr == 0xAA000000);
+
+	result = lrtr_ip_addr_get_bits(&addr, 8, 8);
+	assert(result.u.addr4.addr == 0x00BB0000);
+
+	lrtr_ip_str_to_addr("10.10.10.0", &addr);
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 8);
+	assert(lrtr_ip_str_cmp(&result, "10.0.0.0"));
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 16);
+	assert(lrtr_ip_str_cmp(&result, "10.10.0.0"));
+
+	result = lrtr_ip_addr_get_bits(&addr, 8, 8);
+	assert(lrtr_ip_str_cmp(&result, "0.10.0.0"));
+
+	result = lrtr_ip_addr_get_bits(&addr, 8, 24);
+	assert(lrtr_ip_str_cmp(&result, "0.10.10.0"));
+
+	result = lrtr_ip_addr_get_bits(&addr, 31, 1);
+	assert(result.u.addr4.addr == 0);
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 1);
+	assert(result.u.addr4.addr == 0);
+
+	result = lrtr_ip_addr_get_bits(&addr, 3, 3);
+	assert(lrtr_ip_str_cmp(&result, "8.0.0.0"));
+
+	assert(lrtr_ip_str_to_addr("132.200.0.0", &addr) == 0);
+	result = lrtr_ip_addr_get_bits(&addr, 0, 1);
+	assert(result.u.addr4.addr == 0x80000000);
+
+	assert(lrtr_ip_str_to_addr("101.200.0.0", &addr) == 0);
+	result = lrtr_ip_addr_get_bits(&addr, 0, 1);
+	assert(result.u.addr4.addr == 0);
+
+	addr.u.addr4.addr = 0x6D698000;
+	result = lrtr_ip_addr_get_bits(&addr, 0, 19);
+	assert(result.u.addr4.addr == 0x6D698000);
+
+	/* ip_str_to_addr("109.105.128.0", &addr);
+	 * result = ip_addr_get_bits(&addr, 0, 8);
+	 * printf("%u\n", result.u.addr4.addr);
+	 */
+	char buf[INET_ADDRSTRLEN];
+
+	assert(lrtr_ip_str_to_addr("10.10.10.5", &addr) == 0);
+	assert(lrtr_ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
+	assert(strcmp("10.10.10.5", buf) == 0);
+}
+
+/*
+ * @brief Test IPv6 address bit operations required by trie
+ */
+static void get_bits_testv6(void)
+{
+	struct lrtr_ip_addr addr;
+	struct lrtr_ip_addr result;
+
+	addr.ver = LRTR_IPV6;
+	addr.u.addr6.addr[0] = 0x22AABBCC;
+	addr.u.addr6.addr[1] = 0xDDEEFF99;
+	addr.u.addr6.addr[2] = 0x33001122;
+	addr.u.addr6.addr[3] = 0x33445566;
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 128);
+	assert(result.u.addr6.addr[0] == addr.u.addr6.addr[0] &&
+	       result.u.addr6.addr[1] == addr.u.addr6.addr[1] &&
+	       result.u.addr6.addr[2] == addr.u.addr6.addr[2] &&
+	       result.u.addr6.addr[3] == addr.u.addr6.addr[3]);
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 64);
+	assert(result.u.addr6.addr[0] == addr.u.addr6.addr[0] &&
+	       result.u.addr6.addr[1] == addr.u.addr6.addr[1] &&
+	       result.u.addr6.addr[2] == 0 &&
+	       result.u.addr6.addr[3] == 0);
+
+	bzero(&result, sizeof(result));
+	result = lrtr_ip_addr_get_bits(&addr, 64, 64);
+	assert(result.u.addr6.addr[0] == 0);
+	assert(result.u.addr6.addr[1] == 0);
+	assert(result.u.addr6.addr[2] == addr.u.addr6.addr[2]);
+	assert(result.u.addr6.addr[3] == addr.u.addr6.addr[3]);
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 8);
+	assert(result.u.addr6.addr[0] == 0x22000000 &&
+	       result.u.addr6.addr[1] == 0);
+
+	result = lrtr_ip_addr_get_bits(&addr, 64, 8);
+	assert(result.u.addr6.addr[1] == 0 &&
+	       result.u.addr6.addr[2] == 0x33000000);
+
+	result = lrtr_ip_addr_get_bits(&addr, 7, 8);
+	assert(result.u.addr6.addr[0] == 0xAA0000 &&
+	       result.u.addr6.addr[1] == 0);
+
+	result = lrtr_ip_addr_get_bits(&addr, 68, 7);
+	assert(result.u.addr6.addr[0] == 0 &&
+	       result.u.addr6.addr[2] == 0x03000000);
+
+	char buf[INET6_ADDRSTRLEN];
+
+	lrtr_ip_str_to_addr("fe80::862b:2bff:fe9a:f50f", &addr);
+	addr.ver = LRTR_IPV6;
+	assert(addr.u.addr6.addr[0] == 0xfe800000);
+	assert(addr.u.addr6.addr[1] == 0);
+	assert(addr.u.addr6.addr[2] == 0x862b2bff);
+	assert(addr.u.addr6.addr[3] == 0xfe9af50f);
+
+	assert(lrtr_ip_str_to_addr("2001::", &addr) == 0);
+	assert(addr.u.addr6.addr[0] == 0x20010000);
+	assert(addr.u.addr6.addr[1] == 0);
+	assert(addr.u.addr6.addr[2] == 0);
+	assert(addr.u.addr6.addr[3] == 0);
+
+	assert(lrtr_ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
+	assert(strcmp("2001::", buf) == 0);
+
+	lrtr_ip_str_to_addr("2001:0db8:85a3:08d3:1319:8a2e:0370:7344", &addr);
+	assert(lrtr_ip_addr_to_str(&addr, buf, sizeof(buf)) == 0);
+	assert(strcmp("2001:db8:85a3:8d3:1319:8a2e:370:7344", buf) == 0);
+
+	result = lrtr_ip_addr_get_bits(&addr, 0, 16);
+	assert(lrtr_ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
+	assert(lrtr_ip_str_cmp(&result, "2001::"));
+
+	result = lrtr_ip_addr_get_bits(&addr, 16, 16);
+	assert(lrtr_ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
+	assert(lrtr_ip_str_cmp(&result, "0:db8::"));
+	result = lrtr_ip_addr_get_bits(&addr, 0, 1);
+	assert(lrtr_ip_str_cmp(&result, "::"));
+
+	result = lrtr_ip_addr_get_bits(&addr, 126, 1);
+	assert(lrtr_ip_addr_to_str(&result, buf, sizeof(buf)) == 0);
+	assert(lrtr_ip_str_cmp(&result, "::"));
+}
+
+/*
+ * @brief Test trie core operations such as add and remove
+ * This test validates core operations of the longest prefix first search tree
+ * (trie), namely insert, remove, lookup, and lookup_exact.
+ */
+static void trie_test(void)
+{
+	struct lrtr_ip_addr addr;
+	struct trie_node *result;
+	unsigned int lvl = 0;
+	/* set IP to version 4 */
+	addr.ver = LRTR_IPV4;
+
+	struct trie_node n1;
+	/* init  node n1 */
+	n1.len = 16;
+	n1.lchild = NULL;
+	n1.rchild = NULL;
+	n1.parent = NULL;
+	n1.data = NULL;
+
+	lrtr_ip_str_to_addr("100.200.0.0", &n1.prefix);
+	lrtr_ip_str_to_addr("100.200.0.0", &addr);
+	lvl = 0;
+	result = trie_lookup(&n1, &addr, 16, &lvl);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&result->prefix, "100.200.0.0"));
+
+	lrtr_ip_str_to_addr("100.200.30.0", &addr);
+	lvl = 0;
+	result = trie_lookup(&n1, &addr, 16, &lvl);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&result->prefix, "100.200.0.0"));
+
+	struct trie_node n2;
+	/* init node n2 */
+	n2.len = 16;
+	n2.lchild = NULL;
+	n2.rchild = NULL;
+	n2.parent = NULL;
+	n2.data = NULL;
+
+	lrtr_ip_str_to_addr("132.200.0.0", &n2.prefix);
+	trie_insert(&n1, &n2, 0);
+	lrtr_ip_str_to_addr("132.200.0.0", &addr);
+	lvl = 0;
+	result = trie_lookup(&n1, &addr, 16, &lvl);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&result->prefix, "132.200.0.0"));
+	assert(n1.rchild == &n2);
+
+	struct trie_node n3;
+	/* init node n3 */
+	n3.len = 16;
+	n3.lchild = NULL;
+	n3.rchild = NULL;
+	n3.parent = NULL;
+	n3.data = NULL;
+
+	lrtr_ip_str_to_addr("101.200.0.0", &n3.prefix);
+	trie_insert(&n1, &n3, 0);
+	lrtr_ip_str_to_addr("101.200.0.0", &addr);
+	lvl = 0;
+	result = trie_lookup(&n1, &addr, 16, &lvl);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&result->prefix, "101.200.0.0"));
+	assert(n1.lchild == &n3);
+
+	struct trie_node n4;
+	/* init node n4 */
+	n4.len = 24;
+	n4.lchild = NULL;
+	n4.rchild = NULL;
+	n4.parent = NULL;
+	n4.data = NULL;
+
+	lrtr_ip_str_to_addr("132.200.3.0", &n4.prefix);
+	trie_insert(&n1, &n4, 0);
+	lrtr_ip_str_to_addr("132.200.3.0", &addr);
+	lvl = 0;
+	result = trie_lookup(&n1, &addr, 24, &lvl);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&result->prefix, "132.200.3.0"));
+
+	assert(lrtr_ip_str_cmp(&n2.prefix, "132.200.0.0"));
+	assert(n2.len == 16);
+
+	assert(lrtr_ip_str_cmp(&n2.lchild->prefix, "132.200.3.0"));
+	assert(n2.lchild->len == 24);
+
+	assert(lrtr_ip_str_cmp(&n1.rchild->prefix, "132.200.0.0"));
+	assert(n1.rchild->len == 16);
+
+	assert(lrtr_ip_str_cmp(&n1.lchild->prefix, "101.200.0.0"));
+	assert(n1.lchild->len == 16);
+
+	lrtr_ip_str_to_addr("132.200.0.0", &addr);
+	lvl = 0;
+	result = trie_lookup(&n1, &addr, 16, &lvl);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&result->prefix, "132.200.0.0"));
+
+	lrtr_ip_str_to_addr("132.200.3.0", &addr);
+	lvl = 0;
+	result = trie_lookup(&n1, &addr, 16, &lvl);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&result->prefix, "132.200.0.0"));
+
+	lvl = 0;
+	lrtr_ip_str_to_addr("132.0.0.0", &addr);
+
+	bool found;
+	/* verify prefix 132.0.0.0/16 is not found */
+	result = trie_lookup_exact(&n1, &addr, 16, &lvl, &found);
+	assert(!found);
+
+	lvl = 0;
+	lrtr_ip_str_to_addr("132.200.3.0", &addr);
+	/* verify prefix 132.200.3.0/24 is found */
+	result = trie_lookup_exact(&n1, &addr, 24, &lvl, &found);
+	assert(found);
+	assert(lrtr_ip_str_cmp(&result->prefix, "132.200.3.0"));
+
+	result = trie_remove(&n1, &addr, 24, 0);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&n1.prefix, "100.200.0.0"));
+	assert(lrtr_ip_str_cmp(&n1.lchild->prefix, "101.200.0.0"));
+	assert(lrtr_ip_str_cmp(&n1.rchild->prefix, "132.200.0.0"));
+	assert(!n1.rchild->lchild);
+
+	lrtr_ip_str_to_addr("101.200.0.0", &addr);
+	result = trie_remove(&n1, &addr, 16, 0);
+	assert(result);
+	assert(lrtr_ip_str_cmp(&n1.prefix, "100.200.0.0"));
+	assert(!n1.lchild);
+
+	lrtr_ip_str_to_addr("100.200.0.0", &addr);
+	result = trie_remove(&n1, &addr, 16, 0);
+	assert(result);
+	assert(!n1.lchild);
+	assert(!n1.rchild);
+    assert(lrtr_ip_str_cmp(&n1.prefix, "132.200.0.0"));
+}
+
+int main(void)
+{
+	get_bits_testv4();
+	get_bits_testv6();
+	trie_test();
+	printf("Test successful\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_trie.c
+++ b/tests/test_trie.c
@@ -261,7 +261,7 @@ static void trie_test(void)
 	lvl = 0;
 	result = trie_lookup(&n1, &addr, 24, &lvl);
 	assert(result);
-	assert(lrtr_ip_str_cmp(&result->prefix, "132.200.3.0"));
+	assert(lrtr_ip_str_cmp(&result->prefix, "132.200.0.0"));
 
 	assert(lrtr_ip_str_cmp(&n2.prefix, "132.200.0.0"));
 	assert(n2.len == 16);
@@ -320,7 +320,7 @@ static void trie_test(void)
 	assert(result);
 	assert(!n1.lchild);
 	assert(!n1.rchild);
-    assert(lrtr_ip_str_cmp(&n1.prefix, "132.200.0.0"));
+    	assert(lrtr_ip_str_cmp(&n1.prefix, "132.200.0.0"));
 }
 
 int main(void)


### PR DESCRIPTION
This fixes #99 by using a trie instead of a lpfst. Using a trie, the lookup during validation will find all covering prefixes and check their ROAs.

In this patch the trie is the default data structure, to fall back on lpfst the user has to set "RTRLIB_USE_LPFST" in the main CMakeList.txt

