### PR TITLE
packets: add the packed attribute to the router key pdu.

### DIFF
--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -124,7 +124,7 @@ struct pdu_router_key {
     uint8_t ski[SKI_SIZE];
     uint32_t asn;
     uint8_t spki[SPKI_SIZE];
-};
+} __attribute__((packed));
 
 /*
    0          8          16         24        31

--- a/tests/unittests/test_packets_static.c
+++ b/tests/unittests/test_packets_static.c
@@ -253,6 +253,12 @@ static void test_rtr_pdu_check_size(void **state)
 	pdu.len = 12;
 	assert_true(rtr_pdu_check_size(&pdu));
 
+	pdu.type = ROUTER_KEY;
+	pdu.len = 124;
+	assert_false(rtr_pdu_check_size(&pdu));
+	pdu.len = 123;
+	assert_true(rtr_pdu_check_size(&pdu));
+
 	/* Test error pdu size checks */
 	error->type = ERROR;
 	error->len = 14;


### PR DESCRIPTION
Due to padding, the pdu_router_key struct was 124 bytes instead of 123 bytes.
Additionally add a unit test for the size of the pdu.
This fixes #163 