### PR TITLE
rtr_mgr: fix memory leak in rtr_mgr_get_spki

### DIFF
--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -424,11 +424,11 @@ inline int rtr_mgr_validate(struct rtr_mgr_config *config,
 inline int rtr_mgr_get_spki(struct rtr_mgr_config *config,
 			    const uint32_t asn,
 			    uint8_t *ski,
-			    struct spki_record *result,
+			    struct spki_record **result,
 			    unsigned int *result_count)
 {
 	return spki_table_get_all(config->groups[0].sockets[0]->spki_table,
-				  asn, ski, &result, result_count);
+				  asn, ski, result, result_count);
 }
 
 void rtr_mgr_stop(struct rtr_mgr_config *config)

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -192,7 +192,7 @@ int rtr_mgr_validate(struct rtr_mgr_config *config,
 int rtr_mgr_get_spki(struct rtr_mgr_config *config,
 		     const uint32_t asn,
 		     uint8_t *ski,
-		     struct spki_record *result,
+		     struct spki_record **result,
 		     unsigned int *result_count);
 
 /**


### PR DESCRIPTION
rtr_mgr_get_spki passes a pointer to a variable that lives in the stack
frame of itself as pointer to pointer to spki_table_get_all.
spki_table_get_all treats this argument as pointer to an array and may
realloc it at will. But since the pointer points to a value on the stack
of rtr_mgr_get_spki it is lost when rtr_mgr_get_spki returns. Thus
leading to a memory leak and causing the function to not actually
returning the result, rendering it useless.

This change technically breaks the api, but since this function was not
functional anyway it should not be a problem.

coverity id: 1420793