### PR TITLE
rtr_mgr: Fix memory leak in rtr_mgr_init

### DIFF
--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -304,6 +304,11 @@ int rtr_mgr_init(struct rtr_mgr_config **config_out,
 		goto err;
 	}
 
+	if (groups_len == 0) {
+		MGR_DBG1("Error Empty rtr_mgr_group array");
+		goto err;
+	}
+
 	config->len = groups_len;
 	config->groups = malloc(groups_len * sizeof(*groups));
 	if (!config->groups)
@@ -370,6 +375,7 @@ err:
 	free(config->groups);
 	free(config);
 	config = NULL;
+	*config_out = NULL;
 	return err_code;
 }
 

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -90,7 +90,7 @@ struct rtr_mgr_config {
  *		     associated with one rtr socket. The preference values must
  *		     be unique in the group array. More than one rtr_mgr_group
  *		     with the same preference value isn't allowed.
- * @param[in] groups_len Number of elements in the groups array.
+ * @param[in] groups_len Number of elements in the groups array. Must be >= 1.
  * @param[in] refresh_interval Interval in seconds between serial queries that
  *			     are sent to the server. Must be >= 1 and <=
  *			     86400s (1d), recommended default is 3600s (1h).


### PR DESCRIPTION
Due to missing validation of the groups_len parameter in rtr_mgr_init
memory allocated for the pfx and spki tables could leak. In the unlikely
case that groups_len is zero no pointer to it would exist after the function
returns. Usually they are passed to rtr_init and stored in the
rtr_sockets, but that does not happen when groups_len is null, since
there is no socket to initialize in that case.

Furthermore this commit fixes a bug in the cleanup which caused a freed
pointer to be returned through config_out, in case of an error
situation.

coverity ids: 1420791 1420783