### PR TITLE
pfx: expose enough of pfxt to make it independently usable

### DIFF
--- a/rtrlib/pfx/pfx_private.h
+++ b/rtrlib/pfx/pfx_private.h
@@ -21,19 +21,6 @@
 #include "rtrlib/pfx/pfx.h"
 #include "rtrlib/lib/ip_private.h"
 
-/**
- * @brief Initializes the pfx_table struct.
- * @param[in] pfx_table pfx_table that will be initialized.
- * @param[in] update_fp Afunction pointers that will be called if a record was added or removed.
- */
-void pfx_table_init(struct pfx_table *pfx_table, pfx_update_fp update_fp);
-
-/**
- * @brief Frees all memory associcated with the pfx_table.
- * @param[in] pfx_table pfx_table that will be freed.
- */
-void pfx_table_free(struct pfx_table *pfx_table);
-
 
 /**
  * @brief Frees all memory associcated with the pfx_table without calling the update callback.
@@ -42,45 +29,11 @@ void pfx_table_free(struct pfx_table *pfx_table);
 void pfx_table_free_without_notify(struct pfx_table *pfx_table);
 
 /**
- * @brief Adds a pfx_record to a pfx_table.
- * @param[in] pfx_table pfx_table to use.
- * @param[in] pfx_record pfx_record that will be added.
- * @return PFX_SUCCESS On success.
- * @return PFX_ERROR On error.
- * @return PFX_DUPLICATE_RECORD If the pfx_record already exists.
+ * @brief Swap root nodes of the argument tables
+ * @param[in,out] a First table
+ * @param[in,out] b second table
  */
-int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *pfx_record);
-
-/**
- * @brief Removes a pfx_record from a pfx_table.
- * @param[in] pfx_table pfx_table to use.
- * @param[in] pfx_record Record that will be removed.
- * @return PFX_SUCCESS On success.
- * @return PFX_ERROR On error.
- * @return PFX_RECORD_NOT_FOUND If pfx_records could'nt be found.
- */
-int pfx_table_remove(struct pfx_table *pfx_table, const struct pfx_record *pfx_record);
-
-/**
- * @brief Removes all entries in the pfx_table that match the passed socket_id value from a pfx_table.
- * @param[in] pfx_table pfx_table to use.
- * @param[in] socket origin socket of the record
- * @return PFX_SUCCESS On success.
- * @return PFX_ERROR On error.
- */
-int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *socket);
-
-/**
- * @brief Validates the origin of a BGP-Route.
- * @param[in] pfx_table pfx_table to use.
- * @param[in] asn Autonomous system number of the Origin-AS of the route.
- * @param[in] prefix Announcend network Prefix.
- * @param[in] mask_len Length of the network mask of the announced prefix.
- * @param[out] result Result of the validation.
- * @return PFX_SUCCESS On success.
- * @return PFX_ERROR On error.
- */
-int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t mask_len, enum pfxv_state *result);
+void pfx_table_swap(struct pfx_table *a, struct pfx_table *b);
 
 /**
  * @brief Copy content of @p src_table into @p dst_table
@@ -90,13 +43,6 @@ int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const st
  * @param[in] socket socket which prefixes should not be copied
  */
 int pfx_table_copy_except_socket(struct pfx_table *src_table, struct pfx_table *dst_table, const struct rtr_socket *socket);
