### PR TITLE
Implement atomic reset

### DIFF
--- a/rtrlib/pfx/pfx.h
+++ b/rtrlib/pfx/pfx.h
@@ -189,7 +189,7 @@ void pfx_table_for_each_ipv6_record(struct pfx_table *pfx_table, pfx_for_each_fp
  * @param[out] dst_table Destination table
  * @param[in] socket socket which prefixes should not be copied
  */
-void pfx_table_copy_except_socket(struct pfx_table *src_table, struct pfx_table *dst_table, const struct rtr_socket *socket);
+int pfx_table_copy_except_socket(struct pfx_table *src_table, struct pfx_table *dst_table, const struct rtr_socket *socket);
 
 /**
  * @brief Swap root nodes of the argument tables

--- a/rtrlib/pfx/pfx.h
+++ b/rtrlib/pfx/pfx.h
@@ -183,18 +183,18 @@ void pfx_table_for_each_ipv4_record(struct pfx_table *pfx_table, pfx_for_each_fp
 void pfx_table_for_each_ipv6_record(struct pfx_table *pfx_table, pfx_for_each_fp fp, void *data);
 
 /**
- * @brief Copy content of src into dst
+ * @brief Copy content of @p src_table into @p dst_table
  * @details dst must be empty and initialized
  * @param[in] src_table Source table
- * @param[in] dst_table Destination table
+ * @param[out] dst_table Destination table
  * @param[in] socket socket which prefixes should not be copied
  */
 void pfx_table_copy_except_socket(struct pfx_table *src_table, struct pfx_table *dst_table, const struct rtr_socket *socket);
 
 /**
  * @brief Swap root nodes of the argument tables
- * @param[in] a First table
- * @param[in] b second table
+ * @param[in,out] a First table
+ * @param[in,out] b second table
  */
 void pfx_table_swap(struct pfx_table *a, struct pfx_table *b);
 

--- a/rtrlib/pfx/pfx.h
+++ b/rtrlib/pfx/pfx.h
@@ -100,6 +100,13 @@ void pfx_table_init(struct pfx_table *pfx_table, pfx_update_fp update_fp);
  */
 void pfx_table_free(struct pfx_table *pfx_table);
 
+
+/**
+ * @brief Frees all memory associcated with the pfx_table without calling the update callback.
+ * @param[in] pfx_table pfx_table that will be freed.
+ */
+void pfx_table_free_without_notify(struct pfx_table *pfx_table);
+
 /**
  * @brief Adds a pfx_record to a pfx_table.
  * @param[in] pfx_table pfx_table to use.
@@ -174,6 +181,31 @@ void pfx_table_for_each_ipv4_record(struct pfx_table *pfx_table, pfx_for_each_fp
  * @param[in] data This parameter is forwarded to the callback function.
  */
 void pfx_table_for_each_ipv6_record(struct pfx_table *pfx_table, pfx_for_each_fp fp, void *data);
+
+/**
+ * @brief Copy content of src into dst
+ * @details dst must be empty and initialized
+ * @param[in] src_table Source table
+ * @param[in] dst_table Destination table
+ * @param[in] socket socket which prefixes should not be copied
+ */
+void pfx_table_copy_except_socket(struct pfx_table *src_table, struct pfx_table *dst_table, const struct rtr_socket *socket);
+
+/**
+ * @brief Swap root nodes of the argument tables
+ * @param[in] a First table
+ * @param[in] b second table
+ */
+void pfx_table_swap(struct pfx_table *a, struct pfx_table *b);
+
+/**
+ * @brief Notify client about changes between to pfx tables regarding one specific socket
+ * @details old_table will be modified it should be freed after calling this function
+ * @param[in] new_table
+ * @param[in] old_table
+ * @param[in] socket socket which prefixes should be diffed
+ */
+void pfx_table_notify_diff(struct pfx_table *new_table, struct pfx_table *old_table, const struct rtr_socket *socket);
 
 #endif
 /* @} */

--- a/rtrlib/pfx/trie/trie-pfx.c
+++ b/rtrlib/pfx/trie/trie-pfx.c
@@ -25,6 +25,19 @@ struct node_data {
     struct data_elem *ary;
 };
 
+struct copy_cb_args {
+	struct pfx_table *pfx_table;
+	const struct rtr_socket *socket;
+};
+
+struct notify_diff_cb_args {
+	struct pfx_table *old_table;
+	struct pfx_table *new_table;
+	const struct rtr_socket *socket;
+	pfx_update_fp pfx_update_fp;
+	bool added;
+};
+
 static struct trie_node *pfx_table_get_root(const struct pfx_table *pfx_table, const enum lrtr_ip_version ver);
 static int pfx_table_del_elem(struct node_data *data, const unsigned int index);
 static int pfx_table_create_node(struct trie_node **node, const struct pfx_record *record);
@@ -512,11 +525,6 @@ void pfx_table_for_each_ipv6_record(struct pfx_table *pfx_table, pfx_for_each_fp
     pthread_rwlock_unlock(&pfx_table->lock);
 }
 
-struct copy_cb_args {
-	struct pfx_table *pfx_table;
-	const struct rtr_socket *socket;
-};
-
 static void pfx_table_copy_cb(const struct pfx_record *record, void *data)
 {
 	struct copy_cb_args *args = data;
@@ -551,14 +559,6 @@ void pfx_table_swap(struct pfx_table *a, struct pfx_table *b)
 	pthread_rwlock_unlock(&(b->lock));
 	pthread_rwlock_unlock(&(a->lock));
 }
-
-struct notify_diff_cb_args {
-	struct pfx_table *old_table;
-	struct pfx_table *new_table;
-	const struct rtr_socket *socket;
-	pfx_update_fp pfx_update_fp;
-	bool added;
-};
 
 static void pfx_table_notify_diff_cb(const struct pfx_record *record, void *data)
 {

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -1090,7 +1090,12 @@ int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
                 RTR_DBG1("Reset in progress creating shadow table for atomic reset");
                 pfx_table_init(&pfx_shadow_table, NULL);
                 pfx_update_table = &pfx_shadow_table;
-                pfx_table_copy_except_socket(rtr_socket->pfx_table, pfx_update_table, rtr_socket);
+                if (pfx_table_copy_except_socket(rtr_socket->pfx_table, pfx_update_table, rtr_socket)) {
+                    RTR_DBG1("Creation of pfx shadow table failed");
+                    rtr_change_socket_state(rtr_socket, RTR_ERROR_FATAL);
+                    retval = RTR_ERROR;
+                    goto cleanup;
+                }
 
                 spki_table_init(&spki_shadow_table, NULL);
                 spki_update_table = &spki_shadow_table;

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -1214,7 +1214,7 @@ int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
     if (rtr_socket->is_resetting) {
         RTR_DBG1("Freeing shadow tables.");
         pfx_table_free_without_notify(&pfx_shadow_table);
-        spki_table_free(&spki_shadow_table);
+        spki_table_free_without_notify(&spki_shadow_table);
         rtr_socket->is_resetting = false;
     }
 

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -90,6 +90,7 @@ int rtr_init(struct rtr_socket *rtr_socket,
     rtr_socket->thread_id = 0;
     rtr_socket->version = RTR_PROTOCOL_MAX_SUPPORTED_VERSION;
     rtr_socket->has_received_pdus = false;
+    rtr_socket->is_resetting = false;
     return RTR_SUCCESS;
 }
 
@@ -120,6 +121,7 @@ void rtr_purge_outdated_records(struct rtr_socket *rtr_socket)
         rtr_socket->request_session_id = true;
         rtr_socket->serial_number = 0;
         rtr_socket->last_update = 0;
+	rtr_socket->is_resetting = true;
     }
 }
 

