### PR TITLE
redhat/debian: Dev package needs to require libssh dev package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Section: libdevel
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: librtr0 (= ${binary:Version}), ${misc:Depends}
+Depends: librtr0 (= ${binary:Version}), ${misc:Depends}, libssh-dev (>= 0.5.0)
 Suggests: librtr-doc
 Description: Small extensible RPKI-RTR-Client C library. Development files
  RTRlib is an open-source C implementation of the  RPKI/Router Protocol

--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -19,7 +19,7 @@ and is easily extendable.
 %package devel
 Summary:        Small extensible RPKI-RTR-Client C library. Development files
 Group:          Development/Libraries
-Requires:       %{name} = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release} libssh-devel >= 0.5.0
 
 %description devel
 RTRlib is an open-source C implementation of the  RPKI/Router Protocol


### PR DESCRIPTION
This fixes issue #159 

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>