### PR TITLE
checkpatch: fix (false positive) warnings and errors

### DIFF
--- a/rtrlib/lib/alloc_utils.h
+++ b/rtrlib/lib/alloc_utils.h
@@ -26,7 +26,7 @@ extern void *(*REALLOC_PTR)(void *ptr, size_t size);
 void lrtr_set_alloc_functions(
 		void *(*malloc_function)(size_t size),
 		void *(*realloc_function)(void *ptr, size_t size),
-		void (free_function)(void *ptr));
+		void (*free_function)(void *ptr));
 
 void *lrtr_malloc(size_t size);
 

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -103,6 +103,7 @@ static void rtr_mgr_close_less_preferable_groups(const struct rtr_socket *sock,
 	while (node) {
 		struct rtr_mgr_group_node *group_node = node->data;
 		struct rtr_mgr_group *current_group = group_node->group;
+
 		if ((current_group->status != RTR_MGR_CLOSED) &&
 		    (current_group != group) &&
 		    (current_group->preference > group->preference)) {
@@ -145,6 +146,7 @@ static bool is_some_rtr_mgr_group_established(struct rtr_mgr_config *config)
 
 	while (node) {
 		struct rtr_mgr_group_node *group_node = node->data;
+
 		if (group_node->group->status == RTR_MGR_ESTABLISHED) {
 			pthread_mutex_unlock(&config->mutex);
 			return true;
@@ -208,6 +210,7 @@ static inline void _rtr_mgr_cb_state_established(const struct rtr_socket *sock,
 		while (node) {
 			struct rtr_mgr_group_node *group_node = node->data;
 			struct rtr_mgr_group *current_group = group_node->group;
+
 			if ((current_group != group) &&
 			    (current_group->status != RTR_MGR_ERROR) &&
 			    (current_group->status != RTR_MGR_CLOSED) &&
@@ -458,6 +461,7 @@ bool rtr_mgr_conf_in_sync(struct rtr_mgr_config *config)
 	while (node) {
 		bool all_sync = true;
 		struct rtr_mgr_group_node *group_node = node->data;
+
 		for (unsigned int j = 0; all_sync &&
 		     (j < group_node->group->sockets_len); j++) {
 			if (group_node->group->sockets[j]->last_update == 0)
@@ -489,6 +493,7 @@ void rtr_mgr_free(struct rtr_mgr_config *config)
 	while (head) {
 		tommy_node *tmp = head;
 		struct rtr_mgr_group_node *group_node = tmp->data;
+
 		head = head->next;
 		for (unsigned int j = 0; j < group_node->group->sockets_len;
 		     j++) {
@@ -534,6 +539,7 @@ void rtr_mgr_stop(struct rtr_mgr_config *config)
 	MGR_DBG1("rtr_mgr_stop()");
 	while (node) {
 		struct rtr_mgr_group_node *group_node = node->data;
+
 		for (unsigned int j = 0; j < group_node->group->sockets_len;
 		     j++) {
 			rtr_stop(group_node->group->sockets[j]);
@@ -690,6 +696,7 @@ int rtr_mgr_for_each_group(struct rtr_mgr_config *conf,
 
 	while (node) {
 		struct rtr_mgr_group_node *group_node = node->data;
+
 		fp(group_node->group, data);
 		node = node->next;
 	}

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -279,8 +279,8 @@ void rtr_mgr_for_each_ipv6_record(struct rtr_mgr_config *config,
 struct rtr_mgr_group *rtr_mgr_get_first_group(struct rtr_mgr_config *config);
 
 int rtr_mgr_for_each_group(struct rtr_mgr_config *config,
-			   void (fp)(const struct rtr_mgr_group *group,
-				     void *data),
+			   void (*fp)(const struct rtr_mgr_group *group,
+				      void *data),
 			   void *data);
 #endif
 /* @} */

--- a/scripts/check-coding-style.sh
+++ b/scripts/check-coding-style.sh
@@ -29,7 +29,7 @@ fi
 cd $SCRIPT_DIR/..
 for i in $CHECKSOURCE; do
 	echo "> check coding style of $i ..."
-    IGNORE="PREFER_KERNEL_TYPES,CONST_STRUCT"
+    IGNORE="PREFER_KERNEL_TYPES,CONST_STRUCT,OPEN_BRACE"
     if [[ $i == *"unittest"* ]]; then
         IGNORE="${IGNORE},CAMELCASE"
     fi


### PR DESCRIPTION
disable check for OPEN_BRACE due to false positive in rtr_mgr.c, error:

```
> check coding style of rtrlib/rtr_mgr.c ...
rtrlib/rtr_mgr.c:724: ERROR:OPEN_BRACE: that open brace { should be on the previous line
```

this line matches `rtr_mgr_for_each_group(...)`, where check patch wants the open `{` on the same line.