### PR TITLE
rtr/packets: add missing break in rtr_pdu_check_size

### DIFF
--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -425,6 +425,7 @@ static bool rtr_pdu_check_size (const struct pdu_header *pdu) {
   case SERIAL_NOTIFY:
     if (sizeof(struct pdu_serial_notify) == pdu->len)
       retval = true;
+    break;
   case CACHE_RESPONSE:
     if (sizeof(struct pdu_cache_response) == pdu->len)
       retval = true;


### PR DESCRIPTION
In the case SERIAL_NOTIFY there is no break causing it to fall through.
If we receive a malformed SERIAL_NOTIFY with the len field set to the
length of CACHE_RESPONSE this would lead to false positive of the pdu
size check. Resulting in possible out of bound reads.