### PR TITLE
lib: fix ip docu

### DIFF
--- a/rtrlib/lib/ipv4.h
+++ b/rtrlib/lib/ipv4.h
@@ -77,11 +77,11 @@ bool lrtr_ipv4_addr_equal(const struct lrtr_ipv4_addr *a,
 
 /**
  * @ingroup util_h[{
- * @brief Converts the passed IPv4 address byte order with the given function.
+ * @brief Converts the passed IPv4 address to given byte order.
  *
- * @param[in] src ipv4 address in source byte order.
- * @param[out] dest ipv4 address in target byte order.
- * @param[in] convert_fp Pointer to the function used for conversion.
+ * @param[in] src       IPv4 address in source byte order.
+ * @param[out] dest     IPv4 address in target byte order.
+ * @param[in] tbo       Target byte order for address conversion.
  * }
  */
 void lrtr_ipv4_addr_convert_byte_order(const uint32_t src, uint32_t *dest,

--- a/rtrlib/lib/ipv6.h
+++ b/rtrlib/lib/ipv6.h
@@ -63,14 +63,14 @@ int lrtr_ipv6_str_to_addr(const char *a, struct lrtr_ipv6_addr *ip);
 
 /**
  * @ingroup util_h[{
- * Converts the passed IPv6 address byte order with the given function.
- * @param[in] src Pointer to a uint32_t array storing a ipv6 address in source byte order.
- * @param[out] dest Pointer a uint32_t array that will be used to store the ipv6 addr in target byte order.
- * @param[in] convert_fp Pointer to the function used for conversion
+ * @brief Converts the passed IPv6 address to given byte order.
+ *
+ * @param[in] src 	IPv6 address (uint32_t array) in source byte order.
+ * @param[out] dest 	IPv6 address (uint32_t array) in target byte order.
+ * @param[in] tbo	Target byte order for address conversion.
  * }
 */
-void lrtr_ipv6_addr_convert_byte_order(const uint32_t *src,
-                                       uint32_t *dest,
+void lrtr_ipv6_addr_convert_byte_order(const uint32_t *src, uint32_t *dest,
 				       const enum target_byte_order tbo);
 
 #endif

--- a/rtrlib/lib/ipv6.h
+++ b/rtrlib/lib/ipv6.h
@@ -18,59 +18,73 @@
 
 /**
  * @brief Struct holding an IPv6 address in host byte order.
- * @param addr The IPv6 address.
  */
 struct lrtr_ipv6_addr {
-    uint32_t addr[4];
+	uint32_t addr[4];	/**< The IPv6 address. */
 };
 
 /**
- * Compares two ipv6_addr structs
- * @param[in] a ipv6_addr
- * @param[in] b ipv6_addr
+ * @brief Compares two lrtr_ipv6_addr structs
+ *
+ * @param[in] a		lrtr_ipv6_addr
+ * @param[in] b		lrtr_ipv6_addr
+ *
  * @return true if a == b
  * @return false if a != b
-*/
-bool lrtr_ipv6_addr_equal(const struct lrtr_ipv6_addr *a, const struct lrtr_ipv6_addr *b);
+ */
+bool lrtr_ipv6_addr_equal(const struct lrtr_ipv6_addr *a,
+			  const struct lrtr_ipv6_addr *b);
 
 /**
- * @brief Extracts quantity bits from a ip address. The bit with the highest
- * significance is bit 0. All bits that aren't in the specified range will be 0.
- * @param[in] val ipv6_addr
- * @param[in] first_bit Position of the first bit that is extracted, inclusive
- * @param[in] quantity How many bits will be extracted.
- * @returns An ipv6_addr, where all bits that aren't in the specified range are set to 0.
-*/
-struct lrtr_ipv6_addr lrtr_ipv6_get_bits(const struct lrtr_ipv6_addr *val, const uint8_t first_bit, const uint8_t quantity);
+ * @brief Extracts quantity bits from an IPv6 address.
+ *
+ * The bit with the highest significance is bit 0. All bits that aren't in the
+ * specified range will be 0.
+ *
+ * @param[in] val	ipv6_addr
+ * @param[in] first_bit Position of the first bit that is extracted, inclusive.
+ * @param[in] quantity	How many bits will be extracted.
+ *
+ * @returns ipv6_addr, with all bits not in specified range set to 0.
+ */
+struct lrtr_ipv6_addr lrtr_ipv6_get_bits(const struct lrtr_ipv6_addr *val,
+					 const uint8_t first_bit,
+					 const uint8_t quantity);
 
 /**
- * Converts the passed ipv6_addr to string representation
- * @param[in] ip ipv6_addr
- * @param[out] str Pointer to a string buffer must be at least INET6_ADDRSTRLEN bytes long.
+ * @brief Converts the passed ipv6_addr to string representation
+ *
+ * @param[in] ip_addr	Pointer to an IPv6 address
+ * @param[out] str	Pointer to string buf, at least INET6_ADDRSTRLEN bytes.
+ * @param[in] len	Length of string buffer @p str
+ *
  * @result 0 on success
  * @result -1 on error
-*/
-int lrtr_ipv6_addr_to_str(const struct lrtr_ipv6_addr *ip_addr, char *b, const unsigned int len);
+ */
+int lrtr_ipv6_addr_to_str(const struct lrtr_ipv6_addr *ip,
+			  char *str, const unsigned int len);
 
 /**
- * Converts the passed IPv6 address in string representation to an ipv6_addr struct.
- * @param[in] str Pointer to a string buffer
- * @param[out] ip ipv6_addr
+ * @brief Converts the passed IPv6 address string in to lrtr_ipv6_addr struct.
+ *
+ * @param[in] str	Pointer to a string buffer
+ * @param[out] ip	Pointer to lrtr_ipv6_addr
+ *
  * @result 0 on success
  * @result -1 on error
-*/
-int lrtr_ipv6_str_to_addr(const char *a, struct lrtr_ipv6_addr *ip);
+ */
+int lrtr_ipv6_str_to_addr(const char *str, struct lrtr_ipv6_addr *ip);
 
 /**
- * @ingroup util_h[{
+ * @ingroup util_h
+ * @{
  * @brief Converts the passed IPv6 address to given byte order.
  *
- * @param[in] src 	IPv6 address (uint32_t array) in source byte order.
- * @param[out] dest 	IPv6 address (uint32_t array) in target byte order.
+ * @param[in] src	IPv6 address (uint32_t array) in source byte order.
+ * @param[out] dest	IPv6 address (uint32_t array) in target byte order.
  * @param[in] tbo	Target byte order for address conversion.
- * }
-*/
+ */
 void lrtr_ipv6_addr_convert_byte_order(const uint32_t *src, uint32_t *dest,
 				       const enum target_byte_order tbo);
-
-#endif
+/** @} */
+#endif /* LRTR_IPV6_H */

--- a/scripts/check-coding-files.txt
+++ b/scripts/check-coding-files.txt
@@ -4,6 +4,7 @@ rtrlib/lib/convert_byte_order.h
 rtrlib/lib/convert_byte_order.c
 rtrlib/lib/ipv4.c
 rtrlib/lib/ipv4.h
+rtrlib/lib/ipv6.h
 rtrlib/pfx/trie/trie.h
 rtrlib/pfx/trie/trie.c
 tests/test_ht_spkitable.c


### PR DESCRIPTION
fixes doxygen documentation in `lib/ipv4.h` and `lib/ipv6.h` and also adapt coding style for the latter.