### PR TITLE
Issues with 0.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-project(rtrlib
-    LANGUAGES C)
+project(rtrlib C)
 
 set(PROJECT_DESCRIPTION "Lightweight C library that implements the RPKI/RTR protocol and prefix origin validation.")
 

--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -6,7 +6,7 @@ Group:          Development/Libraries
 License:        MIT
 URL:            http://rpki.realmv6.org/
 Source0:        %{name}-%{version}.tar.gz
-BuildRequires:  binutils gcc tar chrpath cmake libssh-devel >= 0.5.0 doxygen
+BuildRequires:  binutils gcc tar cmake libssh-devel >= 0.5.0 doxygen
 Requires:       libssh >= 0.5.0
 
 %description
@@ -74,9 +74,7 @@ make %{?_smp_mflags}
 %install
 %make_install
 strip $RPM_BUILD_ROOT/usr/lib64/librtr.so.%{version}
-chrpath -d $RPM_BUILD_ROOT/usr/bin/rpki-rov
 strip $RPM_BUILD_ROOT/usr/bin/rpki-rov
-chrpath -d $RPM_BUILD_ROOT/usr/bin/rtrclient
 strip $RPM_BUILD_ROOT/usr/bin/rtrclient
 cp %{_topdir}/BUILD/CHANGELOG %{buildroot}/%{_docdir}/rtrlib/
 cp %{_topdir}/BUILD/LICENSE %{buildroot}/%{_docdir}/rtrlib/

--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -1,5 +1,5 @@
 Name:           librtr
-Version:        0.5.0
+Version:        0.6.0
 Release:        1%{?dist}
 Summary:        Small extensible RPKI-RTR-Client C library
 Group:          Development/Libraries


### PR DESCRIPTION
I unfortunately noticed two issues with the current release.

1. rpms do not build at all, because we forgot to increase the version number which is used to find the so.
2. Older cmake versions take issue on the LANGUAGES keyword in the project call. 

While I was at it I removed some now unneeded build steps from the spec file.

We should consider releasing this as a bugfix release.