### PR TITLE
Add description to CMake project() command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-project(rtrlib C)
+project(rtrlib
+    DESCRIPTION "Lightweight C library that implements the RPKI/RTR protocol and prefix origin validation."
+    LANGUAGES C)
 
 cmake_minimum_required(VERSION 2.6)
 


### PR DESCRIPTION
This description is used at least in the pkg-config file, where it is currently empty. (Feel free to change the description to whatever you like best.)