### PR TITLE
Dynamic adding and removing of rtr_mgr_groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,8 @@ ADD_TEST(test_ipaddr tests/test_ipaddr)
 
 ADD_TEST(test_getbits tests/test_getbits)
 
+ADD_TEST(test_dynamic_groups tests/test_dynamic_groups)
+
 #install lib
 set (RTRLIB_VERSION_MAJOR 0)
 set (RTRLIB_VERSION_MINOR 4)

--- a/rtrlib/lib/alloc_utils.c
+++ b/rtrlib/lib/alloc_utils.c
@@ -7,6 +7,7 @@
  * Website: http://rtrlib.realmv6.org/
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -43,9 +44,10 @@ inline void *lrtr_realloc(void *ptr, size_t size)
 
 char *lrtr_strdup(const char *string)
 {
+	assert(string);
+
 	size_t length = strlen(string) + 1;
 	char *new_string = lrtr_malloc(length);
 
-	return (new_string ? memcpy(new_string, string, length) : NULL);
-
+	return new_string ? memcpy(new_string, string, length) : NULL;
 }

--- a/rtrlib/lib/alloc_utils.c
+++ b/rtrlib/lib/alloc_utils.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "alloc_utils.h"
 
@@ -38,4 +39,13 @@ inline void lrtr_free(void *ptr)
 inline void *lrtr_realloc(void *ptr, size_t size)
 {
 	return REALLOC_PTR(ptr, size);
+}
+
+char *lrtr_strdup(const char *string)
+{
+	size_t length = strlen(string) + 1;
+	char *new_string = lrtr_malloc(length);
+
+	return (new_string ? memcpy(new_string, string, length) : NULL);
+
 }

--- a/rtrlib/lib/alloc_utils.h
+++ b/rtrlib/lib/alloc_utils.h
@@ -36,10 +36,11 @@ void *lrtr_realloc(void *ptr, size_t size);
 
 /**
  * @brief Duplicates a string
+ * @pre string != NULL
  * @param[in] string
  * @returns Duplicated string
  * @returns NULL on error
  */
-char *lrtr_strdup (const char *string);
+char *lrtr_strdup(const char *string);
 
 #endif

--- a/rtrlib/lib/alloc_utils.h
+++ b/rtrlib/lib/alloc_utils.h
@@ -34,4 +34,12 @@ void lrtr_free(void *ptr);
 
 void *lrtr_realloc(void *ptr, size_t size);
 
+/**
+ * @brief Duplicates a string
+ * @param[in] string
+ * @returns Duplicated string
+ * @returns NULL on error
+ */
+char *lrtr_strdup (const char *string);
+
 #endif

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -19,6 +19,7 @@
 #include "rtrlib/lib/log.h"
 #include "rtrlib/spki/hashtable/ht-spkitable.h"
 
+#define MGR_DBG1(a) lrtr_dbg("RTR_MGR: " a)
 #define TEMPORARY_PDU_STORE_INCREMENT_VALUE 100
 #define MAX_SUPPORTED_PDU_TYPE 10
 
@@ -202,8 +203,12 @@ void rtr_change_socket_state(struct rtr_socket *rtr_socket, const enum rtr_socke
         return;
 
     rtr_socket->state = new_state;
+    if (new_state == RTR_SHUTDOWN) {
+        MGR_DBG1("Calling rtr_mgr_cb with RTR_SHUTDOWN");
+    }    
+
     if (rtr_socket->connection_state_fp != NULL)
-        rtr_socket->connection_state_fp(rtr_socket, new_state,rtr_socket->connection_state_fp_param);
+        rtr_socket->connection_state_fp(rtr_socket, new_state, rtr_socket->connection_state_fp_param_config, rtr_socket->connection_state_fp_param_group);
 }
 
 static void rtr_pdu_convert_header_byte_order(void *pdu, const enum target_byte_order target_byte_order)

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -27,11 +27,14 @@ static const char * const mgr_str_status[] = {
 	[RTR_MGR_ERROR] = "RTR_MGR_ERROR",
 };
 
-static int rtr_mgr_find_group(const struct rtr_mgr_config *config,
-			      const struct rtr_socket *sock,
-			      unsigned int *ind);
+static struct rtr_mgr_group *rtr_mgr_find_group(struct rtr_mgr_config *config,
+						const struct rtr_socket *sock);
 static int rtr_mgr_config_cmp(const void *a, const void *b);
-static bool rtr_mgr_config_status_is_synced(const struct rtr_mgr_group *config);
+static int rtr_mgr_config_cmp_tommy(const void *a, const void *b);
+static bool rtr_mgr_config_status_is_synced(const struct rtr_mgr_group *group);
+static void rtr_mgr_cb(const struct rtr_socket *sock,
+		       const enum rtr_socket_state state,
+		       void *data_config, void *data_group);
 
 static void set_status(const struct rtr_mgr_config *conf,
 		       struct rtr_mgr_group *group,
@@ -59,21 +62,48 @@ static int rtr_mgr_start_sockets(struct rtr_mgr_group *group)
 	return RTR_SUCCESS;
 }
 
