### PR TITLE
rtrlib/rtr: fix race condition in rtr_stop

### DIFF
--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -1009,6 +1009,7 @@ void recv_loop_cleanup(void *p) {
 }
 
 
+/* WARNING: This Function has cancelable sections*/
 int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
     char pdu[RTR_MAX_PDU_LEN];
     enum pdu_type type;
@@ -1282,6 +1283,7 @@ int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
     return retval;
 }
 
+/* WARNING: This Function has cancelable sections */
 int rtr_sync(struct rtr_socket *rtr_socket)
 {
     char pdu[RTR_MAX_PDU_LEN];

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -110,6 +110,7 @@ void rtr_purge_outdated_records(struct rtr_socket *rtr_socket)
     }
 }
 
+/* WARNING: This Function has cancelable sections*/
 void rtr_fsm_start(struct rtr_socket *rtr_socket)
 { 
    if (rtr_socket->state == RTR_SHUTDOWN)

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -23,8 +23,6 @@
 
 static void rtr_purge_outdated_records(struct rtr_socket *rtr_socket);
 static void rtr_fsm_start(struct rtr_socket *rtr_socket);
-static void sighandler(int b);
-static int install_sig_handler();
 
 static const char *socket_str_states[] = {
     [RTR_CONNECTING] = "RTR_CONNECTING",
@@ -38,23 +36,6 @@ static const char *socket_str_states[] = {
     [RTR_ERROR_TRANSPORT] = "RTR_ERROR_TRANSPORT",
     [RTR_SHUTDOWN] = "RTR_SHUTDOWN"
 };
-
-void sighandler(int b __attribute__((unused)) )
-{
-    return;
-}
-
-static int install_sig_handler()
-{
-    struct sigaction sa;
-    sa.sa_handler = &sighandler;
-    sigset_t mask;
-    sigemptyset(&mask);
-    sa.sa_mask = mask;
-    sa.sa_flags = 0;
-
-    return sigaction(SIGUSR1, &sa, NULL);
-}
 
 int rtr_init(struct rtr_socket *rtr_socket,
               struct tr_socket *tr,
@@ -139,7 +120,6 @@ void rtr_fsm_start(struct rtr_socket *rtr_socket)
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldcancelstate);
 
     rtr_socket->state = RTR_CONNECTING;
-    install_sig_handler();
     while(1) {
         if(rtr_socket->state == RTR_CONNECTING) {
             RTR_DBG1("State: RTR_CONNECTING");


### PR DESCRIPTION
rtr_stop currently has a race condition. It uses a unsynchronized shared
variable. Which value this variable has is therefore undefined when the
thread that rtr_stop tries to kill reads it. The only direct solution is
a explicit memory barrier, but C does not support them until C11, even
there it's optional.

The new approach uses pthread_cancel and carefully selected code regions
where it is safe to exit without freeing resources. The shared variable
is still used but we do not rely on it for timely thread exit anymore.