### PR TITLE
tests: add missing include in test_pfx

### DIFF
--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -18,6 +18,7 @@
 #include "rtrlib/lib/ip_private.h"
 #include "rtrlib/lib/utils_private.h"
 #include "rtrlib/pfx/pfx.h"
+#include "rtrlib/pfx/pfx_private.h"
 #include "rtrlib/pfx/trie/trie_private.h"
 #include "rtrlib/rtr/rtr.h"
 


### PR DESCRIPTION
The compiler complained about an implicit function declaration because
of a missing include.

Fix #208 