-int rtr_mgr_find_group(const struct rtr_mgr_config *config,
-		       const struct rtr_socket *sock,
-		       unsigned int *ind)
+static int rtr_mgr_init_sockets(struct rtr_mgr_group *group,
+				struct rtr_mgr_config *config,
+				const unsigned int refresh_interval,
+				const unsigned int expire_interval,
+				const unsigned int retry_interval)
 {
-	for (unsigned int i = 0; i < config->len; i++) {
-		for (unsigned int j = 0;
-		     j < config->groups[i].sockets_len; j++) {
-			if (config->groups[i].sockets[j] == sock) {
-				*ind = i;
-				return RTR_SUCCESS;
+	for (unsigned int i = 0; i < group->sockets_len; i++) {
+		enum rtr_rtvals err_code = rtr_init(group->sockets[i], NULL,
+						    config->pfx_table,
+						    config->spki_table,
+						    refresh_interval,
+						    expire_interval,
+						    retry_interval,
+						    rtr_mgr_cb, config, group);
+		if (err_code)
+			return err_code;
+	}
+	return RTR_SUCCESS;
+}
+
+static struct rtr_mgr_group *rtr_mgr_find_group(struct rtr_mgr_config *config,
+						const struct rtr_socket *sock)
+{
+	tommy_node *node;
+	struct rtr_mgr_group_node *group_node;
+
+	pthread_mutex_lock(&config->mutex);
+	node  = tommy_list_head(&config->groups);
+
+	while (node) {
+		group_node = node->data;
+		for (unsigned int j = 0; j < group_node->group->sockets_len;
+									 j++) {
+			if (group_node->group->sockets[j] == sock) {
+				pthread_mutex_unlock(&config->mutex);
+				return group_node->group;
 			}
 		}
+	node = node->next;
 	}
-	MGR_DBG1("Error couldn't find a wanted rtr_socket in rtr_mgr_config");
-	return RTR_ERROR;
+	pthread_mutex_unlock(&config->mutex);
+	return NULL;
 }
 
 bool rtr_mgr_config_status_is_synced(const struct rtr_mgr_group *group)
@@ -91,135 +121,170 @@ bool rtr_mgr_config_status_is_synced(const struct rtr_mgr_group *group)
 
 static void rtr_mgr_close_less_preferable_groups(const struct rtr_socket *sock,
 						 struct rtr_mgr_config *config,
-						 unsigned int my_group_idx)
+						 struct rtr_mgr_group *group)
 {
-	for (unsigned int i = 0; i < config->len; i++) {
-		struct rtr_mgr_group cg = config->groups[i];
+	struct rtr_mgr_group_node *group_node;
+	struct rtr_mgr_group *current_group;
 
-		if ((cg.status != RTR_MGR_CLOSED) && (i != my_group_idx) &&
-		    (cg.preference > config->groups[my_group_idx].preference)) {
-			for (unsigned int j = 0; j < cg.sockets_len; j++) {
-				pthread_mutex_unlock(&config->mutex);
-				rtr_stop(cg.sockets[j]);
-				pthread_mutex_lock(&config->mutex);
+	pthread_mutex_lock(&config->mutex);
+	tommy_node *node = tommy_list_head(&config->groups);
+
+	while (node) {
+		group_node = node->data;
+		current_group = group_node->group;
+		if ((current_group->status != RTR_MGR_CLOSED) &&
+		    (current_group != group) &&
+		    (current_group->preference > group->preference)) {
+			for (unsigned int j = 0;
+				j < current_group->sockets_len; j++) {
+				rtr_stop(current_group->sockets[j]);
 			}
-			set_status(config, &cg, RTR_MGR_CLOSED, sock);
+			set_status(config, current_group, RTR_MGR_CLOSED, sock);
 		}
+	node = node->next;
 	}
+	pthread_mutex_unlock(&config->mutex);
 }
 
-static struct rtr_mgr_group
-*get_best_inactive_rtr_mgr_group(struct rtr_mgr_config *config,
-				 unsigned int my_group_idx)
+static struct rtr_mgr_group *get_best_inactive_rtr_mgr_group(
+						struct rtr_mgr_config *config,
+						struct rtr_mgr_group *group)
 {
-	/* groups are sorted by preference */
-	for (int i = 0; i < config->len; i++) {
-		if ((i != my_group_idx) &&
-		    (config->groups[i].status == RTR_MGR_CLOSED))
-			return &config->groups[i];
+	struct rtr_mgr_group_node *group_node;
+	struct rtr_mgr_group *current_group;
+
+	pthread_mutex_lock(&config->mutex);
+	tommy_node *node = tommy_list_head(&config->groups);
+
+	while (node) {
+		group_node = node->data;
+		current_group = group_node->group;
+			if ((current_group != group) &&
+			    (current_group->status == RTR_MGR_CLOSED)) {
+				pthread_mutex_unlock(&config->mutex);
+				return current_group;
+			}
+		node = node->next;
 	}
+		pthread_mutex_unlock(&config->mutex);
 	return NULL;
 }
 
 static bool is_some_rtr_mgr_group_established(struct rtr_mgr_config *config)
 {
-	for (int i = 0; i < config->len; i++) {
-		if (config->groups[i].status == RTR_MGR_ESTABLISHED)
+	struct rtr_mgr_group_node *group_node;
+
+	pthread_mutex_lock(&config->mutex);
+	tommy_node *node = tommy_list_head(&config->groups);
+
+	while (node) {
+		group_node = node->data;
+		if (group_node->group->status == RTR_MGR_ESTABLISHED) {
+			pthread_mutex_unlock(&config->mutex);
 			return true;
+		}
+		node = node->next;
 	}
+	pthread_mutex_unlock(&config->mutex);
 	return false;
 }
 
 static inline void _rtr_mgr_cb_state_shutdown(const struct rtr_socket *sock,
 					      struct rtr_mgr_config *config,
-					      unsigned int ind)
+					      struct rtr_mgr_group *group)
 {
 	bool all_down = true;
 
-	for (unsigned int i = 0; i < config->groups[ind].sockets_len; i++) {
-		if (config->groups[ind].sockets[i]->state != RTR_SHUTDOWN) {
+	for (unsigned int i = 0; i < group->sockets_len; i++) {
+		if (group->sockets[i]->state != RTR_SHUTDOWN) {
 			all_down = false;
 			break;
 		}
 	}
 	if (all_down)
-		set_status(config, &config->groups[ind],
+		set_status(config, group,
 			   RTR_MGR_CLOSED, sock);
 	else
-		set_status(config, &config->groups[ind],
-			   config->groups[ind].status, sock);
+		set_status(config, group,
+			   group->status, sock);
 }
 
 static inline void _rtr_mgr_cb_state_established(const struct rtr_socket *sock,
 						 struct rtr_mgr_config *config,
-						 unsigned int ind)
+						 struct rtr_mgr_group *group)
 {
 	/* socket established a connection to the rtr_server */
-	if (config->groups[ind].status == RTR_MGR_CONNECTING) {
+	if (group->status == RTR_MGR_CONNECTING) {
 		/*
 		 * if previous state was CONNECTING, check if all
 		 * other sockets in the group also have a established
 		 * connection, if yes change group state to ESTABLISHED
 		 */
-		if (rtr_mgr_config_status_is_synced(&config->groups[ind])) {
-			set_status(config, &config->groups[ind],
+		if (rtr_mgr_config_status_is_synced(group)) {
+			set_status(config, group,
 				   RTR_MGR_ESTABLISHED, sock);
-			rtr_mgr_close_less_preferable_groups(sock, config, ind);
+			rtr_mgr_close_less_preferable_groups(sock, config,
+							     group);
 		} else {
-			set_status(config, &config->groups[ind],
+			set_status(config, group,
 				   RTR_MGR_CONNECTING, sock);
 		}
-	} else if (config->groups[ind].status == RTR_MGR_ERROR) {
-		/*
-		 * if previous state was ERROR, only change state to
+	} else if (group->status == RTR_MGR_ERROR) {
+		/* if previous state was ERROR, only change state to
 		 * ESTABLISHED if all other more preferable socket
 		 * groups are also in ERROR or SHUTDOWN state
 		 */
 		bool all_error = true;
+		struct rtr_mgr_group_node *group_node;
+		struct rtr_mgr_group *current_group;
 
-		for (unsigned int i = 0; (i < config->len) && all_error; i++) {
-			struct rtr_mgr_group cg = config->groups[i];
+		pthread_mutex_lock(&config->mutex);
+		tommy_node *node = tommy_list_head(&config->groups);
 
-			if (i != ind &&
-			    cg.status != RTR_MGR_ERROR &&
-			    cg.status != RTR_MGR_CLOSED &&
-			    cg.preference < config->groups[ind].preference)
+		while (node) {
+			group_node = node->data;
+			current_group = group_node->group;
+			if ((current_group != group) &&
+			    (current_group->status != RTR_MGR_ERROR) &&
+			    (current_group->status != RTR_MGR_CLOSED) &&
+			    (current_group->preference < group->preference)) {
 				all_error = false;
+			}
+			node = node->next;
 		}
-		if (all_error &&
-		    rtr_mgr_config_status_is_synced(&config->groups[ind])) {
-			set_status(config, &config->groups[ind],
-				   RTR_MGR_ESTABLISHED, sock);
-			rtr_mgr_close_less_preferable_groups(sock, config, ind);
+		pthread_mutex_unlock(&config->mutex);
+
+		if (all_error && rtr_mgr_config_status_is_synced(group)) {
+			set_status(config, group, RTR_MGR_ESTABLISHED, sock);
+			rtr_mgr_close_less_preferable_groups(sock, config,
+							     group);
 		} else {
-			set_status(config, &config->groups[ind],
-				   RTR_MGR_ERROR, sock);
+			set_status(config, group, RTR_MGR_ERROR, sock);
 		}
 	}
 }
 
 static inline void _rtr_mgr_cb_state_connecting(const struct rtr_socket *sock,
 						struct rtr_mgr_config *config,
-						unsigned int ind)
+						struct rtr_mgr_group *group)
 {
-	if (config->groups[ind].status == RTR_MGR_ERROR)
-		set_status(config, &config->groups[ind],
+	if (group->status == RTR_MGR_ERROR)
+		set_status(config, group,
 			   RTR_MGR_ERROR, sock);
 	else
-		set_status(config, &config->groups[ind],
+		set_status(config, group,
 			   RTR_MGR_CONNECTING, sock);
 }
 
 static inline void _rtr_mgr_cb_state_error(const struct rtr_socket *sock,
 					   struct rtr_mgr_config *config,
-					   unsigned int ind)
+					   struct rtr_mgr_group *group)
 {
-	set_status(config, &config->groups[ind],
-		   RTR_MGR_ERROR, sock);
+	set_status(config, group, RTR_MGR_ERROR, sock);
 
 	if (!is_some_rtr_mgr_group_established(config)) {
 		struct rtr_mgr_group *next_group =
-			get_best_inactive_rtr_mgr_group(config, ind);
+			get_best_inactive_rtr_mgr_group(config, group);
 
 		if (next_group)
 			rtr_mgr_start_sockets(next_group);
@@ -230,41 +295,37 @@ static inline void _rtr_mgr_cb_state_error(const struct rtr_socket *sock,
 
 static void rtr_mgr_cb(const struct rtr_socket *sock,
 		       const enum rtr_socket_state state,
-		       void *data)
+		       void *data_config, void *data_group)
 {
-	struct rtr_mgr_config *config = data;
+	if (state == RTR_SHUTDOWN)
+		MGR_DBG1("Received RTR_SHUTDOWN callback");
 
-	/*
-	 * find the index in the rtr_mgr_config struct,
-	 * for which this function was called
-	 */
-	unsigned int ind = 0;
+	struct rtr_mgr_config *config = data_config;
+	struct rtr_mgr_group *group = data_group;
 
-	if (rtr_mgr_find_group(config, sock, &ind) == -1)
+	if (!group) {
+		MGR_DBG1("ERROR: Socket has no group");
 		return;
-
-	pthread_mutex_lock(&config->mutex);
+	}
 
 	switch (state) {
 	case RTR_SHUTDOWN:
-		_rtr_mgr_cb_state_shutdown(sock, config, ind);
+		_rtr_mgr_cb_state_shutdown(sock, config, group);
 		break;
 	case RTR_ESTABLISHED:
-		_rtr_mgr_cb_state_established(sock, config, ind);
+		_rtr_mgr_cb_state_established(sock, config, group);
 		break;
 	case RTR_CONNECTING:
-		_rtr_mgr_cb_state_connecting(sock, config, ind);
+		_rtr_mgr_cb_state_connecting(sock, config, group);
 		break;
 	case RTR_ERROR_FATAL:
 	case RTR_ERROR_TRANSPORT:
 	case RTR_ERROR_NO_DATA_AVAIL:
-		_rtr_mgr_cb_state_error(sock, config, ind);
+		_rtr_mgr_cb_state_error(sock, config, group);
 		break;
 	default:
-		set_status(config, &config->groups[ind],
-			   config->groups[ind].status, sock);
+		set_status(config, group, group->status, sock);
 	}
-	pthread_mutex_unlock(&config->mutex);
 }
 
 int rtr_mgr_config_cmp(const void *a, const void *b)
@@ -279,6 +340,14 @@ int rtr_mgr_config_cmp(const void *a, const void *b)
 	return 0;
 }
 
+int rtr_mgr_config_cmp_tommy(const void *a, const void *b)
+{
+	const struct rtr_mgr_group_node *ar = a;
+	const struct rtr_mgr_group_node *br = b;
+
+	return rtr_mgr_config_cmp(ar->group, br->group);
+}
+
 int rtr_mgr_init(struct rtr_mgr_config **config_out,
 		 struct rtr_mgr_group groups[],
 		 const unsigned int groups_len,
@@ -290,10 +359,12 @@ int rtr_mgr_init(struct rtr_mgr_config **config_out,
 		 const rtr_mgr_status_fp status_fp,
 		 void *status_fp_data)
 {
-	int err_code = RTR_ERROR;
+	enum rtr_rtvals err_code = RTR_ERROR;
 	struct pfx_table *pfxt = NULL;
 	struct spki_table *spki_table = NULL;
 	struct rtr_mgr_config *config = NULL;
+	struct rtr_mgr_group *cg =  NULL;
+	struct rtr_mgr_group_node *group_node;
 	uint8_t last_preference = UINT8_MAX;
 
 	*config_out = NULL;
@@ -308,20 +379,30 @@ int rtr_mgr_init(struct rtr_mgr_config **config_out,
 		return RTR_ERROR;
 
 	config->len = groups_len;
-	config->groups = lrtr_malloc(groups_len * sizeof(*groups));
-	if (!config->groups)
-		goto err;
-	memcpy(config->groups, groups, groups_len * sizeof(*groups));
 
 	if (pthread_mutex_init(&config->mutex, NULL) != 0) {
 		MGR_DBG1("Mutex initialization failed");
 		goto err;
 	}
-
-	/* sort array in asc preference order */
-	qsort(config->groups, config->len,
+	/* sort array in asc order, so we can check for dupl. pref */
+	qsort(groups, groups_len,
 	      sizeof(struct rtr_mgr_group), &rtr_mgr_config_cmp);
 
+	/* Check that the groups have unique pref and at least one socket */
+	for (unsigned int i = 0; i < config->len; i++) {
+		struct rtr_mgr_group cg = groups[i];
+
+		if ((i > 0) && (cg.preference == last_preference)) {
+			MGR_DBG1("Error Same preference for 2 socket groups!");
+			goto err;
+		}
+		if (cg.sockets_len == 0) {
+			MGR_DBG1("Error Empty sockets array in socket group!");
+			goto err;
+		}
+	}
+
+	/* Init data structures that we need to pass to the sockets */
 	pfxt = lrtr_malloc(sizeof(*pfxt));
 	if (!pfxt)
 		goto err;
@@ -332,35 +413,42 @@ int rtr_mgr_init(struct rtr_mgr_config **config_out,
 		goto err;
 	spki_table_init(spki_table, spki_update_fp);
 
-	for (unsigned int i = 0; i < config->len; i++) {
-		struct rtr_mgr_group cg = config->groups[i];
+	config->pfx_table = pfxt;
+	config->spki_table = spki_table;
 
-		cg.status = RTR_MGR_CLOSED;
-		if ((i > 0) && (cg.preference == last_preference)) {
-			MGR_DBG1("Error Same preference for 2 socket groups!");
+	/* Copy the groups from the array into linked list config->groups */
+	config->len = groups_len;
+	config->groups = NULL;
+
+	for (unsigned int i = 0; i < groups_len; i++) {
+		cg = lrtr_malloc(sizeof(struct rtr_mgr_group));
+		if (!cg)
 			goto err;
-		}
-		if (cg.sockets_len == 0) {
-			MGR_DBG1("Error Empty sockets array in socket group!");
+
+		memcpy(cg, &groups[i], sizeof(struct rtr_mgr_group));
+
+		cg->status = RTR_MGR_CLOSED;
+		err_code = rtr_mgr_init_sockets(cg, config, refresh_interval,
+						expire_interval,
+						retry_interval);
+		if (err_code)
 			goto err;
-		}
-		for (unsigned int j = 0; j < cg.sockets_len; j++) {
-			if (rtr_init(cg.sockets[j], NULL,
-				     pfxt, spki_table, refresh_interval,
-				     expire_interval, retry_interval,
-				     rtr_mgr_cb, config) != RTR_SUCCESS) {
-				err_code = RTR_INVALID_PARAM;
-				goto err;
-			}
-		}
-		last_preference = cg.preference;
+
+		group_node = lrtr_malloc(sizeof(struct rtr_mgr_group_node));
+		if (!group_node)
+			goto err;
+
+		group_node->group = cg;
+		tommy_list_insert_tail(&config->groups, &group_node->node,
+				       group_node);
 	}
+	/* Our linked list should be sorted already, since the groups array was
+	 * sorted. However, for safety reasons we sort again.
+	 */
+	tommy_list_sort(&config->groups, &rtr_mgr_config_cmp_tommy);
+
 	config->status_fp_data = status_fp_data;
 	config->status_fp = status_fp;
-
-	if (!*config_out)
-		printf("xyxyx");
-
 	return RTR_SUCCESS;
 
 err:
@@ -371,32 +459,56 @@ err:
 	lrtr_free(pfxt);
 	lrtr_free(spki_table);
 
+	lrtr_free(cg);
+
 	lrtr_free(config->groups);
 	lrtr_free(config);
 	config = NULL;
 	*config_out = NULL;
+
 	return err_code;
+}
+
+struct rtr_mgr_group *rtr_mgr_get_first_group(struct rtr_mgr_config
+						     *config)
+{
+	tommy_node *head = tommy_list_head(&config->groups);
+	struct rtr_mgr_group_node *group_node = head->data;
+
+	return group_node->group;
 }
 
 int rtr_mgr_start(struct rtr_mgr_config *config)
 {
 	MGR_DBG1("rtr_mgr_start()");
-	return rtr_mgr_start_sockets(&config->groups[0]);
+	struct rtr_mgr_group *best_group = rtr_mgr_get_first_group(config);
+
+	return rtr_mgr_start_sockets(best_group);
 }
 
 bool rtr_mgr_conf_in_sync(struct rtr_mgr_config *config)
 {
-	for (unsigned int i = 0; i < config->len; i++) {
-		bool all_sync = true;
+	bool all_sync;
+	struct rtr_mgr_group_node *group_node;
 
-		for (unsigned int j = 0;
-		     all_sync && (j < config->groups[i].sockets_len); j++) {
-			if (config->groups[i].sockets[j]->last_update == 0)
+	pthread_mutex_lock(&config->mutex);
+	tommy_node *node = tommy_list_head(&config->groups);
+
+	while (node) {
+		all_sync = true;
+		group_node = node->data;
+		for (unsigned int j = 0; all_sync &&
+		     (j < group_node->group->sockets_len); j++) {
+			if (group_node->group->sockets[j]->last_update == 0)
 				all_sync = false;
 		}
-		if (all_sync)
+		if (all_sync) {
+			pthread_mutex_unlock(&config->mutex);
 			return true;
+		}
+		node = node->next;
 	}
+	pthread_mutex_unlock(&config->mutex);
 	return false;
 }
 
@@ -404,11 +516,30 @@ void rtr_mgr_free(struct rtr_mgr_config *config)
 {
 	MGR_DBG1("rtr_mgr_free()");
 	pthread_mutex_lock(&config->mutex);
-	pfx_table_free(config->groups[0].sockets[0]->pfx_table);
-	spki_table_free(config->groups[0].sockets[0]->spki_table);
-	lrtr_free(config->groups[0].sockets[0]->spki_table);
-	lrtr_free(config->groups[0].sockets[0]->pfx_table);
-	lrtr_free(config->groups);
+
+	pfx_table_free(config->pfx_table);
+	spki_table_free(config->spki_table);
+	lrtr_free(config->spki_table);
+	lrtr_free(config->pfx_table);
+
+	/* Free linked list */
+	tommy_node *tmp;
+	tommy_node *head = tommy_list_head(&config->groups);
+	struct rtr_mgr_group_node *group_node;
+
+	while (head) {
+		tmp = head;
+		head = head->next;
+		group_node = tmp->data;
+		for (unsigned int j = 0; j < group_node->group->sockets_len;
+		     j++) {
+			tr_free(group_node->group->sockets[j]->tr_socket);
+		}
+
+		lrtr_free(group_node->group);
+		lrtr_free(group_node);
+	}
+
 	pthread_mutex_unlock(&config->mutex);
 	pthread_mutex_destroy(&config->mutex);
 	lrtr_free(config);
@@ -421,8 +552,8 @@ inline int rtr_mgr_validate(struct rtr_mgr_config *config,
 			    const uint8_t mask_len,
 			    enum pfxv_state *result)
 {
-	return pfx_table_validate(config->groups[0].sockets[0]->pfx_table,
-				  asn, prefix, mask_len, result);
+	return pfx_table_validate(config->pfx_table, asn, prefix, mask_len,
+				  result);
 }
 
 /* cppcheck-suppress unusedFunction */
@@ -432,17 +563,179 @@ inline int rtr_mgr_get_spki(struct rtr_mgr_config *config,
 			    struct spki_record **result,
 			    unsigned int *result_count)
 {
-	return spki_table_get_all(config->groups[0].sockets[0]->spki_table,
+	return spki_table_get_all(config->spki_table,
 				  asn, ski, result, result_count);
 }
 
 void rtr_mgr_stop(struct rtr_mgr_config *config)
 {
+	struct rtr_mgr_group_node *group_node;
+
+	pthread_mutex_lock(&config->mutex);
+	tommy_node *node = tommy_list_head(&config->groups);
+
 	MGR_DBG1("rtr_mgr_stop()");
-	for (unsigned int i = 0; i < config->len; i++) {
-		for (unsigned int j = 0; j < config->groups[i].sockets_len; j++)
-			rtr_stop(config->groups[i].sockets[j]);
+	while (node) {
+		group_node = node->data;
+		for (unsigned int j = 0; j < group_node->group->sockets_len;
+		     j++) {
+			rtr_stop(group_node->group->sockets[j]);
+		}
+	node = node->next;
 	}
+	pthread_mutex_unlock(&config->mutex);
+}
+
+int rtr_mgr_add_group(struct rtr_mgr_config *config,
+		      const struct rtr_mgr_group *group)
+{
+	unsigned int refresh_iv = 3600;
+	unsigned int retry_iv = 600;
+	unsigned int expire_iv = 7200;
+	enum rtr_rtvals err_code = RTR_ERROR;
+	struct rtr_mgr_group_node *new_group_node = NULL;
+	struct rtr_mgr_group *new_group = NULL;
+	struct rtr_mgr_group_node *gnode;
+
+	pthread_mutex_lock(&config->mutex);
+
+	tommy_node *node = tommy_list_head(&config->groups);
+
+	while (node) {
+		gnode = node->data;
+		if (gnode->group->preference == group->preference) {
+			MGR_DBG1("Group with preference value already exists!");
+			err_code = RTR_INVALID_PARAM;
+			goto err;
+		}
+
+		//TODO This is not pretty. It wants to get the same intervals
+		//that are being used by other groups. Maybe intervals should
+		//be store globally/per-group/per-socket?
+		if (gnode->group->sockets[0]->refresh_interval)
+			refresh_iv = gnode->group->sockets[0]->refresh_interval;
+		if (gnode->group->sockets[0]->retry_interval)
+			retry_iv = gnode->group->sockets[0]->retry_interval;
+		if (gnode->group->sockets[0]->expire_interval)
+			expire_iv = gnode->group->sockets[0]->expire_interval;
+		node = node->next;
+	}
+	new_group = lrtr_malloc(sizeof(struct rtr_mgr_group));
+
+	if (!new_group)
+		goto err;
+
+	memcpy(new_group, group, sizeof(struct rtr_mgr_group));
+	new_group->status = RTR_MGR_CLOSED;
+
+	err_code = rtr_mgr_init_sockets(new_group, config, refresh_iv,
+					expire_iv, retry_iv);
+	if (err_code)
+		goto err;
+
+	new_group_node = lrtr_malloc(sizeof(struct rtr_mgr_group_node));
+	if (!new_group_node)
+		goto err;
+
+	new_group_node->group = new_group;
+	tommy_list_insert_tail(&config->groups, &new_group_node->node,
+			       new_group_node);
+	config->len++;
+
+	MGR_DBG("Group with preference %d successfully added!",
+		new_group->preference);
+
+	tommy_list_sort(&config->groups, &rtr_mgr_config_cmp_tommy);
+
+	struct rtr_mgr_group *best_group = rtr_mgr_get_first_group(config);
+
+	if (best_group->status == RTR_MGR_CLOSED)
+		rtr_mgr_start_sockets(best_group);
+
+	pthread_mutex_unlock(&config->mutex);
+	return RTR_SUCCESS;
+
+err:
+	pthread_mutex_unlock(&config->mutex);
+
+	if (new_group)
+		lrtr_free(new_group);
+
+	return err_code;
+}
+
+int rtr_mgr_remove_group(struct rtr_mgr_config *config,
+			 unsigned int preference)
+{
+	pthread_mutex_lock(&config->mutex);
+	tommy_node *remove_node = NULL;
+	tommy_node *node = tommy_list_head(&config->groups);
+	struct rtr_mgr_group_node *group_node;
+	struct rtr_mgr_group *remove_group;
+
+	if (config->len == 1) {
+		MGR_DBG1("Cannot remove last remaining group!");
+		pthread_mutex_unlock(&config->mutex);
+		return RTR_ERROR;
+	}
+
+	// Find the node of the group we want to remove
+	while (node && !remove_node) {
+		group_node = node->data;
+		if (group_node->group->preference == preference)
+			remove_node = node;
+		node = node->next;
+	}
+
+	if (!remove_node) {
+		MGR_DBG1("The group that should be removed does not exist!");
+		pthread_mutex_unlock(&config->mutex);
+		return RTR_ERROR;
+	}
+
+	group_node = remove_node->data;
+	remove_group = group_node->group;
+	tommy_list_remove_existing(&config->groups, remove_node);
+	config->len--;
+	MGR_DBG("Group with preference %d successfully removed!", preference);
+	//tommy_list_sort(&config->groups, &rtr_mgr_config_cmp);
+	pthread_mutex_unlock(&config->mutex);
+
+	//If group isn't closed, make it so!
+	if (remove_group->status != RTR_MGR_CLOSED) {
+		for (unsigned int j = 0; j < remove_group->sockets_len; j++) {
+			rtr_stop(remove_group->sockets[j]);
+			tr_free(remove_group->sockets[j]->tr_socket);
+		}
+		set_status(config, remove_group, RTR_MGR_CLOSED, NULL);
+	}
+
+	struct rtr_mgr_group *best_group = rtr_mgr_get_first_group(config);
+
+	if (best_group->status == RTR_MGR_CLOSED)
+		rtr_mgr_start_sockets(best_group);
+
+	lrtr_free(group_node->group);
+	lrtr_free(group_node);
+	return RTR_SUCCESS;
+}
+
+// TODO: write test for this function.
+int rtr_mgr_for_each_group(struct rtr_mgr_config *conf,
+			   void (fp)(const struct rtr_mgr_group *group,
+				     void *data),
+			   void *data)
+{
+	struct rtr_mgr_group_node *group_node;
+	tommy_node *node = tommy_list_head(&conf->groups);
+
+	while (node) {
+		group_node = node->data;
+		fp(group_node->group, data);
+		node = node->next;
+	}
+
+	return RTR_SUCCESS;
 }
 
 const char *rtr_mgr_status_to_str(enum rtr_mgr_status status)
@@ -456,7 +749,7 @@ inline void rtr_mgr_for_each_ipv4_record(struct rtr_mgr_config *config,
 						   void *data),
 						   void *data)
 {
-	pfx_table_for_each_ipv4_record(config->groups[0].sockets[0]->pfx_table,
+	pfx_table_for_each_ipv4_record(config->pfx_table,
 				       fp, data);
 }
 
@@ -466,6 +759,6 @@ inline void rtr_mgr_for_each_ipv6_record(struct rtr_mgr_config *config,
 						   void *data),
 					 void *data)
 {
-	pfx_table_for_each_ipv6_record(config->groups[0].sockets[0]->pfx_table,
+	pfx_table_for_each_ipv6_record(config->pfx_table,
 				       fp, data);
 }

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -127,9 +127,17 @@ void tr_ssh_free(struct tr_socket *tr_sock)
     struct tr_ssh_socket *tr_ssh_sock = tr_sock->socket;
     assert(tr_ssh_sock->channel == NULL);
     assert(tr_ssh_sock->session == NULL);
+
+    SSH_DBG1("Freeing socket", tr_ssh_sock);
+
+    lrtr_free(tr_ssh_sock->config.host);
+    lrtr_free(tr_ssh_sock->config.bindaddr);
+    lrtr_free(tr_ssh_sock->config.username);
+    lrtr_free(tr_ssh_sock->config.client_privkey_path);
+    lrtr_free(tr_ssh_sock->config.server_hostkey_path);
+
     if (tr_ssh_sock->ident != NULL)
         lrtr_free(tr_ssh_sock->ident);
-    SSH_DBG1("Socket freed", tr_ssh_sock);
     lrtr_free(tr_ssh_sock);
     tr_sock->socket = NULL;
 }
@@ -208,7 +216,29 @@ int tr_ssh_init(const struct tr_ssh_config *config, struct tr_socket *socket)
     struct tr_ssh_socket *ssh_socket = socket->socket;
     ssh_socket->channel = NULL;
     ssh_socket->session = NULL;
-    ssh_socket->config = *config;
+    ssh_socket->config.host = lrtr_strdup(config->host);
+    ssh_socket->config.port = config->port;
+    ssh_socket->config.username = lrtr_strdup(config->username);
+
+    if (config->bindaddr) {
+        ssh_socket->config.bindaddr = lrtr_strdup(config->bindaddr);
+    } else {
+        ssh_socket->config.bindaddr = NULL;
+    }
+
+    if (config->bindaddr) {
+        ssh_socket->config.client_privkey_path =
+		lrtr_strdup(config->client_privkey_path);
+    } else {
+        ssh_socket->config.client_privkey_path = NULL;
+    }
+
+    if (config->bindaddr) {
+        ssh_socket->config.server_hostkey_path =
+		lrtr_strdup(config->server_hostkey_path);
+    } else {
+        ssh_socket->config.server_hostkey_path = NULL;
+    }
     ssh_socket->ident = NULL;;
 
     return TR_SUCCESS;

--- a/rtrlib/transport/tcp/tcp_transport.c
+++ b/rtrlib/transport/tcp/tcp_transport.c
@@ -105,10 +105,15 @@ void tr_tcp_free(struct tr_socket *tr_sock)
     assert(tcp_sock != NULL);
     assert(tcp_sock->socket == -1);
 
+    TCP_DBG1("Freeing socket", tcp_sock);
+
+    lrtr_free(tcp_sock->config.host);
+    lrtr_free(tcp_sock->config.port);
+    lrtr_free(tcp_sock->config.bindaddr);
+
     if (tcp_sock->ident != NULL)
         lrtr_free(tcp_sock->ident);
     tr_sock->socket = NULL;
-    TCP_DBG1("Socket freed", tcp_sock);
     lrtr_free(tcp_sock);
 }
 
@@ -200,7 +205,13 @@ int tr_tcp_init(const struct tr_tcp_config *config, struct tr_socket *socket)
     socket->socket = lrtr_malloc(sizeof(struct tr_tcp_socket));
     struct tr_tcp_socket *tcp_socket = socket->socket;
     tcp_socket->socket = -1;
-    tcp_socket->config = *config;
+    tcp_socket->config.host = lrtr_strdup(config->host);
+    tcp_socket->config.port = lrtr_strdup(config->port);
+    if (config->bindaddr) {
+        tcp_socket->config.bindaddr = lrtr_strdup(config->bindaddr);
+    } else {
+        tcp_socket->config.bindaddr = NULL;
+    }
     tcp_socket->ident = NULL;
 
     return TR_SUCCESS;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(test_ipaddr test_ipaddr.c)
 target_link_libraries(test_ipaddr rtrlib)
 add_executable(test_getbits test_getbits.c)
 target_link_libraries(test_getbits rtrlib)
+add_executable(test_dynamic_groups test_dynamic_groups.c)
+target_link_libraries(test_dynamic_groups rtrlib)
 
 
 if(UNIT_TESTING)

--- a/tests/test_dynamic_groups.c
+++ b/tests/test_dynamic_groups.c
@@ -1,0 +1,154 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "rtrlib/rtrlib.h"
+
+int main(void)
+	{
+	//create a TCP transport socket
+	int retval = 0;
+	struct tr_socket tr_tcp;
+	char tcp_host[] = "rpki-validator.realmv6.org";
+	char tcp_port[] = "8282";
+
+	struct tr_tcp_config tcp_config = {
+	tcp_host, //IP
+	tcp_port, //Port
+	NULL      //Source address
+	};
+	tr_tcp_init(&tcp_config, &tr_tcp);
+
+	struct rtr_socket rtr_tcp;
+
+	rtr_tcp.tr_socket = &tr_tcp;
+
+	struct rtr_mgr_group groups[1];
+
+	groups[0].sockets = malloc(sizeof(struct rtr_socket *));
+	groups[0].sockets_len = 1;
+	groups[0].sockets[0] = &rtr_tcp;
+	groups[0].preference = 1;
+
+	struct tr_socket tr_tcp2;
+	struct rtr_socket rtr_tcp2;
+	struct rtr_mgr_group group2;
+
+	tr_tcp_init(&tcp_config, &tr_tcp2);
+	rtr_tcp2.tr_socket = &tr_tcp2;
+	group2.sockets = malloc(sizeof(struct rtr_socket *));
+	group2.sockets_len = 1;
+	group2.sockets[0] = &rtr_tcp2;
+	group2.preference = 2;
+
+	struct rtr_mgr_config *conf;
+
+	rtr_mgr_init(&conf, groups, 1, 30, 600, 600, NULL, NULL, NULL, NULL);
+
+	//start the connection manager
+	rtr_mgr_start(conf);
+
+	//wait till at least one group is fully synchronized with the server
+	while (!rtr_mgr_conf_in_sync(conf))
+		sleep(1);
+
+	assert(conf->len == 1);
+
+	retval = rtr_mgr_add_group(conf, &group2);
+	assert(retval == RTR_SUCCESS);
+
+	//checking behavior in case the group preference already exists
+	//by adding the same group twice.
+	retval = rtr_mgr_add_group(conf, &group2);
+	assert(retval == RTR_INVALID_PARAM);
+
+	tommy_node *node = tommy_list_head(&conf->groups);
+	struct rtr_mgr_group_node *group_node = node->data;
+	struct rtr_mgr_group_node *group_node2 = node->next->data;
+
+	assert(group_node->group->preference == 1);
+	assert(group_node2->group->preference == 2);
+	assert(conf->len == 2);
+
+	rtr_mgr_remove_group(conf, 1);
+
+	node = tommy_list_head(&conf->groups);
+	group_node = node->data;
+	assert(group_node->group->preference == 2);
+	assert(conf->len == 1);
+
+	struct tr_socket tr_tcp3;
+	struct rtr_socket rtr_tcp3;
+	struct rtr_mgr_group group3;
+
+	tr_tcp_init(&tcp_config, &tr_tcp3);
+	rtr_tcp3.tr_socket = &tr_tcp3;
+	group3.sockets = malloc(sizeof(struct rtr_socket *));
+	group3.sockets_len = 1;
+	group3.sockets[0] = &rtr_tcp3;
+	group3.preference = 3;
+
+	struct tr_socket tr_tcp4;
+	struct rtr_socket rtr_tcp4;
+	struct rtr_mgr_group group4;
+
+	tr_tcp_init(&tcp_config, &tr_tcp4);
+	rtr_tcp4.tr_socket = &tr_tcp4;
+	group4.sockets = malloc(sizeof(struct rtr_socket *));
+	group4.sockets_len = 1;
+	group4.sockets[0] = &rtr_tcp4;
+	group4.preference = 4;
+
+	rtr_mgr_add_group(conf, &group4);
+
+	// remove group 2 so group 4 becomes the active group.
+	rtr_mgr_remove_group(conf, 2);
+
+	// add group 3 which has a higher preference than group 4
+	// and check whether it will be set as the active group.
+	rtr_mgr_add_group(conf, &group3);
+
+	node = tommy_list_head(&conf->groups);
+	group_node = node->data;
+	assert(group_node->group->preference == 3);
+
+	//try to remove non-existent group
+	retval = rtr_mgr_remove_group(conf, 10);
+	assert(retval == RTR_ERROR);
+
+	struct tr_socket tr_tcp5;
+	struct rtr_socket rtr_tcp5;
+	struct rtr_mgr_group group5;
+
+	tr_tcp_init(&tcp_config, &tr_tcp5);
+	rtr_tcp5.tr_socket = &tr_tcp5;
+	group5.sockets = malloc(sizeof(struct rtr_socket *));
+	group5.sockets_len = 1;
+	group5.sockets[0] = &rtr_tcp5;
+	group5.preference = 5;
+
+	//add 100 groups
+	for (int i = 0; i < 100; i++) {
+		retval = rtr_mgr_add_group(conf, &group5);
+		group5.preference++;
+		assert(retval == RTR_SUCCESS);
+	}
+
+	//remove 100 groups
+	for (int i = 104; i >= 5; i--) {
+		retval = rtr_mgr_remove_group(conf, i);
+		assert(retval == RTR_SUCCESS);
+	}
+
+	rtr_mgr_remove_group(conf, 4);
+
+	//try to remove last remainig group.
+	retval = rtr_mgr_remove_group(conf, 3);
+	assert(retval == RTR_ERROR);
+
+	rtr_mgr_stop(conf);
+	rtr_mgr_free(conf);
+	free(groups[0].sockets);
+	free(group2.sockets);
+	free(group3.sockets);
+	free(group4.sockets);
+	free(group5.sockets);
+}

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -64,7 +64,6 @@ int main(void)
 					    RPKI_CACHE_POST,
 					    NULL };
 	struct rtr_socket rtr_tcp;
-	struct rtr_mgr_config *conf;
 	struct rtr_mgr_group groups[1];
 
 	/* init a TCP transport and create rtr socket */
@@ -76,6 +75,8 @@ int main(void)
 	groups[0].sockets_len = 1;
 	groups[0].sockets[0] = &rtr_tcp;
 	groups[0].preference = 1;
+
+	struct rtr_mgr_config *conf;
 
 	if  (rtr_mgr_init(&conf, groups, 1, 30, 600, 600, NULL, NULL,
 			  &connection_status_callback, NULL) < 0)
@@ -116,7 +117,6 @@ int main(void)
 
 	rtr_mgr_stop(conf);
 	rtr_mgr_free(conf);
-	free(groups[0].sockets);
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This uses a linked list instead of an array to store rtr_mgr_groups. It also adds two new functions for the user: rtr_mgr_group_add and rtr_mgr_group_remove. These allow users to add and remove groups while rtr_mgr is running. 

Right now this uses a tommy_list out of convenience. This is a generic doubly linked list. 
This means there are now calls to tommy_* functions in rtr_mgr.c 
Do we want to write our own linked list? Or some kind of wrapper for tommy_list?

Since I am in the middle of writing my masters thesis, it would be good if @ColinBS and @mroethke could pick this up and add necessary changes.  This should include more extensive tests, such as adding/removing groups while rtr_mgr is running and checking whether the changes work as they should there as well.