### PR TITLE
Fix doxygen build for out of tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,10 @@ endif(LIBSSH_050 OR LIBSSH_060)
 #doxygen target
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
-    add_custom_target(doc ALL ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/doxygen/Doxyfile
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/doxygen/Doxyfile @ONLY)
+
+    add_custom_target(doc ALL ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doxygen/Doxyfile
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating doxygen API documentation" VERBATIM)
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/docs DESTINATION share/doc/rtrlib)
 endif(DOXYGEN_FOUND)

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -753,7 +753,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = .
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/rtrlib/ @CMAKE_CURRENT_SOURCE_DIR@/doxygen/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -823,7 +823,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = doxygen/examples/
+EXAMPLE_PATH           = @CMAKE_CURRENT_SOURCE_DIR@/doxygen/examples/
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -843,7 +843,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = doxygen/graphics/
+IMAGE_PATH             = @CMAKE_CURRENT_SOURCE_DIR@/doxygen/graphics/
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program


### PR DESCRIPTION
Building the documentation did not work for out of tree builds because doxygen makes assumptions about the working directory it is run from and our build system did not take that into account when configuring and running the build.