### PR TITLE
cmake: search LIBSSH_INCLUDE, LIBSSH_LIBRARY paths for libssh files

### DIFF
--- a/cmake/modules/FindLibSSH.cmake
+++ b/cmake/modules/FindLibSSH.cmake
@@ -28,6 +28,7 @@ if (NOT NoSSH)
         NAMES
           libssh/libssh.h
         PATHS
+          ${LIBSSH_INCLUDE}
           /usr/include
           /usr/local/include
           /opt/local/include
@@ -41,6 +42,7 @@ if (NOT NoSSH)
           ssh
           libssh
         PATHS
+          ${LIBSSH_LIBRARY}
           /usr/lib
           /usr/local/lib
           /opt/local/lib


### PR DESCRIPTION
The README file mentions that the path to the libssh library can
be specified by defining the LIBSSH_INCLUDE and LIBSSH_LIBRARY variables
but CMAKE wasn't searching in those paths for libssh.

Add those variables to the directory search list for libssh include and
lib files.