### PR TITLE
fix doxygen warnings

### DIFF
--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -153,7 +153,7 @@ struct rtr_socket {
 int rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr_socket, struct pfx_table *pfx_table,
              struct spki_table *spki_table, const unsigned int refresh_interval,
              const unsigned int expire_interval, const unsigned int retry_interval,
-             rtr_connection_state_fp fp, void *fp_data_config, void *my_group);
+             rtr_connection_state_fp fp, void *fp_data_config, void *fp_data_group);
 
 /**
  * @brief Starts the RTR protocol state machine in a pthread. Connection to the rtr_server will be established and the

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -276,7 +276,7 @@ void rtr_mgr_for_each_ipv6_record(struct rtr_mgr_config *config,
  * @param[in] config The rtr_mgr_config
  * @return rtr_mgr_group The head of the linked list.
  */
-struct rtr_mgr_group *rtr_mgr_get_first_group(struct rtr_mgr_config *conf);
+struct rtr_mgr_group *rtr_mgr_get_first_group(struct rtr_mgr_config *config);
 
 int rtr_mgr_for_each_group(struct rtr_mgr_config *config,
 			   void (fp)(const struct rtr_mgr_group *group,


### PR DESCRIPTION
Doxygen threw some warings because the parameter names in the
declaration and the doxygen comment did not match in two instances.