### PR TITLE
tests: remove use of u_int32_t

### DIFF
--- a/tests/test_ht_spkitable.c
+++ b/tests/test_ht_spkitable.c
@@ -7,6 +7,7 @@
  * Website: http://rtrlib.realmv6.org/
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -61,11 +62,11 @@ static struct spki_record *create_record(int ASN,
 	memset(record, 0, sizeof(*record));
 	record->asn = ASN;
 
-	for (i = 0; i < sizeof(record->ski) / sizeof(u_int32_t); i++)
-		((u_int32_t *)record->ski)[i] = i + ski_offset;
+	for (i = 0; i < sizeof(record->ski) / sizeof(uint32_t); i++)
+		((uint32_t *)record->ski)[i] = i + ski_offset;
 
-	for (i = 0; i < sizeof(record->spki) / sizeof(u_int32_t); i++)
-		((u_int32_t *)record->spki)[i] = i + spki_offset;
+	for (i = 0; i < sizeof(record->spki) / sizeof(uint32_t); i++)
+		((uint32_t *)record->spki)[i] = i + spki_offset;
 
 	record->socket = socket;
 	return record;


### PR DESCRIPTION
u_int32_t seems to be non standard, while uint32_t is part of the C standard since C99.


I noticed this because the test fails to build on freebsd since the header restructuring.
It relied on transitive includes that are not satisfied anymore on (free)bsd but still are on gnu libc based systems.