### PR TITLE
Add coverity scan on branch coverity_scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,7 @@ addons:
     branch_pattern: coverity_scan
 
 script:
-    - scripts/cppcheck.sh
-    - scripts/check-coding-style.sh
-    - cmake -D CMAKE_BUILD_TYPE=NoSSH .
-    - make
-    - make test
-    - make clean
-    - cmake -D CMAKE_BUILD_TYPE=Release -DENABLE_COVERAGE=On -DUNIT_TESTING=On .
-    - make
-    - make test
-    - make gcov
+  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then scripts/travis.sh; fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,22 @@ install:
     - sudo make install
     - popd && popd
 
+env:
+  global:
+   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+   #   via the "travis encrypt" command using the project repo's public key
+   - secure: "esfY0Q8S2UMLS3V0B/dSqIFQYChACXwJRBmtHTh87dvYMIS9NC2Bv/CVA7UAVIPSP2S1Az2TW1uNtXg3Xa5FjRY/25Zzls3jdeC83HtH6JPd+Hu55V7kq9j3P5ekPr6N7J+bwQosWISGgOsMkh1sbfgtLqsWRCabdLyIzBQpQfuvpP/7MZkL/QeghDOP1WW9I9MFib6w2drcxyI+QItPZ/xTcZc/XIeuDCLynqH9Fzyvy0FnhR1M5xJf7VCDa1whR7l3N2wLZvYtoByMp9wIS8RctW6dPWquQ7vpqzLdMm9fz7jpbrX0WOTUApXu6pPtP1IJAcBvyzmq9NE7ypxha/reJM8ESINg5Gb8MvTHwUKmf1aTLp8DqqjF6hhMRMjAHG8cCnbry+AdA5gpfSz5BLsfe4OvIpV3XiladRTY9vBuv5XMgJWq+r/ONaTURrd8bNZqW+qcck+yfPMVyzQKqo/xkzPBApcSseoain/loE4vhlRo73SqByrTYyt+qiJd22zBBFEpZGSHtCpF7XKrxj9tkyNteSUReXqxH4hQfnTQMKDbtV/A1Ki9p40NIpj+EGeSsTULZBv8FKo4OJ5odq+EkEig/GEgB55ZB+1j7A7oXo5u/UDKDegIJ5DfbJ+fu0xN543cmV4X0USBQ2jgYiHhFhpmRwhv75O3iNsbEWM="
+
+addons:
+  coverity_scan:
+    project:
+      name: "rtrlib/rtrlib"
+      description: "Build submitted via Travis CI"
+    notification_email: rtrlib@googlegroups.com
+    build_command_prepend: "cmake -D CMAKE_BUILD_TYPE=Release -DENABLE_COVERAGE=On -DUNIT_TESTING=On ."
+    build_command:   "make"
+    branch_pattern: coverity_scan
+
 script:
     - scripts/cppcheck.sh
     - scripts/check-coding-style.sh

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+function run_command {
+	eval $@
+
+	ret=$?
+	if [ $ret != 0 ]; then
+		colour=$RED
+	else
+		colour=$GREEN
+	fi
+	echo -e "\n${colour}The command \"$@\" exited with $ret.$NC\n\n"
+}
+
+run_command scripts/cppcheck.sh
+run_command scripts/check-coding-style.sh
+run_command cmake -D CMAKE_BUILD_TYPE=NoSSH .
+run_command make
+run_command make test
+run_command make clean
+run_command cmake -D CMAKE_BUILD_TYPE=Release -DENABLE_COVERAGE=On -DUNIT_TESTING=On .
+run_command make
+run_command make test
+run_command make gcov

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
coverity is a static build analysis tool. Access to the results may be requested on https://scan.coverity.com/projects/rtrlib-rtrlib, but is restricted to project members.

Fixes #62 