-
-/**
- * @brief Swap root nodes of the argument tables
- * @param[in,out] a First table
- * @param[in,out] b second table
- */
-void pfx_table_swap(struct pfx_table *a, struct pfx_table *b);
 
 /**
  * @brief Notify client about changes between to pfx tables regarding one specific socket

--- a/rtrlib/pfx/trie/trie-pfx.c
+++ b/rtrlib/pfx/trie/trie-pfx.c
@@ -12,8 +12,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-#include "rtrlib/pfx/trie/trie-pfx_private.h"
+#include "rtrlib/pfx/trie/trie-pfx.h"
 #include "rtrlib/pfx/trie/trie_private.h"
+#include "rtrlib/pfx/pfx_private.h"
 #include "rtrlib/lib/alloc_utils_private.h"
 #include "rtrlib/rtrlib_export_private.h"
 #include "rtrlib/lib/ip_private.h"
@@ -61,7 +62,7 @@ void pfx_table_notify_clients(struct pfx_table *pfx_table, const struct pfx_reco
         pfx_table->update_fp(pfx_table, *record, added);
 }
 
-void pfx_table_init(struct pfx_table *pfx_table, pfx_update_fp update_fp)
+RTRLIB_EXPORT void pfx_table_init(struct pfx_table *pfx_table, pfx_update_fp update_fp)
 {
     pfx_table->ipv4 = NULL;
     pfx_table->ipv6 = NULL;
@@ -75,7 +76,7 @@ void pfx_table_free_without_notify(struct pfx_table *pfx_table)
     pfx_table_free(pfx_table);
 }
 
-void pfx_table_free(struct pfx_table *pfx_table)
+RTRLIB_EXPORT void pfx_table_free(struct pfx_table *pfx_table)
 {
     for(int i = 0; i < 2; i++) {
         struct trie_node *root = (i == 0 ? pfx_table->ipv4 : pfx_table->ipv6);
@@ -207,7 +208,7 @@ int pfx_table_del_elem(struct node_data *data, const unsigned int index)
     return PFX_SUCCESS;
 }
 
-int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *record)
+RTRLIB_EXPORT int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *record)
 {
     pthread_rwlock_wrlock(&(pfx_table->lock));
 
@@ -257,7 +258,7 @@ int pfx_table_add(struct pfx_table *pfx_table, const struct pfx_record *record)
     return PFX_SUCCESS;
 }
 
-int pfx_table_remove(struct pfx_table *pfx_table, const struct pfx_record *record)
+RTRLIB_EXPORT int pfx_table_remove(struct pfx_table *pfx_table, const struct pfx_record *record)
 {
     pthread_rwlock_wrlock(&(pfx_table->lock));
     struct trie_node *root = pfx_table_get_root(pfx_table, record->prefix.ver);
@@ -420,12 +421,12 @@ RTRLIB_EXPORT int pfx_table_validate_r(
     return PFX_SUCCESS;
 }
 
-int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
+RTRLIB_EXPORT int pfx_table_validate(struct pfx_table *pfx_table, const uint32_t asn, const struct lrtr_ip_addr *prefix, const uint8_t prefix_len, enum pfxv_state *result)
 {
     return pfx_table_validate_r(pfx_table, NULL, NULL, asn, prefix, prefix_len, result);
 }
 
-int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *socket)
+RTRLIB_EXPORT int pfx_table_src_remove(struct pfx_table *pfx_table, const struct rtr_socket *socket)
 {
     for(unsigned int i = 0; i < 2; i++) {
         struct trie_node **root = (i == 0 ? &(pfx_table->ipv4) : &(pfx_table->ipv6));

--- a/rtrlib/pfx/trie/trie-pfx.h
+++ b/rtrlib/pfx/trie/trie-pfx.h
@@ -20,11 +20,39 @@
  * @{
  */
 
-#ifndef RTR_TRIE_PFX_PRIVATE
-#define RTR_TRIE_PFX_PRIVATE
+#ifndef RTR_TRIE_PFX
+#define RTR_TRIE_PFX
 #include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
 
-#include "rtrlib/pfx/pfx_private.h"
+#include "rtrlib/lib/ip.h"
+
+struct pfx_table;
+
+/**
+ * @brief pfx_record.
+ * @param asn Origin AS number.
+ * @param prefix IP prefix.
+ * @param min_len Minimum prefix length.
+ * @param max_len Maximum prefix length.
+ * @param socket The rtr_socket that received this record.
+ */
+struct pfx_record {
+    uint32_t asn;
+    struct lrtr_ip_addr prefix;
+    uint8_t min_len;
+    uint8_t max_len;
+    const struct rtr_socket *socket;
+};
+
+/**
+ * @brief A function pointer that is called if an record was added to the pfx_table or was removed from the pfx_table.
+ * @param pfx_table which was updated.
+ * @param record pfx_record that was modified.
+ * @param added True if the record was added, false if the record was removed.
+ */
+typedef void (*pfx_update_fp)(struct pfx_table *pfx_table, const struct pfx_record record, const bool added);
 
 /**
  * @brief pfx_table.

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -17,7 +17,7 @@
 #include "rtrlib/lib/convert_byte_order_private.h"
 #include "rtrlib/lib/log_private.h"
 #include "rtrlib/lib/utils_private.h"
-#include "rtrlib/pfx/trie/trie-pfx_private.h"
+#include "rtrlib/pfx/pfx_private.h"
 #include "rtrlib/rtr/packets_private.h"
 #include "rtrlib/rtr/rtr_private.h"
 #include "rtrlib/spki/hashtable/ht-spkitable_private.h"

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -15,7 +15,7 @@
 
 #include "rtrlib/lib/alloc_utils_private.h"
 #include "rtrlib/lib/log_private.h"
-#include "rtrlib/pfx/trie/trie-pfx_private.h"
+#include "rtrlib/pfx/pfx_private.h"
 #include "rtrlib/rtr/rtr_private.h"
 #include "rtrlib/rtr_mgr_private.h"
 #include "rtrlib/rtrlib_export_private.h"

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -17,7 +17,7 @@
 
 #include "rtrlib/lib/ip_private.h"
 #include "rtrlib/lib/utils_private.h"
-#include "rtrlib/pfx/trie/trie-pfx_private.h"
+#include "rtrlib/pfx/pfx.h"
 #include "rtrlib/pfx/trie/trie_private.h"
 #include "rtrlib/rtr/rtr.h"
 

--- a/tests/test_pfx_locks.c
+++ b/tests/test_pfx_locks.c
@@ -17,7 +17,8 @@
 #include <pthread.h>
 #include <time.h>
 #include "rtrlib/lib/ip.h"
-#include "rtrlib/pfx/trie/trie-pfx_private.h"
+#include "rtrlib/pfx/trie/trie-pfx.h"
+#include "rtrlib/pfx/pfx.h"
 
 uint32_t min_i = 0xFF000000;
 uint32_t max_i = 0xFFFFFFF0;


### PR DESCRIPTION
This exposes enough of pfxt to make it usable without rtr_mgr.

#190 
@salsh