--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -161,6 +161,7 @@ struct rtr_socket {
     unsigned int version;
     bool has_received_pdus;
     struct spki_table *spki_table;
+    bool is_resetting;
 };
 
 /**

--- a/rtrlib/spki/hashtable/ht-spkitable.c
+++ b/rtrlib/spki/hashtable/ht-spkitable.c
@@ -339,7 +339,7 @@ void spki_table_notify_diff(struct spki_table *new_table, struct spki_table *old
 
     // Iterate new_table and try to delete every entry from the given socket in old_table
     // If the prefix could not be removed it was added in new_table and the update cb must be called
-    for(tommy_node *current_node = tommy_list_head(&new_table->list); current_node; current_node = current_node->next) {
+    for (tommy_node *current_node = tommy_list_head(&new_table->list); current_node; current_node = current_node->next) {
         struct key_entry *entry = (struct key_entry *) current_node->data;
         if (entry->socket == socket) {
             struct spki_record record;
@@ -353,7 +353,7 @@ void spki_table_notify_diff(struct spki_table *new_table, struct spki_table *old
 
     // Iterate old_table and call cb for every remianing entry from the given socket with added false
     // because it is not present in new_table
-    for(tommy_node *current_node = tommy_list_head(&old_table->list); current_node; current_node = current_node->next) {
+    for (tommy_node *current_node = tommy_list_head(&old_table->list); current_node; current_node = current_node->next) {
         struct key_entry *entry = (struct key_entry *) current_node->data;
         if (entry->socket == socket) {
             struct spki_record record;

--- a/rtrlib/spki/hashtable/ht-spkitable.c
+++ b/rtrlib/spki/hashtable/ht-spkitable.c
@@ -326,7 +326,7 @@ void spki_table_notify_diff(struct spki_table *new_table, struct spki_table *old
     old_table->update_fp = NULL;
 
     // Iterate new_table and try to delete every entry from the given socket in old_table
-    // If the prefix could not be removed it was added in new_table and teh update cb must be called
+    // If the prefix could not be removed it was added in new_table and the update cb must be called
     for(tommy_node *current_node = tommy_list_head(&new_table->list); current_node; current_node = current_node->next) {
         struct key_entry *entry = (struct key_entry *) current_node->data;
         if (entry->socket == socket) {

--- a/rtrlib/spki/hashtable/ht-spkitable.c
+++ b/rtrlib/spki/hashtable/ht-spkitable.c
@@ -102,6 +102,18 @@ void spki_table_free(struct spki_table *spki_table)
     pthread_rwlock_destroy(&spki_table->lock);
 }
 
+void spki_table_free_without_notify(struct spki_table *spki_table)
+{
+    pthread_rwlock_wrlock(&spki_table->lock);
+
+    spki_table->update_fp = NULL;
+    tommy_list_foreach(&spki_table->list, free);
+    tommy_hashlin_done(&spki_table->hashtable);
+
+    pthread_rwlock_unlock(&spki_table->lock);
+    pthread_rwlock_destroy(&spki_table->lock);
+}
+
 int spki_table_add_entry(struct spki_table *spki_table,
                          struct spki_record *spki_record)
 {

--- a/rtrlib/spki/hashtable/ht-spkitable.c
+++ b/rtrlib/spki/hashtable/ht-spkitable.c
@@ -288,3 +288,89 @@ int spki_table_src_remove(struct spki_table *spki_table,
     pthread_rwlock_unlock(&spki_table->lock);
     return SPKI_SUCCESS;
 }
+
+int spki_table_copy_except_socket(struct spki_table *src, struct spki_table *dst, struct rtr_socket *socket)
+{
+    tommy_node *current_node;
+    int ret = SPKI_SUCCESS;
+
+    pthread_rwlock_rdlock(&src->lock);
+    current_node = tommy_list_head(&src->list);
+    while (current_node) {
+        struct key_entry *entry;
+        struct spki_record record;
+
+        entry = (struct key_entry *) current_node->data;
+        key_entry_to_spki_record(entry, &record);
+
+        if (entry->socket == socket) {
+            if (spki_table_add_entry(dst, &record) != SPKI_SUCCESS) {
+                ret = SPKI_ERROR;
+                break;
+            }
+        }
+        current_node = current_node->next;
+    }
+
+    pthread_rwlock_unlock(&src->lock);
+
+    return ret;
+}
+
+void spki_table_notify_diff(struct spki_table *new_table, struct spki_table *old_table, const struct rtr_socket *socket)
+{
+    spki_update_fp old_table_fp;
+
+    // Disable update callback for old_table
+    old_table_fp = old_table->update_fp;
+    old_table->update_fp = NULL;
+
+    // Iterate new_table and try to delete every entry from the given socket in old_table
+    // If the prefix could not be removed it was added in new_table and teh update cb must be called
+    for(tommy_node *current_node = tommy_list_head(&new_table->list); current_node; current_node = current_node->next) {
+        struct key_entry *entry = (struct key_entry *) current_node->data;
+        if (entry->socket == socket) {
+            struct spki_record record;
+            key_entry_to_spki_record(entry, &record);
+
+            if (spki_table_remove_entry(old_table, &record) == SPKI_RECORD_NOT_FOUND) {
+                spki_table_notify_clients(new_table, &record, true);
+            }
+        }
+    }
+
+    // Iterate old_table and call cb for every remianing entry from the given socket with added false
+    // because it is not present in new_table
+    for(tommy_node *current_node = tommy_list_head(&old_table->list); current_node; current_node = current_node->next) {
+        struct key_entry *entry = (struct key_entry *) current_node->data;
+        if (entry->socket == socket) {
+            struct spki_record record;
+            key_entry_to_spki_record(entry, &record);
+            spki_table_notify_clients(new_table, &record, false);
+        }
+    }
+
+    // Restore original state of old_tables update_fp
+    old_table->update_fp = old_table_fp;
+}
+
+void spki_table_swap(struct spki_table *a, struct spki_table *b)
+{
+    tommy_hashlin tmp_hashtable;
+    tommy_list tmp_list;
+
+    pthread_rwlock_wrlock(&a->lock);
+    pthread_rwlock_wrlock(&b->lock);
+
+    memcpy(&tmp_hashtable, &a->hashtable, sizeof(tmp_hashtable));
+    memcpy(&tmp_list, &a->list, sizeof(tmp_list));
+
+    memcpy(&a->hashtable, &b->hashtable, sizeof(tmp_hashtable));
+    memcpy(&a->list, &b->list, sizeof(tmp_list));
+
+    memcpy(&b->hashtable, &tmp_hashtable, sizeof(tmp_hashtable));
+    memcpy(&b->list, &tmp_list, sizeof(tmp_list));
+
+    pthread_rwlock_unlock(&a->lock);
+    pthread_rwlock_unlock(&b->lock);
+}

--- a/rtrlib/spki/hashtable/ht-spkitable.c
+++ b/rtrlib/spki/hashtable/ht-spkitable.c
@@ -303,7 +303,7 @@ int spki_table_copy_except_socket(struct spki_table *src, struct spki_table *dst
         entry = (struct key_entry *) current_node->data;
         key_entry_to_spki_record(entry, &record);
 
-        if (entry->socket == socket) {
+        if (entry->socket != socket) {
             if (spki_table_add_entry(dst, &record) != SPKI_SUCCESS) {
                 ret = SPKI_ERROR;
                 break;

--- a/rtrlib/spki/spkitable.h
+++ b/rtrlib/spki/spkitable.h
@@ -141,5 +141,29 @@ int spki_table_remove_entry(struct spki_table *spki_table,
 int spki_table_src_remove(struct spki_table *spki_table,
 			  const struct rtr_socket *socket);
 
+/**
+ * @brief Copy spki table except entries from the given socket
+ * @param[in] src source table
+ * @param[in] dest target table
+ * @param[in] rtr_socket socket which entries should not be copied
+ */
+int spki_table_copy_except_socket(struct spki_table *src, struct spki_table *dest, struct rtr_socket *socket);
+
+/**
+ * @brief Notify client about changes between two spki tables regarding one specific socket
+ * @details old_table will be modified and should probebly be freed after calling this function
+ * @param[in] new_table
+ * @param[in] old_table
+ * @param[in] socket socket which entries should be diffed
+ */
+void spki_table_notify_diff(struct spki_table *new_table, struct spki_table *old_table, const struct rtr_socket *socket);
+
+/**
+ * @brief tommy_hashlin and tommy_list of the argument tables
+ * @param[in] a
+ * @param[in] b
+ */
+void spki_table_swap(struct spki_table *a, struct spki_table *b);
+
 #endif
 /* @} */

