### PR TITLE
 rtr: prefix interval mode symbols 

### DIFF
--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -204,23 +204,23 @@ int rtr_check_interval_range(uint32_t interval, uint32_t minimum,
 			     uint32_t maximum)
 {
     if (interval < minimum) {
-        return BELOW_INTERVAL_RANGE;
+        return RTR_BELOW_INTERVAL_RANGE;
     } else if (interval > maximum) {
-        return ABOVE_INTERVAL_RANGE;
+        return RTR_ABOVE_INTERVAL_RANGE;
     }
 
-    return INSIDE_INTERVAL_RANGE;
+    return RTR_INSIDE_INTERVAL_RANGE;
 }
 
 void apply_interval_value(struct rtr_socket *rtr_socket,
 			  uint32_t interval,
-			  enum interval_type type)
+			  enum rtr_interval_type type)
 {
-    if (type == EXPIRATION) {
+    if (type == RTR_INTERVAL_TYPE_EXPIRATION) {
         rtr_socket->expire_interval = interval;
-    } else if (type == REFRESH) {
+    } else if (type == RTR_INTERVAL_TYPE_REFRESH) {
         rtr_socket->refresh_interval = interval;
-    } else if (type == RETRY) {
+    } else if (type == RTR_INTERVAL_TYPE_RETRY) {
         rtr_socket->retry_interval = interval;
     }
 }
@@ -228,7 +228,7 @@ void apply_interval_value(struct rtr_socket *rtr_socket,
 int rtr_check_interval_option(struct rtr_socket *rtr_socket,
 			      int interval_mode,
 			      uint32_t interval,
-			      enum interval_type type)
+			      enum rtr_interval_type type)
 {
     uint16_t minimum;
     uint32_t maximum;
@@ -236,17 +236,17 @@ int rtr_check_interval_option(struct rtr_socket *rtr_socket,
     int interv_retval;
 
     switch (type) {
-    case EXPIRATION:
+    case RTR_INTERVAL_TYPE_EXPIRATION:
         minimum = RTR_EXPIRATION_MIN;
         maximum = RTR_EXPIRATION_MAX;
         interv_retval = rtr_check_interval_range(interval, minimum, maximum);
         break;
-    case REFRESH:
+    case RTR_INTERVAL_TYPE_REFRESH:
         minimum = RTR_REFRESH_MIN;
         maximum = RTR_REFRESH_MAX;
         interv_retval = rtr_check_interval_range(interval, minimum, maximum);
         break;
-    case RETRY:
+    case RTR_INTERVAL_TYPE_RETRY:
         minimum = RTR_RETRY_MIN;
         maximum = RTR_RETRY_MAX;
         interv_retval = rtr_check_interval_range(interval, minimum, maximum);
@@ -256,11 +256,11 @@ int rtr_check_interval_option(struct rtr_socket *rtr_socket,
         return RTR_ERROR;
     }
 
-    if (interv_retval == INSIDE_INTERVAL_RANGE ||
-	interval_mode == ACCEPT_ANY) {
+    if (interv_retval == RTR_INSIDE_INTERVAL_RANGE ||
+	interval_mode == RTR_INTERVAL_MODE_ACCEPT_ANY) {
         apply_interval_value(rtr_socket, interval, type);
-    } else if (interval_mode == DEFAULT_MIN_MAX) {
-        if (interv_retval == BELOW_INTERVAL_RANGE)
+    } else if (interval_mode == RTR_INTERVAL_MODE_DEFAULT_MIN_MAX) {
+        if (interv_retval == RTR_BELOW_INTERVAL_RANGE)
             apply_interval_value(rtr_socket, minimum, type);
         else
             apply_interval_value(rtr_socket, maximum, type);
@@ -1053,10 +1053,10 @@ int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
             }
 
             if (eod_pdu->ver == RTR_PROTOCOL_VERSION_1
-                    && rtr_socket->iv_mode != IGNORE_ANY) {
+                    && rtr_socket->iv_mode != RTR_INTERVAL_MODE_IGNORE_ANY) {
 
                 int interv_retval;
-                interv_retval = rtr_check_interval_option(rtr_socket, rtr_socket->iv_mode, ((struct pdu_end_of_data_v1 *) pdu)->expire_interval, EXPIRATION);
+                interv_retval = rtr_check_interval_option(rtr_socket, rtr_socket->iv_mode, ((struct pdu_end_of_data_v1 *) pdu)->expire_interval, RTR_INTERVAL_TYPE_EXPIRATION);
 
                 if(interv_retval == RTR_ERROR) {
                     interval_send_error_pdu(rtr_socket, pdu, ((struct pdu_end_of_data_v1 *) pdu)->expire_interval, RTR_EXPIRATION_MIN, RTR_EXPIRATION_MAX);
@@ -1064,7 +1064,7 @@ int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
                     goto cleanup;
                 }
 
-                interv_retval = rtr_check_interval_option(rtr_socket, rtr_socket->iv_mode, ((struct pdu_end_of_data_v1 *) pdu)->refresh_interval, REFRESH);
+                interv_retval = rtr_check_interval_option(rtr_socket, rtr_socket->iv_mode, ((struct pdu_end_of_data_v1 *) pdu)->refresh_interval, RTR_INTERVAL_TYPE_REFRESH);
 
                 if(interv_retval == RTR_ERROR) {
                     interval_send_error_pdu(rtr_socket, pdu, ((struct pdu_end_of_data_v1 *) pdu)->refresh_interval, RTR_REFRESH_MIN, RTR_REFRESH_MAX);
@@ -1072,7 +1072,7 @@ int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
                     goto cleanup;
                 }
 
-                interv_retval = rtr_check_interval_option(rtr_socket, rtr_socket->iv_mode, ((struct pdu_end_of_data_v1 *) pdu)->retry_interval, RETRY);
+                interv_retval = rtr_check_interval_option(rtr_socket, rtr_socket->iv_mode, ((struct pdu_end_of_data_v1 *) pdu)->retry_interval, RTR_INTERVAL_TYPE_RETRY);
 
                 if(interv_retval == RTR_ERROR) {
                     interval_send_error_pdu(rtr_socket, pdu, ((struct pdu_end_of_data_v1 *) pdu)->retry_interval, RTR_RETRY_MIN, RTR_RETRY_MAX);

--- a/rtrlib/rtr/packets.h
+++ b/rtrlib/rtr/packets.h
@@ -28,9 +28,9 @@ int rtr_check_interval_range(uint32_t interval, uint32_t minimum,
 			     uint32_t maximum);
 void apply_interval_value(struct rtr_socket *rtr_socket,
 			  uint32_t interval,
-			  enum interval_type type);
+			  enum rtr_interval_type type);
 int rtr_check_interval_option(struct rtr_socket *rtr_socket,
 			      int interval_mode,
 			      uint32_t interval,
-			      enum interval_type type);
+			      enum rtr_interval_type type);
 #endif

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -250,11 +250,13 @@ const char *rtr_state_to_str(enum rtr_socket_state state)
     return socket_str_states[state];
 }
 
+/* cppcheck-suppress unusedFunction */
 enum rtr_interval_mode rtr_get_interval_mode(struct rtr_socket *rtr_socket)
 {
 	return rtr_socket->iv_mode;
 }
 
+/* cppcheck-suppress unusedFunction */
 void rtr_set_interval_mode(struct rtr_socket *rtr_socket, enum rtr_interval_mode option)
 {
 	switch (option) {

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -59,7 +59,7 @@ int rtr_init(struct rtr_socket *rtr_socket,
               const unsigned int refresh_interval,
               const unsigned int expire_interval,
               const unsigned int retry_interval,
-	      enum interval_mode iv_mode,
+	      enum rtr_interval_mode iv_mode,
               rtr_connection_state_fp fp, void *fp_param_config,
 	      void *fp_param_group)
 {
@@ -67,9 +67,9 @@ int rtr_init(struct rtr_socket *rtr_socket,
         rtr_socket->tr_socket = tr;
 
     // Check if one of the intervals is not in range of the predefined values.
-    if(rtr_check_interval_range(refresh_interval, RTR_REFRESH_MIN, RTR_REFRESH_MAX) != INSIDE_INTERVAL_RANGE ||
-       rtr_check_interval_range(expire_interval, RTR_EXPIRATION_MIN, RTR_EXPIRATION_MAX) != INSIDE_INTERVAL_RANGE ||
-       rtr_check_interval_range(retry_interval, RTR_RETRY_MIN, RTR_RETRY_MAX) != INSIDE_INTERVAL_RANGE) {
+    if(rtr_check_interval_range(refresh_interval, RTR_REFRESH_MIN, RTR_REFRESH_MAX) != RTR_INSIDE_INTERVAL_RANGE ||
+       rtr_check_interval_range(expire_interval, RTR_EXPIRATION_MIN, RTR_EXPIRATION_MAX) != RTR_INSIDE_INTERVAL_RANGE ||
+       rtr_check_interval_range(retry_interval, RTR_RETRY_MIN, RTR_RETRY_MAX) != RTR_INSIDE_INTERVAL_RANGE) {
         RTR_DBG("Interval value not in range.");
         return RTR_INVALID_PARAM;
     }
@@ -249,3 +249,23 @@ const char *rtr_state_to_str(enum rtr_socket_state state)
 {
     return socket_str_states[state];
 }
+
+enum rtr_interval_mode rtr_get_interval_mode(struct rtr_socket *rtr_socket)
+{
+	return rtr_socket->iv_mode;
+}
+
+void rtr_set_interval_mode(struct rtr_socket *rtr_socket, enum rtr_interval_mode option)
+{
+	switch (option) {
+	case RTR_INTERVAL_MODE_IGNORE_ANY:
+	case RTR_INTERVAL_MODE_ACCEPT_ANY:
+	case RTR_INTERVAL_MODE_DEFAULT_MIN_MAX:
+	case RTR_INTERVAL_MODE_IGNORE_ON_FAILURE:
+		rtr_socket->iv_mode = option;
+		break;
+	default:
+		RTR_DBG1("Invalid interval mode. Mode remains unchanged.");
+	}
+}
+

--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -51,26 +51,26 @@ enum rtr_rtvals {
     RTR_INVALID_PARAM = -2
 };
 
-enum interval_range {
-    BELOW_INTERVAL_RANGE = -1,
-    INSIDE_INTERVAL_RANGE = 0,
-    ABOVE_INTERVAL_RANGE = 1
+enum rtr_interval_range {
+    RTR_BELOW_INTERVAL_RANGE = -1,
+    RTR_INSIDE_INTERVAL_RANGE = 0,
+    RTR_ABOVE_INTERVAL_RANGE = 1
 };
 
-enum interval_type {
-    EXPIRATION,
-    REFRESH,
-    RETRY
+enum rtr_interval_type {
+    RTR_INTERVAL_TYPE_EXPIRATION,
+    RTR_INTERVAL_TYPE_REFRESH,
+    RTR_INTERVAL_TYPE_RETRY
 };
 
 /**
  * @brief These modes let the user configure how received intervals should be handled.
  */
-enum interval_mode {
-    IGNORE_ANY,         /*< Ignore appliance of interval values at all. */
-    ACCEPT_ANY,         /*< Accept any interval values, even if outside of range. */
-    DEFAULT_MIN_MAX,    /*< If interval value is outside of range, apply min (if below range) or max (if above range). */
-    IGNORE_ON_FAILURE   /*< Ignore any interval values that are outside of range. */
+enum rtr_interval_mode {
+    RTR_INTERVAL_MODE_IGNORE_ANY,         /*< Ignore appliance of interval values at all. */
+    RTR_INTERVAL_MODE_ACCEPT_ANY,         /*< Accept any interval values, even if outside of range. */
+    RTR_INTERVAL_MODE_DEFAULT_MIN_MAX,    /*< If interval value is outside of range, apply min (if below range) or max (if above range). */
+    RTR_INTERVAL_MODE_IGNORE_ON_FAILURE   /*< Ignore any interval values that are outside of range. */
 };
 
 /**
@@ -148,7 +148,7 @@ struct rtr_socket {
     time_t last_update;
     unsigned int expire_interval;
     unsigned int retry_interval;
-    enum interval_mode iv_mode;
+    enum rtr_interval_mode iv_mode;
     enum rtr_socket_state state;
     uint32_t session_id;
     bool request_session_id;
@@ -191,7 +191,7 @@ struct rtr_socket {
 int rtr_init(struct rtr_socket *rtr_socket, struct tr_socket *tr_socket, struct pfx_table *pfx_table,
              struct spki_table *spki_table, const unsigned int refresh_interval,
              const unsigned int expire_interval, const unsigned int retry_interval,
-             enum interval_mode iv_mode, rtr_connection_state_fp fp, void *fp_data_config,
+             enum rtr_interval_mode iv_mode, rtr_connection_state_fp fp, void *fp_data_config,
 	     void *fp_data_group);
 
 /**
@@ -216,5 +216,20 @@ void rtr_stop(struct rtr_socket *rtr_socket);
  * @return !=NULL The rtr_socket_state as String.
  */
 const char *rtr_state_to_str(enum rtr_socket_state state);
+
+/**
+ * @brief Set the interval option to the desired one. It's either RTR_INTERVAL_MODE_IGNORE_ANY,
+ * RTR_INTERVAL_MODE_APPLY_ANY, RTR_INTERVAL_MODE_DEFAULT_MIN_MAX or RTR_INTERVAL_MODE_IGNORE_ON_FAILURE.
+ * @param[in] rtr_socket The target socket.
+ * @param[in] option The new interval option that should be applied.
+ */
+void rtr_set_interval_mode(struct rtr_socket *rtr_socket, enum rtr_interval_mode option);
+
+/**
+ * @brief Get the current interval mode.
+ * @param[in] rtr_socket The target socket.
+ * @return The value of the interval_option variable.
+ */
+enum rtr_interval_mode rtr_get_interval_mode(struct rtr_socket *rtr_socket);
 #endif
 /* @} */

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -34,25 +34,6 @@ static void rtr_mgr_cb(const struct rtr_socket *sock,
 		       const enum rtr_socket_state state,
 		       void *data_config, void *data_group);
 
-int get_interval_mode(struct rtr_socket *rtr_socket)
-{
-	return rtr_socket->iv_mode;
-}
-
-void set_interval_mode(struct rtr_socket *rtr_socket, int option)
-{
-	switch (option) {
-	case IGNORE_ANY:
-	case ACCEPT_ANY:
-	case DEFAULT_MIN_MAX:
-	case IGNORE_ON_FAILURE:
-		rtr_socket->iv_mode = option;
-		break;
-	default:
-		RTR_DBG1("Invalid interval mode. Mode remains unchanged.");
-	}
-}
-
 static void set_status(const struct rtr_mgr_config *conf,
 		       struct rtr_mgr_group *group,
 		       enum rtr_mgr_status mgr_status,
@@ -84,7 +65,7 @@ static int rtr_mgr_init_sockets(struct rtr_mgr_group *group,
 				const unsigned int refresh_interval,
 				const unsigned int expire_interval,
 				const unsigned int retry_interval,
-				enum interval_mode iv_mode)
+				enum rtr_interval_mode iv_mode)
 {
 	for (unsigned int i = 0; i < group->sockets_len; i++) {
 		enum rtr_rtvals err_code = rtr_init(group->sockets[i], NULL,
@@ -347,7 +328,7 @@ int rtr_mgr_init(struct rtr_mgr_config **config_out,
 		 void *status_fp_data)
 {
 	enum rtr_rtvals err_code = RTR_ERROR;
-	enum interval_mode iv_mode = DEFAULT_MIN_MAX;
+	enum rtr_interval_mode iv_mode = RTR_INTERVAL_MODE_DEFAULT_MIN_MAX;
 	struct pfx_table *pfxt = NULL;
 	struct spki_table *spki_table = NULL;
 	struct rtr_mgr_config *config = NULL;
@@ -578,7 +559,7 @@ int rtr_mgr_add_group(struct rtr_mgr_config *config,
 	unsigned int refresh_iv = 3600;
 	unsigned int retry_iv = 600;
 	unsigned int expire_iv = 7200;
-	enum interval_mode iv_mode = DEFAULT_MIN_MAX;
+	enum rtr_interval_mode iv_mode = RTR_INTERVAL_MODE_DEFAULT_MIN_MAX;
 	enum rtr_rtvals err_code = RTR_ERROR;
 	struct rtr_mgr_group_node *new_group_node = NULL;
 	struct rtr_mgr_group *new_group = NULL;

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -270,13 +270,6 @@ void rtr_mgr_for_each_ipv4_record(struct rtr_mgr_config *config,
 void rtr_mgr_for_each_ipv6_record(struct rtr_mgr_config *config,
 				  pfx_for_each_fp fp,
 				  void *data);
-/**
- * @brief Set the interval option to the desired one. It's either IGNORE_ANY,
- * APPLY_ANY, DEFAULT_MIN_MAX or IGNORE_ON_FAILURE.
- * @param[in] rtr_socket The target socket.
- * @param[in] option The new interval option that should be applied.
- */
-void set_interval_mode(struct rtr_socket *rtr_socket, int option);
 
 /**
  * @brief Returns the first, thus active group.
@@ -289,11 +282,5 @@ int rtr_mgr_for_each_group(struct rtr_mgr_config *config,
 			   void (*fp)(const struct rtr_mgr_group *group,
 				      void *data),
 			   void *data);
-/**
- * @brief Get the current interval mode.
- * @param[in] rtr_socket The target socket.
- * @return The value of the interval_option variable.
- */
-int get_interval_mode(struct rtr_socket *rtr_socket);
 #endif
 /* @} */

--- a/tests/unittests/test_packets_static.c
+++ b/tests/unittests/test_packets_static.c
@@ -378,29 +378,38 @@ static void test_rtr_pdu_check_interval(void **state)
 	pdu_eod.expire_interval = 601;
 
 	/* test appliance of interval values to the rtr_socket */
-	apply_interval_value(&rtr_socket, pdu_eod.refresh_interval, REFRESH);
+	apply_interval_value(
+			&rtr_socket,
+			pdu_eod.refresh_interval,
+			RTR_INTERVAL_TYPE_REFRESH);
 	assert_int_equal(rtr_socket.refresh_interval,
 			 pdu_eod.refresh_interval);
 
-	apply_interval_value(&rtr_socket, pdu_eod.retry_interval, RETRY);
+	apply_interval_value(
+			&rtr_socket,
+			pdu_eod.retry_interval,
+			RTR_INTERVAL_TYPE_RETRY);
 	assert_int_equal(rtr_socket.retry_interval, pdu_eod.retry_interval);
 
-	apply_interval_value(&rtr_socket, pdu_eod.expire_interval, EXPIRATION);
+	apply_interval_value(
+			&rtr_socket,
+			pdu_eod.expire_interval,
+			RTR_INTERVAL_TYPE_EXPIRATION);
 	assert_int_equal(rtr_socket.expire_interval, pdu_eod.expire_interval);
 
 	/* test checks that determine if value is inside range */
 	retval = rtr_check_interval_range(pdu_eod.refresh_interval,
 					  RTR_REFRESH_MIN, RTR_REFRESH_MAX);
-	assert_int_equal(retval, INSIDE_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_INSIDE_INTERVAL_RANGE);
 
 	retval = rtr_check_interval_range(pdu_eod.retry_interval,
 					  RTR_RETRY_MIN, RTR_RETRY_MAX);
-	assert_int_equal(retval, INSIDE_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_INSIDE_INTERVAL_RANGE);
 
 	retval = rtr_check_interval_range(pdu_eod.expire_interval,
 					  RTR_EXPIRATION_MIN,
 					  RTR_EXPIRATION_MAX);
-	assert_int_equal(retval, INSIDE_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_INSIDE_INTERVAL_RANGE);
 
 	/* test checks that determine if value is below range */
 	pdu_eod.refresh_interval = RTR_REFRESH_MIN - 1;
@@ -409,16 +418,16 @@ static void test_rtr_pdu_check_interval(void **state)
 
 	retval = rtr_check_interval_range(pdu_eod.refresh_interval,
 					  RTR_REFRESH_MIN, RTR_REFRESH_MAX);
-	assert_int_equal(retval, BELOW_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_BELOW_INTERVAL_RANGE);
 
 	retval = rtr_check_interval_range(pdu_eod.retry_interval,
 					  RTR_RETRY_MIN, RTR_RETRY_MAX);
-	assert_int_equal(retval, BELOW_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_BELOW_INTERVAL_RANGE);
 
 	retval = rtr_check_interval_range(pdu_eod.expire_interval,
 					  RTR_EXPIRATION_MIN,
 					  RTR_EXPIRATION_MAX);
-	assert_int_equal(retval, BELOW_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_BELOW_INTERVAL_RANGE);
 
 	/* test checks that determine if value is above range */
 	pdu_eod.refresh_interval = RTR_REFRESH_MAX + 1;
@@ -427,51 +436,66 @@ static void test_rtr_pdu_check_interval(void **state)
 
 	retval = rtr_check_interval_range(pdu_eod.refresh_interval,
 					  RTR_REFRESH_MIN, RTR_REFRESH_MAX);
-	assert_int_equal(retval, ABOVE_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_ABOVE_INTERVAL_RANGE);
 
 	retval = rtr_check_interval_range(pdu_eod.retry_interval,
 					  RTR_RETRY_MIN, RTR_RETRY_MAX);
-	assert_int_equal(retval, ABOVE_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_ABOVE_INTERVAL_RANGE);
 
 	retval = rtr_check_interval_range(pdu_eod.expire_interval,
 					  RTR_EXPIRATION_MIN,
 					  RTR_EXPIRATION_MAX);
-	assert_int_equal(retval, ABOVE_INTERVAL_RANGE);
+	assert_int_equal(retval, RTR_ABOVE_INTERVAL_RANGE);
 
 	/* test the different interval options the user can choose */
 	rtr_socket.refresh_interval = 0;
 	pdu_eod.refresh_interval = 42;
-	retval = rtr_check_interval_option(&rtr_socket, ACCEPT_ANY,
-					   pdu_eod.refresh_interval, REFRESH);
+	retval = rtr_check_interval_option(
+			&rtr_socket,
+			RTR_INTERVAL_MODE_ACCEPT_ANY,
+			pdu_eod.refresh_interval,
+			RTR_INTERVAL_TYPE_REFRESH);
 	assert_int_equal(retval, RTR_SUCCESS);
 	assert_int_equal(rtr_socket.refresh_interval,
 			 pdu_eod.refresh_interval);
 
 	rtr_socket.refresh_interval = 0;
 	pdu_eod.refresh_interval = RTR_REFRESH_MAX + 1;
-	retval = rtr_check_interval_option(&rtr_socket, DEFAULT_MIN_MAX,
-					   pdu_eod.refresh_interval, REFRESH);
+	retval = rtr_check_interval_option(
+			&rtr_socket,
+			RTR_INTERVAL_MODE_DEFAULT_MIN_MAX,
+			pdu_eod.refresh_interval,
+			RTR_INTERVAL_TYPE_REFRESH);
 	assert_int_equal(retval, RTR_SUCCESS);
 	assert_int_equal(rtr_socket.refresh_interval, RTR_REFRESH_MAX);
 
 	rtr_socket.refresh_interval = 0;
 	pdu_eod.refresh_interval = RTR_REFRESH_MIN - 1;
-	retval = rtr_check_interval_option(&rtr_socket, DEFAULT_MIN_MAX,
-					   pdu_eod.refresh_interval, REFRESH);
+	retval = rtr_check_interval_option(
+			&rtr_socket,
+			RTR_INTERVAL_MODE_DEFAULT_MIN_MAX,
+			pdu_eod.refresh_interval,
+			RTR_INTERVAL_TYPE_REFRESH);
 	assert_int_equal(retval, RTR_SUCCESS);
 	assert_int_equal(rtr_socket.refresh_interval, RTR_REFRESH_MIN);
 
 	rtr_socket.refresh_interval = 42;
 	pdu_eod.refresh_interval = RTR_REFRESH_MIN - 1;
-	retval = rtr_check_interval_option(&rtr_socket, IGNORE_ON_FAILURE,
-					   pdu_eod.refresh_interval, REFRESH);
+	retval = rtr_check_interval_option(
+			&rtr_socket,
+			RTR_INTERVAL_MODE_IGNORE_ON_FAILURE,
+			pdu_eod.refresh_interval,
+			RTR_INTERVAL_TYPE_REFRESH);
 	assert_int_equal(retval, RTR_SUCCESS);
 	assert_int_equal(rtr_socket.refresh_interval, 42);
 
 	rtr_socket.refresh_interval = 0;
 	pdu_eod.refresh_interval = RTR_REFRESH_MAX + 1;
-	retval = rtr_check_interval_option(&rtr_socket, ACCEPT_ANY,
-					   pdu_eod.refresh_interval, REFRESH);
+	retval = rtr_check_interval_option(
+			&rtr_socket,
+			RTR_INTERVAL_MODE_ACCEPT_ANY,
+			pdu_eod.refresh_interval,
+			RTR_INTERVAL_TYPE_REFRESH);
 	assert_int_equal(retval, RTR_SUCCESS);
 	assert_int_equal(rtr_socket.refresh_interval, RTR_REFRESH_MAX + 1);
 }
@@ -482,20 +506,29 @@ static void test_set_interval_option(void **state)
 
 	struct rtr_socket rtr_socket;
 
-	set_interval_mode(&rtr_socket, IGNORE_ANY);
-	assert_int_equal(get_interval_mode(&rtr_socket), IGNORE_ANY);
+	rtr_set_interval_mode(&rtr_socket, RTR_INTERVAL_MODE_IGNORE_ANY);
+	assert_int_equal(
+			rtr_get_interval_mode(&rtr_socket),
+			RTR_INTERVAL_MODE_IGNORE_ANY);
 
-	set_interval_mode(&rtr_socket, ACCEPT_ANY);
-	assert_int_equal(get_interval_mode(&rtr_socket), ACCEPT_ANY);
+	rtr_set_interval_mode(&rtr_socket, RTR_INTERVAL_MODE_ACCEPT_ANY);
+	assert_int_equal(
+			rtr_get_interval_mode(&rtr_socket),
+			RTR_INTERVAL_MODE_ACCEPT_ANY);
 
-	set_interval_mode(&rtr_socket, DEFAULT_MIN_MAX);
-	assert_int_equal(get_interval_mode(&rtr_socket), DEFAULT_MIN_MAX);
+	rtr_set_interval_mode(&rtr_socket, RTR_INTERVAL_MODE_DEFAULT_MIN_MAX);
+	assert_int_equal(
+			rtr_get_interval_mode(&rtr_socket),
+			RTR_INTERVAL_MODE_DEFAULT_MIN_MAX);
 
-	set_interval_mode(&rtr_socket, IGNORE_ON_FAILURE);
-	assert_int_equal(get_interval_mode(&rtr_socket), IGNORE_ON_FAILURE);
+	rtr_set_interval_mode(
+			&rtr_socket, RTR_INTERVAL_MODE_IGNORE_ON_FAILURE);
+	assert_int_equal(
+			rtr_get_interval_mode(&rtr_socket),
+			RTR_INTERVAL_MODE_IGNORE_ON_FAILURE);
 
-	set_interval_mode(&rtr_socket, 4);
-	assert(get_interval_mode(&rtr_socket) != 4);
+	rtr_set_interval_mode(&rtr_socket, 4);
+	assert(rtr_get_interval_mode(&rtr_socket) != 4);
 }
 
 int main(void)


### PR DESCRIPTION
The intervals mode symbols do not have a prefix at all right now. This
is problematic because it could easily lead to name collisions when used
in other projects.
Furthermore are the {set,get}_interval_mode functions in the wrong place
they operate on rtr_sockets and should therefore be in rtr.c not in
rtr_mgr.c

While this is a breaking API change I argue that it does not really
matter because the interval mode code has never officially been
released.