### PR TITLE
lpfst: fix validation

### DIFF
--- a/rtrlib/pfx/lpfst/lpfst-pfx.c
+++ b/rtrlib/pfx/lpfst/lpfst-pfx.c
@@ -320,10 +320,13 @@ int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason
     }
 
     while(!pfx_table_elem_matches(node->data, asn, prefix_len)) {
-        if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, lvl++, 1))) //post-incr lvl, lpfst_lookup is performed on child_nodes => parent lvl + 1
-            node = lpfst_lookup(node->lchild, prefix, prefix_len, &lvl);
-        else
-            node = lpfst_lookup(node->rchild, prefix, prefix_len, &lvl);
+	//post-incr lvl, lpfst_lookup is performed on child_nodes => parent lvl + 1
+        if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, lvl++, 1))) {
+	    node = lpfst_lookup_fallback(node->lchild, node->rchild, prefix, prefix_len, &lvl);
+	}
+	else {
+	    node = lpfst_lookup_fallback(node->rchild, node->lchild, prefix, prefix_len, &lvl);
+	}
 
         if(node == NULL) {
             pthread_rwlock_unlock(&pfx_table->lock);

--- a/rtrlib/pfx/lpfst/lpfst-pfx.c
+++ b/rtrlib/pfx/lpfst/lpfst-pfx.c
@@ -13,6 +13,13 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include <stdio.h>
+#include <sys/types.h>
+#include <assert.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include "rtrlib/lib/ipv6.h"
+
 struct data_elem {
     uint32_t asn;
     uint8_t max_len;
@@ -318,14 +325,23 @@ int pfx_table_validate_r(struct pfx_table *pfx_table, struct pfx_record **reason
             return PFX_ERROR;
         }
     }
-
+    char ip[INET6_ADDRSTRLEN];
+    lrtr_ip_addr_to_str(&node->prefix, ip, INET6_ADDRSTRLEN);
+    fprintf(stderr, "pfx_table_validate_r: found prefix %s/%d\n", ip, node->len);
     while(!pfx_table_elem_matches(node->data, asn, prefix_len)) {
+	//char ip[INET6_ADDRSTRLEN];
+   	lrtr_ip_addr_to_str(&node->prefix, ip, INET6_ADDRSTRLEN);
+	fprintf(stderr, "pfx_table_validate_r: found prefix %s/%d\n", ip, node->len);
 	//post-incr lvl, lpfst_lookup is performed on child_nodes => parent lvl + 1
         if(lrtr_ip_addr_is_zero(lrtr_ip_addr_get_bits(prefix, lvl++, 1))) {
-	    node = lpfst_lookup_fallback(node->lchild, node->rchild, prefix, prefix_len, &lvl);
+		fprintf(stderr, "pfx_table_validate_r: look left\n");
+	    	//node = lpfst_lookup_fallback(node->lchild, node->rchild, prefix, prefix_len, &lvl);
+		node = lpfst_lookup(node->lchild, prefix, prefix_len, &lvl);
 	}
 	else {
-	    node = lpfst_lookup_fallback(node->rchild, node->lchild, prefix, prefix_len, &lvl);
+		fprintf(stderr, "pfx_table_validate_r: look right\n");
+	    	//node = lpfst_lookup_fallback(node->rchild, node->lchild, prefix, prefix_len, &lvl);
+	    	node = lpfst_lookup(node->rchild, prefix, prefix_len, &lvl);
 	}
 
         if(node == NULL) {

--- a/rtrlib/pfx/lpfst/lpfst.c
+++ b/rtrlib/pfx/lpfst/lpfst.c
@@ -89,8 +89,7 @@ struct lpfst_node *lpfst_lookup(const struct lpfst_node *root,
 		if ((is_left_child(prefix, *lvl) && root->lchild) ||
 		    (!is_left_child(prefix, *lvl) && !root->rchild)) {
 			root = root->lchild;
-		}
-		else {
+		} else {
 			root = root->rchild;
 		}
 
@@ -107,7 +106,9 @@ struct lpfst_node *lpfst_lookup_fallback(const struct lpfst_node *first,
 {
 	unsigned int tmp_lvl = *lvl;
 	struct lpfst_node *tmp_node;
-	if((tmp_node = lpfst_lookup(first, prefix, mask_len, lvl)))
+
+	tmp_node = lpfst_lookup(first, prefix, mask_len, lvl);
+	if (tmp_node)
 		return (struct lpfst_node *)tmp_node;
 	*lvl = tmp_lvl;
 	return lpfst_lookup(second, prefix, mask_len, lvl);

--- a/rtrlib/pfx/lpfst/lpfst.c
+++ b/rtrlib/pfx/lpfst/lpfst.c
@@ -86,14 +86,31 @@ struct lpfst_node *lpfst_lookup(const struct lpfst_node *root,
 							     root->len)))
 			return (struct lpfst_node *)root;
 
-		if (is_left_child(prefix, *lvl))
+		if ((is_left_child(prefix, *lvl) && root->lchild) ||
+		    (!is_left_child(prefix, *lvl) && !root->rchild)) {
 			root = root->lchild;
-		else
+		}
+		else {
 			root = root->rchild;
+		}
 
 		(*lvl)++;
 	}
 	return NULL;
+}
+
+struct lpfst_node *lpfst_lookup_fallback(const struct lpfst_node *first,
+					 const struct lpfst_node *second,
+					 const struct lrtr_ip_addr *prefix,
+					 const uint8_t mask_len,
+					 unsigned int *lvl)
+{
+	unsigned int tmp_lvl = *lvl;
+	struct lpfst_node *tmp_node;
+	if((tmp_node = lpfst_lookup(first, prefix, mask_len, lvl)))
+		return (struct lpfst_node *)tmp_node;
+	*lvl = tmp_lvl;
+	return lpfst_lookup(second, prefix, mask_len, lvl);
 }
 
 struct lpfst_node *lpfst_lookup_exact(struct lpfst_node *root_node,

--- a/rtrlib/pfx/lpfst/lpfst.h
+++ b/rtrlib/pfx/lpfst/lpfst.h
@@ -57,6 +57,25 @@ struct lpfst_node *lpfst_lookup(const struct lpfst_node *root_node,
 				const uint8_t mask_len, unsigned int *level);
 
 /**
+ * @brief Searches for the node with the longest prefix, matching the passed ip
+ *	  prefix and prefix length.
+ * @param[in] first_node Node were the lookup process starts.
+ * @param[in] second_node Fallback node, if lookup on first node fails.
+ * @param[in] lrtr_ip_addr IP-Prefix.
+ * @param[in] mask_len Length of the network mask of the prefix.
+ * @param[in,out] level of the the node root in the tree. Is set to the level of
+ *		  the node that is returned.
+ * @returns The lpfst_node with the longest prefix in the tree matching the
+ *	    passed ip prefix and prefix length.
+ * @returns NULL if no node that matches the passed prefix and prefix length
+ *	    could be found.
+ */
+struct lpfst_node *lpfst_lookup_fallback(const struct lpfst_node *first_node,
+					 const struct lpfst_node *second_node,
+					 const struct lrtr_ip_addr *prefix,
+					 const uint8_t mask_len,
+					 unsigned int *level);
+/**
  * @brief Search for a node with the same prefix and prefix length.
  * @param[in] root_node Node were the lookup process starts.
  * @param[in] lrtr_ip_addr IP-Prefix.

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -35,6 +35,9 @@ const struct test_validity_query queries[] = {
 	{"2001:7fb:fd03::",	48, 12654, BGP_PFXV_STATE_INVALID},
 	{"84.205.83.0",		24, 12654, BGP_PFXV_STATE_NOT_FOUND},
 	{"2001:7fb:ff03::",	48, 12654, BGP_PFXV_STATE_NOT_FOUND},
+	/* verify issue #99 solved */
+	{"1.9.0.0",		16, 4788,  BGP_PFXV_STATE_VALID},
+	{"1.9.23.0",		24, 4788,  BGP_PFXV_STATE_VALID},
 	{NULL, 0, 0, 0}
 };
 

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -426,6 +426,27 @@ static void pfx_table_test(void)
 				  &res) == PFX_SUCCESS);
 	assert(res == BGP_PFXV_STATE_VALID);
 
