### PR TITLE
cmake: set project description in a way that is compatible with cmake<=3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(rtrlib
-    DESCRIPTION "Lightweight C library that implements the RPKI/RTR protocol and prefix origin validation."
     LANGUAGES C)
+
+set(PROJECT_DESCRIPTION "Lightweight C library that implements the RPKI/RTR protocol and prefix origin validation.")
 
 cmake_minimum_required(VERSION 2.6)
 


### PR DESCRIPTION
set project description in a way that is compatible with cmake<=3.8