### PR TITLE
unittests: explicitely disable for Apple macOS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,8 +20,7 @@ add_executable(test_dynamic_groups test_dynamic_groups.c)
 target_link_libraries(test_dynamic_groups rtrlib)
 
 
-if(UNIT_TESTING)
+if(UNIT_TESTING AND NOT APPLE)
     find_package(CMocka REQUIRED)
     add_subdirectory(unittests)
-endif(UNIT_TESTING)
-
+endif(UNIT_TESTING AND NOT APPLE)


### PR DESCRIPTION
 Reason: the linker on macOS does not support the `--wrap` option

When running `cmake -DUNIT_TESTING=On .` on macOS I got the following linker error:

```
[...]
[ 95%] Building C object tests/unittests/CMakeFiles/test_packets.dir/test_packets.c.o
[ 96%] Linking C executable test_packets
ld: unknown option: --wrap=rtr_change_socket_state
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [tests/unittests/test_packets] Error 1
make[1]: *** [tests/unittests/CMakeFiles/test_packets.dir/all] Error 2
make: *** [all] Error 2
```

This PR disables cmocka unit testing on macOS, just in case someone tries that.