+	assert(lrtr_ip_str_to_addr("255.0.0.0", &pfx.prefix) == 0);
+	pfx.min_len = 24;
+	pfx.max_len = 24;
+	pfx.asn = 300;
+	assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
+	assert(lrtr_ip_str_to_addr("128.0.0.0", &pfx.prefix) == 0);
+	pfx.min_len = 1;
+	pfx.max_len = 24;
+	pfx.asn = 400;
+	assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
+	assert(lrtr_ip_str_to_addr("128.0.0.0", &pfx.prefix) == 0);
+	assert(pfx_table_validate_r(&pfxt, &r, &r_len, 400,
+				    &pfx.prefix, 24,
+				    &res) == PFX_SUCCESS);
+	assert(res == BGP_PFXV_STATE_VALID);
+	assert(lrtr_ip_str_to_addr("255.0.0.0", &pfx.prefix) == 0);
+	assert(pfx_table_validate_r(&pfxt, &r, &r_len, 400,
+				    &pfx.prefix, 24,
+				    &res) == PFX_SUCCESS);
+	assert(res == BGP_PFXV_STATE_VALID);
+
 	/* cleanup: free record and table */
 	free(r);
 	pfx_table_free(&pfxt);

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -420,7 +420,7 @@ static void pfx_table_test(void)
 				  &pfx.prefix, 24,
 				  &res) == PFX_SUCCESS);
 	assert(res == BGP_PFXV_STATE_VALID);
-	
+
 	assert(pfx_table_validate(&pfxt, 200,
 				  &pfx.prefix, 24,
 				  &res) == PFX_SUCCESS);

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -403,6 +403,29 @@ static void pfx_table_test(void)
 	assert(res == BGP_PFXV_STATE_INVALID);
 	assert(r_len == 3);
 
+	/* */
+	assert(lrtr_ip_str_to_addr("10.100.0.0", &pfx.prefix) == 0);
+	pfx.min_len = 16;
+	pfx.max_len = 24;
+	pfx.asn = 100;
+	assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
+
+	assert(lrtr_ip_str_to_addr("10.100.200.0", &pfx.prefix) == 0);
+	pfx.min_len = 24;
+	pfx.max_len = 24;
+	pfx.asn = 200;
+	assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
+
+	assert(pfx_table_validate(&pfxt, 100,
+				  &pfx.prefix, 24,
+				  &res) == PFX_SUCCESS);
+	assert(res == BGP_PFXV_STATE_VALID);
+	
+	assert(pfx_table_validate(&pfxt, 200,
+				  &pfx.prefix, 24,
+				  &res) == PFX_SUCCESS);
+	assert(res == BGP_PFXV_STATE_VALID);
+
 	/* cleanup: free record and table */
 	free(r);
 	pfx_table_free(&pfxt);


### PR DESCRIPTION
This is an alternative to #103 for issue #99, but it fixes the currently used prefix table struct and algorithm.

It also extends `test_pfx` and `test_live_validation` with tests to verify validation is correct.