### PR TITLE
cmake: fix library installation path (again)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,17 +27,6 @@ if(NOT APPLE)
     find_library(RT_LIB rt)
 endif(NOT APPLE)
 
-# note: this must be before the include() directives below since
-# these directives will change CMAKE_INSTALL_LIBDIR to an absolute path
-if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
-    set (PKG_CONFIG_LIBDIR ${CMAKE_INSTALL_LIBDIR})
-    set (RTRLIB_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
-else()
-    set (PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
-    set (RTRLIB_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-endif(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
-
-include(UseMultiArch) # needed for debian packaging
 include(GNUInstallDirs) # for man page install path
 
 set(RTRLIB_SRC rtrlib/rtr_mgr.c rtrlib/lib/utils.c rtrlib/lib/alloc_utils.c rtrlib/lib/convert_byte_order.c
@@ -109,7 +98,7 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/rtrlib/rtrlib.h.cmake ${CMAKE_SOURCE_DIR}/rtr
 set(LIBRARY_VERSION ${RTRLIB_VERSION_MAJOR}.${RTRLIB_VERSION_MINOR}.${RTRLIB_VERSION_PATCH})
 set(LIBRARY_SOVERSION ${RTRLIB_VERSION_MAJOR})
 set_target_properties(rtrlib PROPERTIES SOVERSION ${LIBRARY_SOVERSION} VERSION ${LIBRARY_VERSION} OUTPUT_NAME rtr)
-install(TARGETS rtrlib LIBRARY DESTINATION ${RTRLIB_INSTALL_LIBDIR}/)
+install(TARGETS rtrlib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/)
 
 
 # Get lists of all headers
@@ -134,6 +123,7 @@ if(LIBSSH_FOUND)
 endif(LIBSSH_FOUND)
 
 # '#include <rtrlib/rtrlib.h>' includes the "rtrlib/"
+set (PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
 set (PKG_CONFIG_INCLUDEDIR "\${prefix}/include")
 set (PKG_CONFIG_LIBS       "-L\${libdir} -lrtr")
 set (PKG_CONFIG_CFLAGS     "-I\${includedir}")
@@ -144,7 +134,7 @@ configure_file (
 )
 install (
     FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-    DESTINATION "${RTRLIB_INSTALL_LIBDIR}/pkgconfig"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
 #add uninstall target
 configure_file(


### PR DESCRIPTION
GNUInstallDirs and UseMultiArch conflict with each other on newer deb
based distributions because both expand CMAKE_INSTALL_LIBDIR.

Alternative to #196 