### PR TITLE
rtr_mgr: fix uninitialized pointer read in rtr_mgr_init

### DIFF
--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -293,27 +293,27 @@ int rtr_mgr_init(struct rtr_mgr_config **config_out,
 	struct pfx_table *pfxt = NULL;
 	struct spki_table *spki_table = NULL;
 	struct rtr_mgr_config *config = NULL;
-
 	*config_out = NULL;
-	*config_out = config = malloc(sizeof(*config));
-	if (!config)
-		return RTR_ERROR;
-
-	if (pthread_mutex_init(&config->mutex, NULL) != 0) {
-		MGR_DBG1("Mutex initialization failed");
-		goto err;
-	}
 
 	if (groups_len == 0) {
 		MGR_DBG1("Error Empty rtr_mgr_group array");
-		goto err;
+		return RTR_ERROR;
 	}
+
+	*config_out = config = malloc(sizeof(*config));
+	if (!config)
+		return RTR_ERROR;
 
 	config->len = groups_len;
 	config->groups = malloc(groups_len * sizeof(*groups));
 	if (!config->groups)
 		goto err;
 	memcpy(config->groups, groups, groups_len * sizeof(*groups));
+
+	if (pthread_mutex_init(&config->mutex, NULL) != 0) {
+		MGR_DBG1("Mutex initialization failed");
+		goto err;
+	}
 
 	/* sort array in asc preference order */
 	qsort(config->groups, config->len,


### PR DESCRIPTION
This fixes a bug introduced by 7c6ba5ccf8791a954d31a094bddc9858c381df84. Due to the way cleanup on
error is handled an uninitialized pointer is passed to free if the
execution jumps to err before config->groups is initialized. This
can happen when group_len is zero or when pthread_mutex_init fails.

This commit fixes this by reordering the instructions and returning
early if group_len is zero, because config->groups cannot be initialized
before group_len is validated. The other approach, using different error
labels, would unnecessarily complicate error handling.

coverity id: 1434592