### PR TITLE
README: remove c11 requirement

### DIFF
--- a/README
+++ b/README
@@ -14,8 +14,6 @@ be found in the bin/ directory.
 
 Requirements
 ------------
-A compiler that supports C11.
-
 To build the RTRlib, the CMake build system must be installed.
 
 To establish an SSH connection between RTR-Client and RTR-Server, the


### PR DESCRIPTION
C11 was only required because of typedef forward declarations, but they
are not used anymore (see PR #188).