### PR TITLE
debian packaging updates for 0.6.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ librtr0 (0.6.1.1) UNRELEASED; urgency=medium
 
   * add myself as maintainer as I'll be uploading this to mentors.
   * flip priorities from extra to optional (4.0.1 policy)
+  * add watch file (4.1.4 policy)
 
  -- David Lamparter <equinox-debian@diac24.net>  Thu, 25 Oct 2018 13:29:03 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-librtr0 (0.6.1.1) UNRELEASED; urgency=medium
+librtr0 (0.6.1.1) testing; urgency=medium
 
   * add myself as maintainer as I'll be uploading this to mentors.
   * flip priorities from extra to optional (4.0.1 policy)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+librtr0 (0.6.1.1) UNRELEASED; urgency=medium
+
+  * add myself as maintainer as I'll be uploading this to mentors.
+
+ -- David Lamparter <equinox-debian@diac24.net>  Thu, 25 Oct 2018 13:29:03 +0200
+
 librtr0 (0.6.1.0) stable; urgency=high
   * Fix for cmake versions >= 2.8
   * Fix rpm build

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ librtr0 (0.6.1.1) UNRELEASED; urgency=medium
   * add myself as maintainer as I'll be uploading this to mentors.
   * flip priorities from extra to optional (4.0.1 policy)
   * add watch file (4.1.4 policy)
+  * remove shlib:Depends from rtr-tools-dbg
 
  -- David Lamparter <equinox-debian@diac24.net>  Thu, 25 Oct 2018 13:29:03 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 librtr0 (0.6.1.1) UNRELEASED; urgency=medium
 
   * add myself as maintainer as I'll be uploading this to mentors.
+  * flip priorities from extra to optional (4.0.1 policy)
 
  -- David Lamparter <equinox-debian@diac24.net>  Thu, 25 Oct 2018 13:29:03 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,8 @@
 Source: librtr0
 Section: libs
 Priority: optional
-Maintainer: Fabian Holler <mail@fholler.de>
+Maintainer: David Lamparter <equinox-debian@diac24.net>
+Uploaders: Fabian Holler <mail@fholler.de>
 Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev (>= 0.5.0), doxygen
 Standards-Version: 3.9.6
 Vcs-Git: git://github.com/rtrlib/rtrlib.git

--- a/debian/control
+++ b/debian/control
@@ -83,7 +83,7 @@ Package: rtr-tools-dbg
 Priority: optional
 Section: debug
 Architecture: any
-Depends: rtr-tools (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
+Depends: rtr-tools (= ${binary:Version}), ${misc:Depends}
 Description: RPKI-RTR command line tools
  Contains rtrclient and rpki-rov.
  rtrclient is command line that connects to an RPKI-RTR server and prints

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: David Lamparter <equinox-debian@diac24.net>
 Uploaders: Fabian Holler <mail@fholler.de>
 Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev (>= 0.5.0), doxygen
-Standards-Version: 4.0.1
+Standards-Version: 4.1.4
 Vcs-Git: git://github.com/rtrlib/rtrlib.git
 Vcs-Browser: https://github.com/rtrlib/rtrlib
 Homepage: http://rpki.realmv6.org/

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: David Lamparter <equinox-debian@diac24.net>
 Uploaders: Fabian Holler <mail@fholler.de>
 Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev (>= 0.5.0), doxygen
-Standards-Version: 3.9.6
+Standards-Version: 4.0.1
 Vcs-Git: git://github.com/rtrlib/rtrlib.git
 Vcs-Browser: https://github.com/rtrlib/rtrlib
 Homepage: http://rpki.realmv6.org/
@@ -38,7 +38,7 @@ Description: Small extensible RPKI-RTR-Client C library. Development files
  This package contains development files.
 
 Package: librtr-dbg
-Priority: extra
+Priority: optional
 Section: debug
 Architecture: any
 Multi-Arch: same
@@ -80,7 +80,7 @@ Description: RPKI-RTR command line tools
 
 
 Package: rtr-tools-dbg
-Priority: extra
+Priority: optional
 Section: debug
 Architecture: any
 Depends: rtr-tools (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,5 @@
+version=4
+
+opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%rtrlib-$1.tar.gz%" \
+https://github.com/rtrlib/rtrlib/releases \
+	.*?/v(\d[\d.]*)\.tar\.gz debian uupdate


### PR DESCRIPTION
After getting tired of waiting for someone of the Debian people to pick things up, I decided to go upload at https://mentors.debian.net/ myself :)

This is just a bunch of cleanups on the debian packaging.

NB: it would be very nice if you could put a release tag (v0.6.1.1) at commit 70874d6 so the version numbers match up (pretty please :D)