--- a/rtrlib/spki/spkitable.h
+++ b/rtrlib/spki/spkitable.h
@@ -83,6 +83,12 @@ void spki_table_init(struct spki_table *spki_table, spki_update_fp update_fp);
 void spki_table_free(struct spki_table *spki_table);
 
 /**
+ * @brief Frees the memory associcated with the spki_table without calling the update callback.
+ * @param[in] spki_table spki_table that will be initialized.
+ */
+void spki_table_free_without_notify(struct spki_table *spki_table);
+
+/**
  * @brief Adds a spki_record to a spki_table.
  * @param[in] spki_table spki_table to use.
  * @param[in] spki_record spki_record that will be added.

--- a/rtrlib/spki/spkitable.h
+++ b/rtrlib/spki/spkitable.h
@@ -145,7 +145,9 @@ int spki_table_src_remove(struct spki_table *spki_table,
  * @brief Copy spki table except entries from the given socket
  * @param[in] src source table
  * @param[in] dest target table
- * @param[in] rtr_socket socket which entries should not be copied
+ * @param[in] socket socket which entries should not be copied
+ * @return SPKI_SUCCESS On success.
+ * @return SPKI_ERROR On error.
  */
 int spki_table_copy_except_socket(struct spki_table *src, struct spki_table *dest, struct rtr_socket *socket);
 

--- a/tests/test_ht_spkitable.c
+++ b/tests/test_ht_spkitable.c
@@ -608,15 +608,7 @@ static void update_spki(struct spki_table *s __attribute__((unused)),
 			const struct spki_record record,
 			const bool added)
 {
-	char c;
-
-	if (added)
-		c = '+';
-	else
-		c = '-';
-
-	printf("%c ", c);
-	printf("ASN:  %u\n  ", record.asn);
+	printf("%c ASN: %u\n", (added ? '+' : '-'), record.asn);
 
 	int i;
 	int size = sizeof(record.ski);


### PR DESCRIPTION
If a cache server is unable to perform a incremental update rtrlib resets the socket and deletes all records from that server. Once this is done it starts to recieve new records and then adds them to the tables.
In the time period between the reset and the completion of the add operation the state of the spki and pfx tabe is invalid. Validations in that time period will likely have wrong results.

This implements an atomic reset using a shadow table. It incurs a notable delay in the operations of rtrlibs thread but does not affect validation. Since a cache reset should be rare with properly implemented cache servers this should not be a problem in real world scenarios.