### PR TITLE
scripts: fix travis.sh

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -14,6 +14,10 @@ function run_command {
 		colour=$GREEN
 	fi
 	echo -e "\n${colour}The command \"$@\" exited with $ret.$NC\n\n"
+
+	if [ $ret != 0 ]; then
+		exit $ret
+	fi
 }
 
 run_command scripts/cppcheck.sh


### PR DESCRIPTION
Due to an error in the travis script the travis build can not fail
because the return value of failed build steps are never propagated to
the build engine.

This commit is expected to fail travis.