### PR TITLE
doc: fix link to trie implementation on doxygen mainpage

### DIFF
--- a/doxygen/mainpage.dox
+++ b/doxygen/mainpage.dox
@@ -30,7 +30,7 @@ stores them in a prefix table data structure.\n
 @par
 The @ref mod_pfx_h stores validated prefix origin data. The abstract data
 structure provides a common interface to add and delete entries as well as
-to verify a specific prefix. The library implements a @ref mod_spfst_pfx_h,
+to verify a specific prefix. The library implements a @ref mod_trie_pfx_h,
 but can be extended to other data structures.\n
 
 @par
@@ -51,4 +51,3 @@ For a general overview of the topic have look at the homepage of the <a
 href="http://datatracker.ietf.org/wg/sidr/charter/">IETF SIDR working
 group</a>.
 */
-


### PR DESCRIPTION
fixes broken link to pfx table data struct (aka trie) on doxygen mainpage.