### PR TITLE
tools: fix install type for tools

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(rtrclient rtrclient.c)
 target_link_libraries(rtrclient rtrlib)
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rtrclient DESTINATION bin)
+install(TARGETS rtrclient DESTINATION bin)
 
 add_executable(rpki-rov rpki-rov.c)
 target_link_libraries(rpki-rov rtrlib)
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rpki-rov DESTINATION bin)
+install(TARGETS rpki-rov DESTINATION bin)
 


### PR DESCRIPTION
According to the cmake documentation TARGETS is supposed to be used for
all files that where build by the project. PROGRAMS is for scripts and
such.