### PR TITLE
redhat: Add rpm Package build infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ cmake_install.cmake
 CMakeCache.txt
 rtrlib.pc
 
+## REDHAT ##
+redhat/BUILD
+redhat/BUILDROOT
+redhat/RPMS
+redhat/SOURCES
+redhat/SRPMS
+

--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -1,0 +1,128 @@
+Name:           librtr
+Version:        0.5.0
+Release:        1%{?dist}
+Summary:        Small extensible RPKI-RTR-Client C library
+Group:          Development/Libraries
+License:        MIT
+URL:            http://rpki.realmv6.org/
+Source0:        %{name}-%{version}.tar.gz
+BuildRequires:  binutils gcc tar chrpath cmake libssh-devel >= 0.6.0 doxygen
+Requires:       libssh >= 0.6.0
+
+%description
+RTRlib is an open-source C implementation of the  RPKI/Router Protocol
+client. The library allows one to fetch and store validated prefix origin
+data from a RTR-cache and performs origin verification of prefixes. It
+supports different types of transport sessions (e.g., SSH, unprotected TCP)
+and is easily extendable.
+
+%package devel
+Summary:        Small extensible RPKI-RTR-Client C library. Development files
+Group:          Development/Libraries
+Requires:       %{name} = %{version}-%{release}
+
+%description devel
+RTRlib is an open-source C implementation of the  RPKI/Router Protocol
+client. The library allows one to fetch and store validated prefix origin
+data from a RTR-cache and performs origin verification of prefixes. It
+supports different types of transport sessions (e.g., SSH, unprotected TCP)
+and is easily extendable.
+.
+This package contains development files.
+
+%package doc
+Summary:        Small extensible RPKI-RTR-Client C library. Documentation
+Group:          Development/Libraries
+Requires:       %{name} = %{version}-%{release}
+BuildArch:      noarch
+
+%description doc
+RTRlib is an open-source C implementation of the  RPKI/Router Protocol
+client. The library allows one to fetch and store validated prefix origin
+data from a RTR-cache and performs origin verification of prefixes. It
+supports different types of transport sessions (e.g., SSH, unprotected TCP)
+and is easily extendable.
+.
+This package contains documentation files.
+
+%package -n rtrclient
+Summary:        RPKI-RTR command line tool
+Group:          Development/Libraries
+Requires:       %{name} = %{version}-%{release}
+
+%description -n rtrclient
+Rtrclient is command line that connects to an RPKI-RTR server and prints
+protocol information and information about the fetched ROAs to the console.
+
+%package -n cli-validator
+Summary:        RPKI-RTR command line tool
+Group:          Development/Libraries
+Requires:       %{name} = %{version}-%{release}
+
+%description -n cli-validator
+Cli-validator is a command line tool that connects to an RPKI-RTR server and
+allows to validate given IP prefixes and origin ASes.
+
+%prep
+if [ ! -f %{SOURCE0} ]; then
+  # Build Source Tarball first
+  pushd `dirname %_topdir`; tar czf %{SOURCE0} . --exclude-vcs --exclude=redhat; popd
+fi
+cd %{_topdir}/BUILD
+rm -rf %{name}-%{version}
+tar xzf %{SOURCE0}
+/usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+
+%build
+%cmake -D CMAKE_BUILD_TYPE=Release .
+make %{?_smp_mflags}
+
+%install
+%make_install
+strip $RPM_BUILD_ROOT/usr/lib64/librtr.so.0.5.0
+chrpath -d $RPM_BUILD_ROOT/usr/bin/cli-validator
+strip $RPM_BUILD_ROOT/usr/bin/cli-validator
+chrpath -d $RPM_BUILD_ROOT/usr/bin/rtrclient
+strip $RPM_BUILD_ROOT/usr/bin/rtrclient
+cp %{_topdir}/BUILD/CHANGELOG %{buildroot}/%{_docdir}/rtrlib/
+cp %{_topdir}/BUILD/LICENSE %{buildroot}/%{_docdir}/rtrlib/
+
+%check
+make test
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%clean
+
+%files
+%{_libdir}/lib*.so.0
+%attr(755,root,root) %{_libdir}/lib*.so.0.*
+%doc CHANGELOG
+%doc LICENSE
+
+%files devel
+%{_libdir}/lib*.so
+%attr(644,root,root) %{_libdir}/pkgconfig/rtrlib.pc
+%{_includedir}/rtrlib
+%doc CHANGELOG
+%doc LICENSE
+
+%files doc
+%{_docdir}/rtrlib
+
+%files -n rtrclient
+%attr(755,root,root) %{_bindir}/rtrclient
+%doc CHANGELOG
+%doc LICENSE
+
+%files -n cli-validator
+%attr(755,root,root) %{_bindir}/cli-validator
+%doc CHANGELOG
+%doc LICENSE
+
+%changelog
+* Fri Nov 24 2017 Martin Winter <mwinter@opensourcerouting.org> - %{version}-%{release}
+- RPM Packaging added
+

