### PR TITLE
redhat: Fix tar command to move options before file

### DIFF
--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -60,7 +60,7 @@ allows to validate given IP prefixes and origin ASes.
 %prep
 if [ ! -f %{SOURCE0} ]; then
   # Build Source Tarball first
-  pushd `dirname %_topdir`; tar czf %{SOURCE0} . --exclude-vcs --exclude=redhat; popd
+  pushd `dirname %_topdir`; tar czf %{SOURCE0} --exclude-vcs --exclude=redhat . ; popd
 fi
 cd %{_topdir}/BUILD
 rm -rf %{name}-%{version}


### PR DESCRIPTION
Small fix for the rpm package spec file. Newer tar commands (found in Fedora 29), require the correct placement of the `--exclude options`

Fix required to build RPMs on Fedora 29 and probably other newer RPM based systems

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>