--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -45,21 +45,15 @@ and is easily extendable.
 .
 This package contains documentation files.
 
-%package -n rtrclient
-Summary:        RPKI-RTR command line tool
+%package -n rtr-tools
+Summary:        RPKI-RTR command line tools
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
 
-%description -n rtrclient
+%description -n rtr-tools
+Tools for the RTRlib
 Rtrclient is command line that connects to an RPKI-RTR server and prints
 protocol information and information about the fetched ROAs to the console.
-
-%package -n cli-validator
-Summary:        RPKI-RTR command line tool
-Group:          Development/Libraries
-Requires:       %{name} = %{version}-%{release}
-
-%description -n cli-validator
 Cli-validator is a command line tool that connects to an RPKI-RTR server and
 allows to validate given IP prefixes and origin ASes.
 
@@ -110,12 +104,8 @@ export LD_LIBRARY_PATH=.; make test
 %files doc
 %{_docdir}/rtrlib
 
-%files -n rtrclient
+%files -n rtr-tools
 %attr(755,root,root) %{_bindir}/rtrclient
-%doc CHANGELOG
-%doc LICENSE
-
-%files -n cli-validator
 %attr(755,root,root) %{_bindir}/cli-validator
 %doc CHANGELOG
 %doc LICENSE

--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -6,8 +6,8 @@ Group:          Development/Libraries
 License:        MIT
 URL:            http://rpki.realmv6.org/
 Source0:        %{name}-%{version}.tar.gz
-BuildRequires:  binutils gcc tar chrpath cmake libssh-devel >= 0.6.0 doxygen
-Requires:       libssh >= 0.6.0
+BuildRequires:  binutils gcc tar chrpath cmake libssh-devel >= 0.5.0 doxygen
+Requires:       libssh >= 0.5.0
 
 %description
 RTRlib is an open-source C implementation of the  RPKI/Router Protocol
@@ -71,7 +71,7 @@ fi
 cd %{_topdir}/BUILD
 rm -rf %{name}-%{version}
 tar xzf %{SOURCE0}
-/usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+/bin/chmod -Rf a+rX,u+w,g-w,o-w .
 
 %build
 %cmake -D CMAKE_BUILD_TYPE=Release .
@@ -79,7 +79,7 @@ make %{?_smp_mflags}
 
 %install
 %make_install
-strip $RPM_BUILD_ROOT/usr/lib64/librtr.so.0.5.0
+strip $RPM_BUILD_ROOT/usr/lib64/librtr.so.%{version}
 chrpath -d $RPM_BUILD_ROOT/usr/bin/cli-validator
 strip $RPM_BUILD_ROOT/usr/bin/cli-validator
 chrpath -d $RPM_BUILD_ROOT/usr/bin/rtrclient
@@ -88,13 +88,11 @@ cp %{_topdir}/BUILD/CHANGELOG %{buildroot}/%{_docdir}/rtrlib/
 cp %{_topdir}/BUILD/LICENSE %{buildroot}/%{_docdir}/rtrlib/
 
 %check
-make test
+export LD_LIBRARY_PATH=.; make test
 
 %post -p /sbin/ldconfig
 
 %postun -p /sbin/ldconfig
-
-%clean
 
 %files
 %{_libdir}/lib*.so.0
@@ -123,6 +121,6 @@ make test
 %doc LICENSE
 
 %changelog
-* Fri Nov 24 2017 Martin Winter <mwinter@opensourcerouting.org> - %{version}-%{release}
+* Thu Dec 14 2017 Martin Winter <mwinter@opensourcerouting.org> - %{version}-%{release}
 - RPM Packaging added
 


### PR DESCRIPTION
RPM package additions based on setup similar to debian package
Before agreeing to merge, please look at Debian issues in #140 

RPM tested and build clean on CentOS 7 and Fedora 24. It fails on CentOS 6 (libssh is at 0.5.5 which is too old in CentOS 6)

RPM Spec file is designed to work from the SRPM and directly from Git. To build the RPM, use
(from within the rtrlib directory):

    rpmbuild --define "_topdir `pwd`/redhat" -ba redhat/SPECS/librtr.spec

Example packages for this PR can be seen at https://ci1.netdef.org/browse/RPKI-RTRLIB-27/artifact

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>