### PR TITLE
BGPsec support for RTRlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tags
 *.so*
 */Makefile
 rtrlib/rtrlib.h
+rtrlib/config.h
 tools/rpki-rov
 tools/rtrclient
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,25 @@ if (NOT DEFINED RTRLIB_TRANSPORT_SSH OR RTRLIB_TRANSPORT_SSH)
     endif(LIBSSH_FOUND)
 endif(NOT DEFINED RTRLIB_TRANSPORT_SSH OR RTRLIB_TRANSPORT_SSH)
 
+# bgpsec
+if(DEFINED WITH_BGPSEC AND NOT WITH_BGPSEC)
+    message(STATUS "building librtr without BGPsec support")
+else()
+    find_package(OpenSSL 1.0 QUIET)
+
+    if(OPENSSL_FOUND AND OPENSSL_CRYPTO_LIBRARY)
+        set(RTRLIB_BGPSEC_ENABLED 1)
+        include_directories(${OPENSSL_INCLUDE_DIRS})
+        set(RTRLIB_SRC ${RTRLIB_SRC} rtrlib/bgpsec/bgpsec.c rtrlib/bgpsec/bgpsec_utils.c)
+        set(RTRLIB_LINK ${RTRLIB_LINK} ${OPENSSL_LIBRARIES})
+        message(STATUS "libcrypto (OpenSSL ${OPENSSL_VERSION}) found, building librtr with BGPsec support")
+    elseif(WITH_BGPSEC)
+        message(FATAL_ERROR "libcrypto (OpenSSL) not found, aborting build.")
+    else()
+        message(STATUS "libcrypto (OpenSSL) not found, building librtr without BGPsec support.")
+    endif(OPENSSL_FOUND AND OPENSSL_CRYPTO_LIBRARY)
+endif(DEFINED WITH_BGPSEC AND NOT WITH_BGPSEC)
+
 #doxygen target
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
@@ -120,11 +139,16 @@ ADD_TEST(test_getbits tests/test_getbits)
 
 ADD_TEST(test_dynamic_groups tests/test_dynamic_groups)
 
+if(RTRLIB_BGPSEC_ENABLED)
+    ADD_TEST(test_bgpsec tests/test_bgpsec)
+endif(RTRLIB_BGPSEC_ENABLED)
+
 #install lib
 set (RTRLIB_VERSION_MAJOR 0)
 set (RTRLIB_VERSION_MINOR 8)
 set (RTRLIB_VERSION_PATCH 0)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/rtrlib/rtrlib.h.cmake ${CMAKE_SOURCE_DIR}/rtrlib/rtrlib.h)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/rtrlib/config.h.cmake ${CMAKE_SOURCE_DIR}/rtrlib/config.h)
 set(LIBRARY_VERSION ${RTRLIB_VERSION_MAJOR}.${RTRLIB_VERSION_MINOR}.${RTRLIB_VERSION_PATCH})
 set(LIBRARY_SOVERSION ${RTRLIB_VERSION_MAJOR})
 set_target_properties(rtrlib PROPERTIES SOVERSION ${LIBRARY_SOVERSION} VERSION ${LIBRARY_VERSION} OUTPUT_NAME rtr)
@@ -151,6 +175,12 @@ endforeach()
 if(RTRLIB_TRANSPORT_SSH)
     set (PKG_CONFIG_REQUIRES "libssh >= 0.5.0")
 endif(RTRLIB_TRANSPORT_SSH)
+
+if(OPENSSL_CRYPTO_LIBRARY)
+    set (PKG_CONFIG_REQUIRES ${PKG_CONFIG_REQUIRES} "libcrypto >= 1.0")
+endif(OPENSSL_CRYPTO_LIBRARY)
+
+string(REPLACE ";" ", " PKG_CONFIG_REQUIRES "${PKG_CONFIG_REQUIRES}")
 
 # '#include <rtrlib/rtrlib.h>' includes the "rtrlib/"
 set (PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ To build the RTRlib, the CMake build system must be installed.
 To establish an SSH connection between RTR-Client and RTR-Server, the
 libssh 0.6.x or higher library must also be installed.
 
+To enable BGPsec support for validating and signing AS paths, libssl
+1.0 or higher needs to be installed.
+
 cmocka (optional) is required for unit tests
 Doxygen (optional) is required to create the HTML documentation.
 
@@ -64,6 +67,18 @@ Compilation
   can pass the following argument to cmake:
 
       -D CMAKE_INSTALL_PREFIX=<path>
+
+  BGPsec support is enabled by default. If dependencies cannot be
+  resolved, rtrlib builds without BGPsec.
+  
+  To explicitly disable BGPsec:
+
+      -D WITH_BGPSEC=No
+
+  To explicitly enable BGPsec and fail the build if dependencies
+  cannot be resolved:
+
+      -D WITH_BGPSEC=Yes
 
 * Build library, tests, and tools
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: librtr0
 Section: libs
 Priority: optional
 Maintainer: Fabian Holler <mail@fholler.de>
-Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev (>= 0.5.0), doxygen
+Build-Depends: cmake, dpkg-dev (>= 1.16.1~), debhelper (>= 9), libssh-dev (>= 0.5.0), libssl1.0-dev (>= 1.0) | libssl-dev (>= 1.0), doxygen
 Standards-Version: 3.9.6
 Vcs-Git: git://github.com/rtrlib/rtrlib.git
 Vcs-Browser: https://github.com/rtrlib/rtrlib
@@ -16,9 +16,9 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, libssh-4 (>= 0.5.0)
 Description: Small extensible RPKI-RTR-Client C library.
  RTRlib is an open-source C implementation of the  RPKI/Router Protocol
  client. The library allows one to fetch and store validated prefix origin data
- from a RTR-cache and performs origin verification of prefixes. It supports
- different types of transport sessions (e.g., SSH, unprotected TCP) and is
- easily extendable.
+ from a RTR-cache and performs origin verification of prefixes. It also allows
+ validating and signing BGPsec AS paths. RTRlib supports different types of
+ transport sessions (e.g., SSH, unprotected TCP) and is easily extendable.
 
 Package: librtr-dev
 Section: libdevel
@@ -30,9 +30,9 @@ Suggests: librtr-doc
 Description: Small extensible RPKI-RTR-Client C library. Development files
  RTRlib is an open-source C implementation of the  RPKI/Router Protocol
  client. The library allows one to fetch and store validated prefix origin data
- from a RTR-cache and performs origin verification of prefixes. It supports
- different types of transport sessions (e.g., SSH, unprotected TCP) and is
- easily extendable.
+ from a RTR-cache and performs origin verification of prefixes. It also allows
+ validating and signing BGPsec AS paths. RTRlib supports different types of
+ transport sessions (e.g., SSH, unprotected TCP) and is easily extendable.
  .
  This package contains development files.
 
@@ -45,9 +45,9 @@ Depends: librtr0 (= ${binary:Version}), ${misc:Depends}
 Description: Small extensible RPKI-RTR-Client C library. Debug Symbols
  RTRlib is an open-source C implementation of the  RPKI/Router Protocol
  client. The library allows one to fetch and store validated prefix origin data
- from a RTR-cache and performs origin verification of prefixes. It supports
- different types of transport sessions (e.g., SSH, unprotected TCP) and is
- easily extendable.
+ from a RTR-cache and performs origin verification of prefixes. It also allows
+ validating and signing BGPsec AS paths. RTRlib supports different types of
+ transport sessions (e.g., SSH, unprotected TCP) and is easily extendable.
  .
  This package contains debug symbols.
 
@@ -60,9 +60,9 @@ Suggests: doc-base
 Description: Small extensible RPKI-RTR-Client C library. Documentation files
  RTRlib is an open-source C implementation of the  RPKI/Router Protocol
  client. The library allows one to fetch and store validated prefix origin data
- from a RTR-cache and performs origin verification of prefixes. It supports
- different types of transport sessions (e.g., SSH, unprotected TCP) and is
- easily extendable.
+ from a RTR-cache and performs origin verification of prefixes. It also allows
+ validating and signing BGPsec AS paths. RTRlib supports different types of
+ transport sessions (e.g., SSH, unprotected TCP) and is easily extendable.
  .
  This package contains documentation files.
 

--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -6,27 +6,29 @@ Group:          Development/Libraries
 License:        MIT
 URL:            http://rpki.realmv6.org/
 Source0:        %{name}-%{version}.tar.gz
-BuildRequires:  binutils gcc tar cmake libssh-devel >= 0.5.0 doxygen
-Requires:       libssh >= 0.5.0
+BuildRequires:  binutils gcc tar cmake libssh-devel >= 0.5.0 openssl-devel >= 1.0 doxygen
+Requires:       libssh >= 0.5.0 openssl >= 1.0
 
 %description
-RTRlib is an open-source C implementation of the  RPKI/Router Protocol
+RTRlib is an open-source C implementation of the RPKI/Router Protocol
 client. The library allows one to fetch and store validated prefix origin
-data from a RTR-cache and performs origin verification of prefixes. It
-supports different types of transport sessions (e.g., SSH, unprotected TCP)
-and is easily extendable.
+data from a RTR-cache and performs origin verification of prefixes. It also
+allows validating and signing BGPsec AS paths. It supports different
+types of transport sessions (e.g., SSH, unprotected TCP) and is easily
+extendable.
 
 %package devel
 Summary:        Small extensible RPKI-RTR-Client C library. Development files
 Group:          Development/Libraries
-Requires:       %{name} = %{version}-%{release} libssh-devel >= 0.5.0
+Requires:       %{name} = %{version}-%{release} libssh-devel >= 0.5.0 openssl-devel >= 1.0
 
 %description devel
-RTRlib is an open-source C implementation of the  RPKI/Router Protocol
+RTRlib is an open-source C implementation of the RPKI/Router Protocol
 client. The library allows one to fetch and store validated prefix origin
-data from a RTR-cache and performs origin verification of prefixes. It
-supports different types of transport sessions (e.g., SSH, unprotected TCP)
-and is easily extendable.
+data from a RTR-cache and performs origin verification of prefixes. It also
+allows validating and signing BGPsec AS paths. It supports different
+types of transport sessions (e.g., SSH, unprotected TCP) and is easily
+extendable.
 .
 This package contains development files.
 
@@ -37,11 +39,12 @@ Requires:       %{name} = %{version}-%{release}
 BuildArch:      noarch
 
 %description doc
-RTRlib is an open-source C implementation of the  RPKI/Router Protocol
+RTRlib is an open-source C implementation of the RPKI/Router Protocol
 client. The library allows one to fetch and store validated prefix origin
-data from a RTR-cache and performs origin verification of prefixes. It
-supports different types of transport sessions (e.g., SSH, unprotected TCP)
-and is easily extendable.
+data from a RTR-cache and performs origin verification of prefixes. It also
+allows validating and signing BGPsec AS paths. It supports different
+types of transport sessions (e.g., SSH, unprotected TCP) and is easily
+extendable.
 .
 This package contains documentation files.
 

--- a/rtrlib/bgpsec/bgpsec.c
+++ b/rtrlib/bgpsec/bgpsec.c
@@ -1,0 +1,585 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include "rtrlib/bgpsec/bgpsec.h"
+
+#include "rtrlib/bgpsec/bgpsec_private.h"
+#include "rtrlib/bgpsec/bgpsec_utils_private.h"
+#include "rtrlib/lib/alloc_utils_private.h"
+#include "rtrlib/rtrlib_export_private.h"
+#include "rtrlib/spki/spkitable_private.h"
+
+#define SEC_PATH_LEN(seg, idx)                 \
+	struct rtr_secure_path_seg *tmp = seg; \
+	while (tmp) {                          \
+		(idx)++;                       \
+		tmp = tmp->next;               \
+	}
+
+/** The latest supported BGPsec version. */
+#define BGPSEC_VERSION 0
+
+/**
+ * @brief A static list that contains all supported algorithm suites.
+ */
+static const uint8_t algorithm_suites[] = {RTR_BGPSEC_ALGORITHM_SUITE_1};
+
+/*
+ * The data for digestion must be ordered exactly like this:
+ *
+ * +------------------------------------+
+ * | Target AS Number                   |
+ * +------------------------------------+----\
+ * | Signature Segment   : N-1          |     \
+ * +------------------------------------+     |
+ * | Secure_Path Segment : N            |     |
+ * +------------------------------------+     \
+ *       ...                                  >  Data from
+ * +------------------------------------+     /   N Segments
+ * | Signature Segment   : 1            |     |
+ * +------------------------------------+     |
+ * | Secure_Path Segment : 2            |     |
+ * +------------------------------------+     /
+ * | Secure_Path Segment : 1            |    /
+ * +------------------------------------+---/
+ * | Algorithm Suite Identifier         |
+ * +------------------------------------+
+ * | AFI                                |
+ * +------------------------------------+
+ * | SAFI                               |
+ * +------------------------------------+
+ * | NLRI                               |
+ * +------------------------------------+
+ *
+ * https://tools.ietf.org/html/rfc8205#section-4.2
+ */
+
+/* The arrays are passed in "AS path order", meaning the last appended
+ * Signature Segment / Secure_Path Segment is at the first
+ * position of the array.
+ */
+
+int rtr_bgpsec_validate_as_path(const struct rtr_bgpsec *data, struct spki_table *table)
+{
+	/* The AS path validation result. */
+	enum rtr_bgpsec_rtvals retval = 0;
+
+	/* The resulting hash. */
+	unsigned char *hash_result = NULL;
+
+	/* A temporare spki record */
+	struct spki_record *tmp_key = NULL;
+
+	/* A stream that holds the data that is hashed */
+	struct stream *s = NULL;
+
+	/* Total size of required space for the stream */
+	unsigned int stream_size = 0;
+
+	/* Use a temp variable in the validation loop since we don't want to
+	 * alter data->sigs.
+	 */
+	struct rtr_signature_seg *tmp_sig = NULL;
+
+	/* Temp variable that holds the signature length of the of the
+	 * next signature segment.
+	 */
+	int tmp_sig_len = 0;
+
+	/* Check, if the parameters are not NULL */
+	if (!data || !data->path || !data->sigs || !table)
+		return RTR_BGPSEC_INVALID_ARGUMENTS;
+
+	/* Check, if there are as many signature segments as there are
+	 * secure path segments
+	 */
+	if (data->path_len != data->sigs_len)
+		return RTR_BGPSEC_WRONG_SEGMENT_COUNT;
+
+	/* Check, if the algorithm suite is supported by RTRlib. */
+	if (rtr_bgpsec_has_algorithm_suite(data->alg) == RTR_BGPSEC_ERROR)
+		return RTR_BGPSEC_UNSUPPORTED_ALGORITHM_SUITE;
+
+	/* Check, if the AFI is usable with BGPsec */
+	if ((data->nlri->afi != BGPSEC_IPV4) && (data->nlri->afi != BGPSEC_IPV6))
+		return RTR_BGPSEC_UNSUPPORTED_AFI;
+
+	/* Make sure that all router keys are available. */
+	retval = check_router_keys(data->sigs, table);
+
+	if (retval != RTR_BGPSEC_SUCCESS)
+		goto err;
+
+	/* Calculate the required stream size and initialize the stream */
+	stream_size = req_stream_size(data, VALIDATION);
+	s = init_stream(stream_size);
+
+	/* Align the byte sequence and store it in the stream */
+	retval = align_byte_sequence(data, s, VALIDATION);
+
+	if (retval != RTR_BGPSEC_SUCCESS)
+		goto err;
+
+	/*
+	 * The validation is an iterative process. In the first iteration,
+	 * the entire byte sequence is hashed to validate the first signature.
+	 * In the next iteration, the process is repeated. This time, the
+	 * starting position for hashing is moved by an offset to only hash
+	 * the data required to validate the next signature. This procedure
+	 * is repeated until all signatures are validated or a signature is
+	 * determined invalid.
+	 *
+	 * offset: the current position from where on the bytes should
+	 * be hashed.
+	 *
+	 * next_offset: adds to offset, after the bytes on the
+	 * current offset have been processed. next_offset is not
+	 * constant and must be calculated each iteration:
+	 *
+	 * signature length +
+	 * SKI size +
+	 * sizeof(var that holds signature length) +
+	 * sizeof(a secure path segment)
+	 *
+	 *
+	 *  offset
+	 * |o++++++++++++++++++++++++++++++++++++++++| bytes
+	 *
+	 *		offset+=
+	 *		new_offset
+	 * |------------o++++++++++++++++++++++++++++| bytes
+	 *
+	 *			    offset+=
+	 *			    new_offset
+	 * |------------------------o++++++++++++++++| bytes
+	 *
+	 *
+	 * A more detailed view can be found at
+	 *https://mailarchive.ietf.org/arch/msg/sidr/8B_e4CNxQCUKeZ_AUzsdnn2f5Mu
+	 **/
+
+	/* Set retval to RTR_BGPSEC_VALID so the for-condition does not
+	 * fail on the first for loop check.
+	 */
+	retval = RTR_BGPSEC_VALID;
+	tmp_sig = data->sigs;
+
+	for (unsigned int offset = 0, next_offset = 0; offset <= get_stream_size(s) && retval == RTR_BGPSEC_VALID;
+	     offset += next_offset) {
+		if (tmp_sig->next)
+			tmp_sig_len = tmp_sig->next->sig_len;
+		else
+			tmp_sig_len = tmp_sig->sig_len;
+
+		next_offset = tmp_sig_len + SKI_SIZE + sizeof(tmp_sig->sig_len) + SECURE_PATH_SEG_SIZE;
+
+		/*
+		 * From a certain position on, read until the end of the stream.
+		 * The starting position is determined by the offset. The end
+		 * of the stream is the total length minus the offset.
+		 * The curr pointer points to the resulting "sub-stream".
+		 * Hacky, could be improved.
+		 */
+		size_t len = get_stream_size(s) - offset;
+
+		uint8_t *curr = lrtr_malloc(len);
+
+		read_stream_at(curr, s, offset, len);
+
+		retval = hash_byte_sequence(curr, len, data->alg, &hash_result);
+
+		lrtr_free(curr);
+
+		if (retval != RTR_BGPSEC_SUCCESS)
+			goto err;
+
+		/* Store all router keys for the given SKI in tmp_key. */
+		unsigned int router_keys_len = 0;
+		enum spki_rtvals spki_retval =
+			spki_table_search_by_ski(table, tmp_sig->ski, &tmp_key, &router_keys_len);
+		if (spki_retval == SPKI_ERROR) {
+			retval = RTR_BGPSEC_ERROR;
+			goto err;
+		}
+
+		/* Loop in case there are multiple router keys for one SKI. */
+		for (unsigned int j = 0; j < router_keys_len; j++) {
+			/* Validate the siganture depending on the algorithm
+			 * suite. More if-cases are added with new algorithm
+			 * suites.
+			 */
+			if (data->alg == RTR_BGPSEC_ALGORITHM_SUITE_1) {
+				retval = validate_signature(hash_result, tmp_sig, &tmp_key[j]);
+			} else {
+				retval = RTR_BGPSEC_UNSUPPORTED_ALGORITHM_SUITE;
+				goto err;
+			}
+			/* As soon as one of the router keys produces a valid
+			 * result, exit the loop.
+			 */
+			if (retval == RTR_BGPSEC_VALID)
+				break;
+		}
+		lrtr_free(hash_result);
+		lrtr_free(tmp_key);
+		hash_result = NULL;
+		tmp_key = NULL;
+		tmp_sig = tmp_sig->next;
+	}
+
+err:
+	if (hash_result)
+		lrtr_free(hash_result);
+	if (tmp_key)
+		lrtr_free(tmp_key);
+	if (s)
+		free_stream(s);
+
+	if (retval == RTR_BGPSEC_VALID)
+		BGPSEC_DBG1("Validation result for the whole BGPsec_PATH: valid");
+	else if (retval == RTR_BGPSEC_NOT_VALID)
+		BGPSEC_DBG1("Validation result for the whole BGPsec_PATH: invalid");
+
+	return retval;
+}
+
+int rtr_bgpsec_generate_signature(const struct rtr_bgpsec *data, uint8_t *private_key,
+				  struct rtr_signature_seg **new_signature)
+{
+	/* The signature generation result. */
+	enum rtr_bgpsec_rtvals retval = 0;
+
+	/* The resulting hash. */
+	unsigned char *hash_result = NULL;
+
+	/* The required size for the signature */
+	int req_sig_size = 0;
+
+	/* A stream that holds the data that is hashed */
+	struct stream *s = NULL;
+
+	/* Total size of required space for the stream */
+	unsigned int stream_size = 0;
+
+	/* OpenSSL private key structure. */
+	EC_KEY *priv_key = NULL;
+
+	/* Check, if the parameters are not NULL except for *new_signature,
+	 * which must be NULL.
+	 */
+	if (!data || !data->path || !private_key || *new_signature)
+		return RTR_BGPSEC_INVALID_ARGUMENTS;
+
+	/* Make sure the algorithm suite is supported. */
+	if (rtr_bgpsec_has_algorithm_suite(data->alg) == RTR_BGPSEC_ERROR)
+		return RTR_BGPSEC_UNSUPPORTED_ALGORITHM_SUITE;
+
+	/* Check, if the AFI is usable with BGPsec */
+	if ((data->nlri->afi != BGPSEC_IPV4) && (data->nlri->afi != BGPSEC_IPV6))
+		return RTR_BGPSEC_UNSUPPORTED_AFI;
+
+	/* Check, if there is one more secure path segment than there are
+	 * signature segments. This is because the next signature is generated
+	 * for a secure path segment, that was not signed yet (the last appended
+	 * secure path segment).
+	 */
+	if (data->path_len != (data->sigs_len + 1))
+		return RTR_BGPSEC_WRONG_SEGMENT_COUNT;
+
+	/* Load the private key from buffer into OpenSSL structure. */
+	retval = load_private_key(&priv_key, private_key);
+
+	if (retval != RTR_BGPSEC_SUCCESS) {
+		retval = RTR_BGPSEC_LOAD_PRIV_KEY_ERROR;
+		goto err;
+	}
+
+	/* Allocate the needed space for the signature */
+	req_sig_size = ECDSA_size(priv_key);
+	if (req_sig_size == 0) {
+		retval = RTR_BGPSEC_LOAD_PRIV_KEY_ERROR;
+		goto err;
+	}
+
+	*new_signature = rtr_bgpsec_new_signature_seg(NULL, req_sig_size, NULL);
+	if (!(*new_signature)) {
+		retval = RTR_BGPSEC_ERROR;
+		goto err;
+	}
+
+	/* The function call above expects the exact size of the signature.
+	 * Because the signature was not generated yet, we pass the maximum
+	 * possible length to it so enough space is allocated. Then, the
+	 * sig_len field is set to 0, since the signature does not exist yet.
+	 * This is a rather hacky workaround and might get changed in the
+	 * future.
+	 */
+	(*new_signature)->sig_len = 0;
+
+	/* Calculate the required stream size and initialize the stream */
+	stream_size = req_stream_size(data, SIGNING);
+	s = init_stream(stream_size);
+
+	/* Align the bytes to prepare them for hashing. */
+	retval = align_byte_sequence(data, s, SIGNING);
+
+	if (retval != RTR_BGPSEC_SUCCESS)
+		goto err;
+
+	/* Hash the aligned bytes. */
+	uint8_t *curr = get_stream_start(s);
+
+	retval = hash_byte_sequence(curr, get_stream_size(s), data->alg, &hash_result);
+
+	if (retval != RTR_BGPSEC_SUCCESS)
+		goto err;
+
+	/* Sign the hash depending on the algorithm suite. */
+	retval = sign_byte_sequence(hash_result, priv_key, data->alg, *new_signature);
+
+err:
+	if (hash_result)
+		lrtr_free(hash_result);
+	if (*new_signature && (retval == RTR_BGPSEC_SIGNING_ERROR))
+		rtr_bgpsec_free_signatures(*new_signature);
+	if (s)
+		free_stream(s);
+	if (priv_key) {
+		EC_KEY_free(priv_key);
+		priv_key = NULL;
+	}
+
+	return retval;
+}
+
+/*************************************************
+ **** Functions for versions and algo suites *****
+ ************************************************/
+
+int rtr_bgpsec_get_version(void)
+{
+	return BGPSEC_VERSION;
+}
+
+int rtr_bgpsec_has_algorithm_suite(uint8_t alg_suite)
+{
+	int alg_suites_len = sizeof(algorithm_suites) / sizeof(uint8_t);
+
+	for (int i = 0; i < alg_suites_len; i++) {
+		if (alg_suite == algorithm_suites[i])
+			return RTR_BGPSEC_SUCCESS;
+	}
+
+	return RTR_BGPSEC_ERROR;
+}
+
+int rtr_bgpsec_get_algorithm_suites(const uint8_t **algs_arr)
+{
+	*algs_arr = algorithm_suites;
+	return sizeof(algorithm_suites) / sizeof(uint8_t);
+}
+
+int rtr_bgpsec_prepend_sig_seg(struct rtr_bgpsec *bgpsec, struct rtr_signature_seg *new_seg)
+{
+	if (!new_seg || !new_seg->signature || !new_seg->sig_len || ski_is_empty(new_seg->ski))
+		return RTR_BGPSEC_ERROR;
+
+	if (bgpsec->sigs)
+		new_seg->next = bgpsec->sigs;
+
+	bgpsec->sigs = new_seg;
+	bgpsec->sigs_len++;
+
+	return RTR_BGPSEC_SUCCESS;
+}
+
+struct rtr_signature_seg *rtr_bgpsec_pop_signature_seg(struct rtr_bgpsec *bgpsec)
+{
+	struct rtr_signature_seg *tmp = NULL;
+
+	if (!bgpsec->sigs)
+		return NULL;
+
+	tmp = bgpsec->sigs;
+	bgpsec->sigs = bgpsec->sigs->next;
+	bgpsec->sigs_len--;
+	tmp->next = NULL;
+	return tmp;
+}
+
+int rtr_bgpsec_append_sig_seg(struct rtr_bgpsec *bgpsec, struct rtr_signature_seg *new_seg)
+{
+	struct rtr_signature_seg *last = bgpsec->sigs;
+
+	if (!new_seg || !new_seg->signature || !new_seg->sig_len || ski_is_empty(new_seg->ski))
+		return RTR_BGPSEC_ERROR;
+
+	if (bgpsec->sigs) {
+		while (last->next)
+			last = last->next;
+		last->next = new_seg;
+	} else {
+		bgpsec->sigs = new_seg;
+	}
+
+	bgpsec->sigs_len++;
+
+	return RTR_BGPSEC_SUCCESS;
+}
+
+struct rtr_signature_seg *rtr_bgpsec_new_signature_seg(uint8_t *ski, uint16_t sig_len, uint8_t *signature)
+{
+	struct rtr_signature_seg *sig_seg = lrtr_malloc(sizeof(struct rtr_signature_seg));
+
+	if (!sig_seg)
+		return NULL;
+
+	sig_seg->signature = lrtr_calloc(sig_len, 1);
+	if (!sig_seg->signature) {
+		lrtr_free(sig_seg);
+		return NULL;
+	}
+
+	if (ski)
+		memcpy(sig_seg->ski, ski, SKI_SIZE);
+	else
+		memset(sig_seg->ski, '\0', SKI_SIZE);
+
+	if (signature)
+		memcpy(sig_seg->signature, signature, sig_len);
+
+	sig_seg->sig_len = sig_len;
+	sig_seg->next = NULL;
+	return sig_seg;
+}
+
+void rtr_bgpsec_free_signatures(struct rtr_signature_seg *seg)
+{
+	if (!seg)
+		return;
+	if (seg->next)
+		rtr_bgpsec_free_signatures(seg->next);
+	lrtr_free(seg->signature);
+	lrtr_free(seg);
+}
+
+void rtr_bgpsec_prepend_sec_path_seg(struct rtr_bgpsec *bgpsec, struct rtr_secure_path_seg *new_seg)
+{
+	if (bgpsec->path)
+		new_seg->next = bgpsec->path;
+
+	bgpsec->path = new_seg;
+	bgpsec->path_len++;
+}
+
+void rtr_bgpsec_append_sec_path_seg(struct rtr_bgpsec *bgpsec, struct rtr_secure_path_seg *new_seg)
+{
+	struct rtr_secure_path_seg *last = bgpsec->path;
+
+	if (bgpsec->path) {
+		while (last->next)
+			last = last->next;
+		last->next = new_seg;
+	} else {
+		bgpsec->path = new_seg;
+	}
+
+	bgpsec->path_len++;
+}
+
+struct rtr_secure_path_seg *rtr_bgpsec_new_secure_path_seg(uint8_t pcount, uint8_t flags, uint32_t asn)
+{
+	struct rtr_secure_path_seg *seg = lrtr_malloc(sizeof(struct rtr_secure_path_seg));
+
+	seg->pcount = pcount;
+	seg->flags = flags;
+	seg->asn = asn;
+	seg->next = NULL;
+	return seg;
+}
+
+struct rtr_secure_path_seg *rtr_bgpsec_pop_secure_path_seg(struct rtr_bgpsec *bgpsec)
+{
+	struct rtr_secure_path_seg *tmp = NULL;
+
+	if (!bgpsec->path)
+		return NULL;
+
+	tmp = bgpsec->path;
+	bgpsec->path = bgpsec->path->next;
+	bgpsec->path_len--;
+	tmp->next = NULL;
+	return tmp;
+}
+
+struct rtr_bgpsec *rtr_bgpsec_new(uint8_t alg, uint8_t safi, uint16_t afi, uint32_t my_as, uint32_t target_as,
+				  struct rtr_bgpsec_nlri *nlri)
+{
+	struct rtr_bgpsec *bgpsec = lrtr_malloc(sizeof(struct rtr_bgpsec));
+
+	if (!bgpsec)
+		return NULL;
+
+	bgpsec->alg = alg;
+	bgpsec->safi = safi;
+	bgpsec->afi = afi;
+	bgpsec->my_as = my_as;
+	bgpsec->target_as = target_as;
+	bgpsec->nlri = nlri;
+	bgpsec->path_len = 0;
+	bgpsec->path = NULL;
+	bgpsec->sigs_len = 0;
+	bgpsec->sigs = NULL;
+
+	return bgpsec;
+}
+
+void rtr_bgpsec_free(struct rtr_bgpsec *bgpsec)
+{
+	if (bgpsec->path)
+		rtr_bgpsec_free_secure_path(bgpsec->path);
+	if (bgpsec->sigs)
+		rtr_bgpsec_free_signatures(bgpsec->sigs);
+	if (bgpsec->nlri)
+		rtr_bgpsec_nlri_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+}
+
+void rtr_bgpsec_free_secure_path(struct rtr_secure_path_seg *seg)
+{
+	if (!seg)
+		return;
+	if (seg->next)
+		rtr_bgpsec_free_secure_path(seg->next);
+	lrtr_free(seg);
+}
+
+struct rtr_bgpsec_nlri *rtr_bgpsec_nlri_new(int nlri_len)
+{
+	struct rtr_bgpsec_nlri *nlri = lrtr_malloc(sizeof(struct rtr_bgpsec_nlri));
+
+	nlri->nlri = lrtr_malloc(nlri_len);
+	return nlri;
+}
+
+void rtr_bgpsec_nlri_free(struct rtr_bgpsec_nlri *nlri)
+{
+	if (!nlri)
+		return;
+
+	if (nlri->nlri)
+		lrtr_free(nlri->nlri);
+
+	lrtr_free(nlri);
+}
+
+void rtr_bgpsec_add_spki_record(struct spki_table *table, struct spki_record *record)
+{
+	spki_table_add_entry(table, record);
+}

--- a/rtrlib/bgpsec/bgpsec.h
+++ b/rtrlib/bgpsec/bgpsec.h
@@ -1,0 +1,142 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+/**
+ * @defgroup mod_bgpsec_h BGPsec AS path validation
+ * @brief BGPsec allows for validation of the BGPsec_PATH attribute of a
+ * BGPsec update.
+ * @{
+ */
+
+#ifndef RTR_BGPSEC_H
+#define RTR_BGPSEC_H
+
+#include "rtrlib/lib/ip.h"
+#include "rtrlib/spki/spkitable.h"
+
+#include <stdint.h>
+
+#define BGPSEC_IPV4 1
+#define BGPSEC_IPV6 2
+
+/**
+ * @brief All supported algorithm suites.
+ */
+enum rtr_bgpsec_algorithm_suites {
+	/** Algorithm suite 1 */
+	RTR_BGPSEC_ALGORITHM_SUITE_1 = 1,
+};
+
+/**
+ * @brief Status codes for various cases.
+ */
+enum rtr_bgpsec_rtvals {
+	/** At least one signature is not valid. */
+	RTR_BGPSEC_NOT_VALID = 2,
+	/** All signatures are valid. */
+	RTR_BGPSEC_VALID = 1,
+	/** An operation was successful. */
+	RTR_BGPSEC_SUCCESS = 0,
+	/** An operation was not sucessful. */
+	RTR_BGPSEC_ERROR = -1,
+	/** The public key could not be loaded. */
+	RTR_BGPSEC_LOAD_PUB_KEY_ERROR = -2,
+	/** The private key could not be loaded. */
+	RTR_BGPSEC_LOAD_PRIV_KEY_ERROR = -3,
+	/** The SKI for a router key was not found. */
+	RTR_BGPSEC_ROUTER_KEY_NOT_FOUND = -4,
+	/** An error during signing occurred. */
+	RTR_BGPSEC_SIGNING_ERROR = -5,
+	/** The specified algorithm suite is not supported by RTRlib. */
+	RTR_BGPSEC_UNSUPPORTED_ALGORITHM_SUITE = -6,
+	/** The specified AFI is not supported by BGPsec. */
+	RTR_BGPSEC_UNSUPPORTED_AFI = -7,
+	/** The count of signature and secure path segments are not equal. */
+	RTR_BGPSEC_WRONG_SEGMENT_COUNT = -8,
+	/** There is data missing for validation or signing. */
+	RTR_BGPSEC_INVALID_ARGUMENTS = -9,
+};
+
+/**
+ * @brief A single Secure Path Segment.
+ * @param next Reference to the next Secure Path Segment (do not edit manually).
+ * @param pcount The pCount field of the segment.
+ * @param flags The flags field of the segment.
+ * @param asn The ASN of the Segment.
+ */
+struct rtr_secure_path_seg {
+	/** Reference to the next Secure Path Segment (do not edit manually). */
+	struct rtr_secure_path_seg *next;
+	uint8_t pcount;
+	uint8_t flags;
+	uint32_t asn;
+};
+
+/**
+ * @brief A single Signature Segment.
+ * @param next Reference to the next Signature Segment (do not edit manually).
+ * @param ski The SKI of the segment.
+ * @param sig_len The length in octets of the signature field.
+ * @param signature The signature of the segment.
+ */
+struct rtr_signature_seg {
+	struct rtr_signature_seg *next;
+	uint8_t ski[SKI_SIZE];
+	uint16_t sig_len;
+	/** The signature of the segment. */
+	uint8_t *signature;
+};
+
+/**
+ * @brief This struct contains the Network Layer Reachability Information
+ *	  (NLRI). The NLRI consists of a prefix and its length.
+ * @param afi The Address Family Identifier.
+ * @param safi The Subsequent Address Family Identifier.
+ * @param nlri_len The length of the nlri in bits.
+ * @param nlri The Network Layer Reachability Information. Trailing bits
+ *	       must be set to 0.
+ */
+struct rtr_bgpsec_nlri {
+	uint16_t afi;
+	uint8_t safi;
+	uint8_t nlri_len;
+	uint8_t *nlri;
+};
+
+/**
+ * @brief The data that is passed to the rtr_mgr_bgpsec_validate_as_path function.
+ * @param alg The Algorithm Suite Identifier.
+ * @param safi The Subsequent Address Family Identifier.
+ * @param afi The Address Family Identifier.
+ * @param my_as The AS that is currently performing validation (you).
+ * @param target_as The AS where the update should be sent to.
+ * @param sigs_len Count of Signature Segments (do not edit manually).
+ * @param path_len Count of Secure Path Segments (do not edit manually).
+ * @param nlri Reference to the Network Layer Reachability Information.
+ * @param sigs Reference to the Signature Segments.
+ * @param path Reference to the Secure Path Segments.
+ */
+struct rtr_bgpsec {
+	uint8_t alg;
+	uint8_t safi;
+	uint16_t afi;
+	uint32_t my_as;
+	uint32_t target_as;
+	/** Count of Signature Segments (do not edit manually). */
+	uint16_t sigs_len;
+	/** Count of Secure Path Segments (do not edit manually). */
+	uint8_t path_len;
+	struct rtr_bgpsec_nlri *nlri;
+	/** Reference to the Signature Segments. */
+	struct rtr_signature_seg *sigs;
+	/** Reference to the Secure Path Segments. */
+	struct rtr_secure_path_seg *path;
+};
+#endif
+/* @} */

--- a/rtrlib/bgpsec/bgpsec_private.h
+++ b/rtrlib/bgpsec/bgpsec_private.h
@@ -1,0 +1,195 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+/**
+ * @defgroup mod_bgpsec_h BGPsec AS path validation
+ * @brief BGPsec allows for validation of the BGPsec_PATH attribute of a
+ * BGPsec update.
+ * @{
+ */
+
+#ifndef RTR_BGPSEC_PRIVATE_H
+#define RTR_BGPSEC_PRIVATE_H
+
+#include "rtrlib/bgpsec/bgpsec_utils_private.h"
+
+/**
+ * @brief Validation function for AS path validation.
+ * @param[in] data Data required for AS path validation. See @ref rtr_bgpsec.
+ * @param[in] table The SPKI table that contains the router keys.
+ * @return RTR_BGPSEC_VALID If the AS path was valid.
+ * @return RTR_BGPSEC_NOT_VALID If the AS path was not valid.
+ * @return RTR_BGPSEC_ERROR If an error occurred. Refer to error codes for
+ *			more details.
+ */
+int rtr_bgpsec_validate_as_path(const struct rtr_bgpsec *data, struct spki_table *table);
+
+/**
+ * @brief Signing function for a BGPsec_PATH.
+ * @param[in] data Data required for AS path validation. See @ref rtr_bgpsec.
+ * @param[in] private_key The raw bytes of the private key that is used for signing.
+ * @param[out] new_signature Contains the generated signature and its length if
+ *			     successful. Must not be allocated.
+ * @return RTR_BGPSEC_SUCCESS If the signature was successfully generated.
+ * @return RTR_BGPSEC_ERROR If an error occurred. Refer to error codes for
+ *			    more details.
+ */
+int rtr_bgpsec_generate_signature(const struct rtr_bgpsec *data, uint8_t *private_key,
+				  struct rtr_signature_seg **new_signature);
+
+/**
+ * @brief Returns the highest supported BGPsec version.
+ * @return RTR_BGPSEC_VERSION The currently supported BGPsec version.
+ */
+int rtr_bgpsec_get_version(void);
+
+/**
+ * @brief Check, if an algorithm suite is supported by RTRlib.
+ * @param[in] alg_suite The algorithm suite that is to be checked.
+ * @return RTR_BGPSEC_SUCCESS If the algorithm suite is supported.
+ * @return RTR_BGPSEC_ERROR If the algorithm suite is not supported.
+ */
+int rtr_bgpsec_has_algorithm_suite(uint8_t alg_suite);
+
+/**
+ * @brief Returns a pointer to a list that holds all supported algorithm suites.
+ * @param[out] algs_arr A char pointer that contains all supported suites.
+ * @return ALGORITHM_SUITES_COUNT The size of algs_arr
+ */
+int rtr_bgpsec_get_algorithm_suites(const uint8_t **algs_arr);
+
+/** @brief Free a signature and any signatures that are pointed to.
+ * @param[in] seg The signature that has been passed to the signing
+ *	      function.
+ */
+void rtr_bgpsec_free_signatures(struct rtr_signature_seg *seg);
+
+/**
+ * @brief Return an allocated and initialized Secure Path Segment.
+ * @param[in] pcount The pcount field.
+ * @param[in] flags The flags field.
+ * @param[in] asn The ASN of the segment.
+ * @return A pointer to an initialized rtr_secure_path_seg struct
+ */
+struct rtr_secure_path_seg *rtr_bgpsec_new_secure_path_seg(uint8_t pcount, uint8_t flags, uint32_t asn);
+
+/**
+ * @brief Prepend a given Secure Path Segment to @ref rtr_bgpsec.path.
+ * @param[in] bgpsec The rtr_bgpsec struct that holds the path.
+ * @param[in] new_seg The Secure Path Segment that is appended to the path.
+ */
+void rtr_bgpsec_prepend_sec_path_seg(struct rtr_bgpsec *bgpsec, struct rtr_secure_path_seg *new_seg);
+
+/**
+ * @brief Return an allocated and initialized Signature.
+ * @param[in] ski The Subject Key Identifier as byte representation.
+ * @param[in] sig_len The length of the signature.
+ * @param[in] signature The signature itself.
+ * @return A pointer to an initialized rtr_secure_path_seg struct.
+ *	   @ref rtr_signature_seg.signature is allocated with sig_len
+ *	   bytes.
+ */
+struct rtr_signature_seg *rtr_bgpsec_new_signature_seg(uint8_t *ski, uint16_t sig_len, uint8_t *signature);
+
+/**
+ * @brief Prepend a given Signature Segment to @ref rtr_bgpsec.sigs. All fields
+ *	  of the new_seg must be filled.
+ * @param[in] bgpsec The rtr_bgpsec struct that holds the signatures.
+ * @param[in] new_seg The Signature Segment that is appended to the signatures.
+ * @return RTR_BGPSEC_SUCCESS If the signature was successfully prepended.
+ * @return RTR_BGPSEC_ERROR If an error occurred during prepending, e.g. one
+ *			    or more fields of new_seg was missing.
+ */
+int rtr_bgpsec_prepend_sig_seg(struct rtr_bgpsec *bgpsec, struct rtr_signature_seg *new_seg);
+
+/**
+ * @brief Initializes and returns a pointer to a rtr_bgpsec struct.
+ * @param[in] alg The Algorithm Suite Identifier.
+ * @param[in] safi The Subsequent Address Family Identifier.
+ * @param[in] afi The Address Family Identifier.
+ * @param[in] my_as The AS that is currently performing validation (you).
+ * @param[in] target_as The AS where the update should be sent to.
+ * @param[in] nlri The Network Layer Reachability Information.
+ * @return A pointer to an initialized rtr_bgpsec struct.
+ */
+struct rtr_bgpsec *rtr_bgpsec_new(uint8_t alg, uint8_t safi, uint16_t afi, uint32_t my_as, uint32_t target_as,
+				  struct rtr_bgpsec_nlri *nlri);
+
+/**
+ * @brief Allocate memory for a rtr_bgpsec_nlri struct.
+ * @return A pointer to an allocated rtr_bgpsec_nlri struct.
+ */
+struct rtr_bgpsec_nlri *rtr_bgpsec_nlri_new(int nlri_len);
+
+/**
+ * @brief Free a rtr_bgpsec_nlri struct.
+ * @param[in] nlri The rtr_bgpsec_nlri struct that is to be freed.
+ */
+void rtr_bgpsec_nlri_free(struct rtr_bgpsec_nlri *nlri);
+
+/**
+ * @brief Free a rtr_bgpsec struct and any Secure Path and Signature
+ *	  Segments it holds.
+ * @param[in] bgpsec The rtr_bgpsec struct that is to be freed.
+ */
+void rtr_bgpsec_free(struct rtr_bgpsec *bgpsec);
+
+/**
+ * @brief Free a Secure Path Segment and any segments that are pointed to
+ *	  by @ref rtr_secure_path_seg.next.
+ * @param[in] seg The Secure Path Segment that is to be freed.
+ */
+void rtr_bgpsec_free_secure_path(struct rtr_secure_path_seg *seg);
+
+/**
+ * @brief Pop off the first Signature Segment from a given rtr_bgpsec struct
+ *	  and return this Signature Segment.
+ * @param[in] bgpsec The rtr_bgpsec struct containing the Signature Segments
+ *	      @ref rtr_bgpsec.sigs.
+ * @return The Signature Segment that was popped off from @ref rtr_bgpsec.sigs.
+ */
+struct rtr_signature_seg *rtr_bgpsec_pop_signature_seg(struct rtr_bgpsec *bgpsec);
+
+/**
+ * @brief Pop off the first Secure Path Segment from a given rtr_bgpsec struct
+ *	  and return this Secure Path Segment.
+ * @param[in] bgpsec The rtr_bgpsec struct containing the Secure Path Segments
+ *	      @ref rtr_bgpsec.path.
+ * @return The Secure Path Segment that was popped off from @ref rtr_bgpsec.path.
+ */
+struct rtr_secure_path_seg *rtr_bgpsec_pop_secure_path_seg(struct rtr_bgpsec *bgpsec);
+
+/**
+ * @brief Append a Signature Segment to the end of the @ref rtr_bgpsec.sigs of a
+ *	  given rtr_bgpsec struct.
+ * @param[in] bgpsec The rtr_bgpsec struct with the @ref rtr_bgpsec.sigs to
+ *	      append the Signature Segment to.
+ * @param[in] new_seg The Signature Segments that will be appended.
+ * @return RTR_BGPSEC_SUCCESS If the Signature Segment was successfully appended.
+ * @return RTR_BGPSEC_ERROR If an error occurred in the proccess.
+ */
+int rtr_bgpsec_append_sig_seg(struct rtr_bgpsec *bgpsec, struct rtr_signature_seg *new_seg);
+
+/**
+ * @brief Append a Secure Path Segment to the end of the @ref rtr_bgpsec.path of a
+ *	  given rtr_bgpsec struct.
+ * @param[in] bgpsec The rtr_bgpsec struct with the @ref rtr_bgpsec.path to
+ *	      append the Secure Path Segment to.
+ * @param[in] new_seg The Secure Path Segments that will be appended.
+ */
+void rtr_bgpsec_append_sec_path_seg(struct rtr_bgpsec *bgpsec, struct rtr_secure_path_seg *new_seg);
+
+/**
+ * @brief Manually add a SPKI record into the SPKI table.
+ * @param[in] table The SPKI table holding the SPKI data.
+ * @param[in] record The new record that will be added to the SPKI table.
+ */
+void rtr_bgpsec_add_spki_record(struct spki_table *table, struct spki_record *record);
+#endif
+/* @} */

--- a/rtrlib/bgpsec/bgpsec_utils.c
+++ b/rtrlib/bgpsec/bgpsec_utils.c
@@ -1,0 +1,440 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include "rtrlib/bgpsec/bgpsec_utils_private.h"
+#include "rtrlib/spki/spkitable_private.h"
+
+#include <stdio.h>
+
+/** Macro to get the NLRI length in bytes. */
+#define NLRI_BYTE_LEN(data) (((data)->nlri->nlri_len + 7) / 8)
+
+struct stream {
+	size_t size;
+	uint8_t *stream;
+	const uint8_t *start;
+	uint16_t w_head;
+	uint16_t r_head;
+};
+
+struct stream *init_stream(uint16_t size)
+{
+	struct stream *s = lrtr_calloc(sizeof(struct stream), 1);
+
+	s->stream = lrtr_calloc(size, 1);
+	s->start = s->stream;
+	s->size = size;
+	s->w_head = 0;
+	s->r_head = 0;
+	return s;
+}
+
+/* cppcheck-suppress unusedFunction */
+struct stream *copy_stream(struct stream *s)
+{
+	struct stream *cpy = init_stream(s->size);
+
+	memcpy(cpy->stream, s->stream, s->size);
+	cpy->w_head = s->w_head;
+	cpy->r_head = s->r_head;
+	return cpy;
+}
+
+void free_stream(struct stream *s)
+{
+	lrtr_free((uint8_t *)s->start);
+	lrtr_free(s);
+}
+
+void write_stream(struct stream *s, void *data, uint16_t len)
+{
+	memcpy(s->stream + s->w_head, data, len);
+	s->w_head += len;
+}
+
+/* cppcheck-suppress unusedFunction */
+uint8_t read_stream(struct stream *s)
+{
+	uint8_t c = *(s->start + s->r_head);
+
+	s->r_head++;
+	return c;
+}
+
+/* cppcheck-suppress unusedFunction */
+void read_n_bytes_stream(uint8_t *buff, struct stream *s, uint16_t len)
+{
+	if ((s->r_head + len) >= s->size)
+		len = (s->size - s->r_head) - 1;
+	memcpy(buff, s->start + s->r_head, len);
+	s->r_head += len;
+}
+
+void read_stream_at(uint8_t *buff, struct stream *s, uint16_t start, uint16_t len)
+{
+	if (start + len > s->size)
+		len = s->size - start;
+	memcpy(buff, s->start + start, len);
+}
+
+uint8_t *get_stream_start(struct stream *s)
+{
+	return (uint8_t *)s->start;
+}
+
+size_t get_stream_size(struct stream *s)
+{
+	return s->size;
+}
+
+size_t req_stream_size(const struct rtr_bgpsec *data, enum align_type type)
+{
+	unsigned int sig_segs_size = get_sig_seg_size(data->sigs, type);
+	uint8_t nlri_len_b = (data->nlri->nlri_len + 7) / 8; // bits to bytes
+	unsigned int bytes_len = 9 // alg(1) + afi(2) + safi(1) + asn(4) + prefix_len(1)
+				 + nlri_len_b + sig_segs_size + (SECURE_PATH_SEG_SIZE * data->path_len);
+	return bytes_len;
+}
+
+int get_sig_seg_size(const struct rtr_signature_seg *sig_segs, enum align_type type)
+{
+	unsigned int sig_segs_size = 0;
+
+	if (!sig_segs)
+		return 0;
+
+	/* Iterate over all signature segments and add the calculated
+	 * length to sig_segs_size. Return the sum at the end.
+	 */
+	const struct rtr_signature_seg *curr = sig_segs;
+
+	if (type == VALIDATION)
+		curr = curr->next;
+
+	while (curr) {
+		sig_segs_size += curr->sig_len + sizeof(curr->sig_len) + SKI_SIZE;
+		curr = curr->next;
+	}
+
+	return sig_segs_size;
+}
+
+int check_router_keys(const struct rtr_signature_seg *sig_segs, struct spki_table *table)
+{
+	struct spki_record *tmp_key = NULL;
+	const struct rtr_signature_seg *curr = sig_segs;
+
+	while (curr) {
+		unsigned int router_keys_len = 0;
+		enum spki_rtvals spki_retval =
+			spki_table_search_by_ski(table, (uint8_t *)curr->ski, &tmp_key, &router_keys_len);
+		if (spki_retval == SPKI_ERROR)
+			return RTR_BGPSEC_ERROR;
+
+		/* Return an error, if a router key was not found. */
+		if (router_keys_len == 0) {
+			char ski_str[SKI_STR_LEN] = {0};
+
+			ski_to_char(ski_str, (uint8_t *)curr->ski);
+			BGPSEC_DBG("ERROR: Could not find router key for SKI: %s", ski_str);
+			return RTR_BGPSEC_ROUTER_KEY_NOT_FOUND;
+		}
+		lrtr_free(tmp_key);
+		curr = curr->next;
+	}
+
+	return RTR_BGPSEC_SUCCESS;
+}
+
+int byte_sequence_to_str(char *buffer, uint8_t *bytes, unsigned int bytes_len, unsigned int tabstops)
+{
+	unsigned int bytes_printed = 1;
+
+	for (unsigned int j = 0; j < tabstops; j++)
+		buffer += sprintf(buffer, "\t");
+
+	for (unsigned int i = 0; i < bytes_len; i++, bytes_printed++) {
+		buffer += sprintf(buffer, "%02X ", bytes[i]);
+
+		/* Only print 16 bytes in a single line. */
+		if (bytes_printed % 16 == 0) {
+			buffer += sprintf(buffer, "\n");
+			for (unsigned int j = 0; j < tabstops; j++)
+				buffer += sprintf(buffer, "\t");
+		}
+	}
+
+	/* If there was no new line printed at the end of the for loop,
+	 * print an extra new line.
+	 */
+	if (bytes_len % 16 != 0)
+		buffer += sprintf(buffer, "\n");
+	sprintf(buffer, "\n");
+	return RTR_BGPSEC_SUCCESS;
+}
+
+/* cppcheck-suppress unusedFunction */
+int bgpsec_segment_to_str(char *buffer, struct rtr_signature_seg *sig_seg, struct rtr_secure_path_seg *sec_path)
+{
+	char byte_buffer[256] = {'\0'};
+
+	buffer += sprintf(buffer, "++++++++++++++++++++++++++++++++++++++++\n");
+	buffer += sprintf(buffer, "Signature Segment:\n");
+	buffer += sprintf(buffer, "\tSKI:\n");
+
+	byte_sequence_to_str(byte_buffer, sig_seg->ski, SKI_SIZE, 2);
+	buffer += sprintf(buffer, "%s\n", byte_buffer);
+
+	buffer += sprintf(buffer, "\tLength: %d\n", sig_seg->sig_len);
+	buffer += sprintf(buffer, "\tSignature:\n");
+
+	memset(byte_buffer, 0, sizeof(byte_buffer));
+	byte_sequence_to_str(byte_buffer, sig_seg->signature, sig_seg->sig_len, 2);
+	buffer += sprintf(buffer, "%s\n", byte_buffer);
+
+	buffer += sprintf(buffer, "----------------------------------------\n");
+	buffer += sprintf(buffer,
+			  "Secure_Path Segment:\n"
+			  "\tpCount: %d\n"
+			  "\tFlags: %d\n"
+			  "\tAS number: %d\n",
+			  sec_path->pcount, sec_path->flags, sec_path->asn);
+	buffer += sprintf(buffer, "++++++++++++++++++++++++++++++++++++++++\n");
+	buffer += sprintf(buffer, "\n");
+	*buffer = '\0';
+
+	return RTR_BGPSEC_SUCCESS;
+}
+
+void ski_to_char(char *ski_str, uint8_t *ski)
+{
+	for (unsigned int i = 0; i < SKI_SIZE; i++)
+		sprintf(&ski_str[i * 3], "%02X ", ski[i]);
+}
+
+/*
+ * One step in validating a BGPsec signature is hashing some of the
+ * content of the BGPsec update. These information must be aligned
+ * in a specific order before they are hashed. The function below
+ * handles this alignment. Since every byte affects the resulting
+ * hash, padding or trailing bytes must not exist in the byte
+ * sequence.
+ */
+int align_byte_sequence(const struct rtr_bgpsec *data, struct stream *s, enum align_type type)
+{
+	/* Variables used for network-to-host-order transformation. */
+	uint32_t asn = 0;
+	uint16_t afi = 0;
+
+	/* Temp secure path and signature segments to prevent any
+	 * alteration of the original data.
+	 */
+	struct rtr_secure_path_seg *tmp_sec = NULL;
+	struct rtr_signature_seg *tmp_sig = NULL;
+
+	/* The data alignment begins here, starting with the target ASN. */
+	asn = htonl(data->target_as);
+	write_stream(s, &asn, sizeof(asn));
+
+	/* Depending on whether we are dealing with alignment for validation
+	 * or signing, the first signature segment is skipped.
+	 */
+	if (type == VALIDATION)
+		tmp_sig = data->sigs->next;
+	else
+		tmp_sig = data->sigs;
+
+	tmp_sec = data->path;
+
+	while (tmp_sec) {
+		if (tmp_sig) {
+			uint16_t sig_len = htons(tmp_sig->sig_len);
+
+			/* Write the signature segment data to stream. */
+			write_stream(s, tmp_sig->ski, SKI_SIZE);
+			write_stream(s, &sig_len, sizeof(sig_len));
+			write_stream(s, tmp_sig->signature, tmp_sig->sig_len);
+
+			tmp_sig = tmp_sig->next;
+		}
+
+		/* Write the secure path segment data to stream. */
+		write_stream(s, (uint8_t *)&tmp_sec->pcount, 1);
+		write_stream(s, (uint8_t *)&tmp_sec->flags, 1);
+
+		asn = htonl(tmp_sec->asn);
+		write_stream(s, &asn, sizeof(asn));
+		tmp_sec = tmp_sec->next;
+	}
+
+	/* Write the rest of the data to stream. */
+	write_stream(s, (uint8_t *)&data->alg, 1);
+
+	afi = htons(data->afi);
+	write_stream(s, &afi, sizeof(afi));
+
+	write_stream(s, (uint8_t *)&data->safi, 1);
+	write_stream(s, (uint8_t *)&data->nlri->nlri_len, 1);
+
+	/* Write the NLRI to stream */
+	write_stream(s, data->nlri->nlri, NLRI_BYTE_LEN(data));
+
+	return RTR_BGPSEC_SUCCESS;
+}
+
+int validate_signature(const unsigned char *hash, const struct rtr_signature_seg *sig, struct spki_record *record)
+{
+	int status = 0;
+	enum rtr_bgpsec_rtvals retval;
+
+	EC_KEY *pub_key = NULL;
+
+	/* Load the contents of the spki buffer into the
+	 * OpenSSL public key.
+	 */
+	retval = load_public_key(&pub_key, record->spki);
+
+	if (retval != RTR_BGPSEC_SUCCESS) {
+		/*The output string looks like this: "XX XX XX XX"*/
+		/*where XX is a single byte. Including the spaces,*/
+		/*we need to multiply by 3. The plus 1 is for the string*/
+		/*terminator.*/
+		char ski_str[(SKI_SIZE * 3) + 1] = {'\0'};
+
+		ski_to_char(ski_str, record->ski);
+		BGPSEC_DBG("WARNING: Invalid public key for SKI: %s", ski_str);
+		retval = RTR_BGPSEC_ERROR;
+		goto err;
+	}
+
+	/* The OpenSSL validation function to validate the signature. */
+	status = ECDSA_verify(0, hash, SHA256_DIGEST_LENGTH, sig->signature, sig->sig_len, pub_key);
+
+	switch (status) {
+	case -1:
+		BGPSEC_DBG1("ERROR: Failed to verify EC Signature");
+		retval = RTR_BGPSEC_ERROR;
+		break;
+	case 0:
+		BGPSEC_DBG1("Validation result of signature: invalid");
+		retval = RTR_BGPSEC_NOT_VALID;
+		break;
+	case 1:
+		BGPSEC_DBG1("Validation result of signature: valid");
+		retval = RTR_BGPSEC_VALID;
+		break;
+	}
+
+err:
+	EC_KEY_free(pub_key);
+
+	return retval;
+}
+
+int load_public_key(EC_KEY **pub_key, uint8_t *spki)
+{
+	char *p = NULL;
+	int status = 0;
+
+	p = (char *)spki;
+	*pub_key = NULL;
+
+	/* This whole procedure is one way to copy the spki into
+	 * an EC_KEY, suggested by OpenSSL. Basically, this function
+	 * returns the public key as a long int, which can later be
+	 * casted to an EC_KEY
+	 */
+	*pub_key = d2i_EC_PUBKEY(NULL, (const unsigned char **)&p, (long)SPKI_SIZE);
+
+	if (!*pub_key)
+		return RTR_BGPSEC_LOAD_PUB_KEY_ERROR;
+
+	status = EC_KEY_check_key(*pub_key);
+	if (status == 0) {
+		EC_KEY_free(*pub_key);
+		*pub_key = NULL;
+		return RTR_BGPSEC_LOAD_PUB_KEY_ERROR;
+	}
+
+	return RTR_BGPSEC_SUCCESS;
+}
+
+int load_private_key(EC_KEY **priv_key, uint8_t *bytes_key)
+{
+	int status = 0;
+	char *p = (char *)bytes_key;
+	*priv_key = NULL;
+
+	/* The private key copying is similar to the public key
+	 * copying, except that the private key is returned directly
+	 * as an EC_KEY.
+	 */
+	*priv_key = d2i_ECPrivateKey(NULL, (const unsigned char **)&p, (long)PRIVATE_KEY_LENGTH);
+
+	if (!*priv_key)
+		return RTR_BGPSEC_LOAD_PRIV_KEY_ERROR;
+
+	status = EC_KEY_check_key(*priv_key);
+	if (status == 0) {
+		EC_KEY_free(*priv_key);
+		*priv_key = NULL;
+		return RTR_BGPSEC_LOAD_PRIV_KEY_ERROR;
+	}
+
+	return RTR_BGPSEC_SUCCESS;
+}
+
+int hash_byte_sequence(uint8_t *bytes, size_t bytes_len, uint8_t alg_suite_id, unsigned char **hash_result)
+{
+	if (alg_suite_id == RTR_BGPSEC_ALGORITHM_SUITE_1) {
+		SHA256_CTX ctx;
+
+		*hash_result = lrtr_malloc(SHA256_DIGEST_LENGTH);
+		if (!*hash_result)
+			return RTR_BGPSEC_ERROR;
+
+		SHA256_Init(&ctx);
+		SHA256_Update(&ctx, (const unsigned char *)bytes, bytes_len);
+		SHA256_Final(*hash_result, &ctx);
+
+		if (!*hash_result)
+			return RTR_BGPSEC_ERROR;
+	} else {
+		return RTR_BGPSEC_UNSUPPORTED_ALGORITHM_SUITE;
+	}
+
+	return RTR_BGPSEC_SUCCESS;
+}
+
+int sign_byte_sequence(uint8_t *hash_result, EC_KEY *priv_key, uint8_t alg, struct rtr_signature_seg *new_signature)
+{
+	enum rtr_bgpsec_rtvals retval = RTR_BGPSEC_SUCCESS;
+	unsigned int sig_res = 0;
+
+	if (alg == RTR_BGPSEC_ALGORITHM_SUITE_1) {
+		ECDSA_sign(0, hash_result, SHA256_DIGEST_LENGTH, new_signature->signature, &sig_res, priv_key);
+		if (sig_res < 1)
+			retval = RTR_BGPSEC_SIGNING_ERROR;
+		else
+			new_signature->sig_len = sig_res;
+	} else {
+		retval = RTR_BGPSEC_UNSUPPORTED_ALGORITHM_SUITE;
+	}
+
+	return retval;
+}
+
+int ski_is_empty(uint8_t *ski)
+{
+	for (int i = 0; i < SKI_SIZE; i++) {
+		if (ski[i])
+			return 0;
+	}
+	return 1;
+}

--- a/rtrlib/bgpsec/bgpsec_utils_private.h
+++ b/rtrlib/bgpsec/bgpsec_utils_private.h
@@ -1,0 +1,126 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#ifndef RTR_BGPSEC_UTILS_PRIVATE_H
+#define RTR_BGPSEC_UTILS_PRIVATE_H
+
+#include "rtrlib/bgpsec/bgpsec.h"
+#include "rtrlib/lib/alloc_utils_private.h"
+#include "rtrlib/lib/log_private.h"
+#include "rtrlib/rtrlib_export_private.h"
+
+#include <arpa/inet.h>
+#include <openssl/x509.h>
+#include <string.h>
+
+#define BGPSEC_DBG(fmt, ...) lrtr_dbg("BGPSEC: " fmt, ##__VA_ARGS__)
+#define BGPSEC_DBG1(a) lrtr_dbg("BGPSEC: " a)
+
+/** The length of a rtr_secure_path_seg without the next pointer:
+ * pcount(1) + flags(1) + asn(4)
+ */
+#define SECURE_PATH_SEG_SIZE 6
+
+/** The string length of a SKI, including spaces. */
+#define SKI_STR_LEN 61
+
+/** The total length of a private key in bytes. */
+#define PRIVATE_KEY_LENGTH 121L
+
+/** Control flag, validation and signing procedures for aligning data differs.
+ */
+enum align_type {
+	VALIDATION,
+	SIGNING,
+};
+
+/* Forward declaration of stream to make it opaque. */
+struct stream;
+
+/* Initialize a stream of size bytes */
+struct stream *init_stream(uint16_t size);
+
+/* Copy a stream s and return the copy */
+struct stream *copy_stream(struct stream *s);
+
+/* Free stream s */
+void free_stream(struct stream *s);
+
+/* Write len bytes from data to stream s */
+void write_stream(struct stream *s, void *data, uint16_t len);
+
+/* Get the start position pointer of stream s */
+uint8_t *get_stream_start(struct stream *s);
+
+/* Get the size of the storable data of stream s */
+size_t get_stream_size(struct stream *s);
+
+/* Read one byte from stream s */
+uint8_t read_stream(struct stream *s);
+
+/* Read len bytes from stream s and write them to buff */
+void read_n_bytes_stream(uint8_t *buff, struct stream *s, uint16_t len);
+
+/* Read len bytes from stream s, starting from position start and write
+ * the result to buff.
+ */
+void read_stream_at(uint8_t *buff, struct stream *s, uint16_t start, uint16_t len);
+
+/* Calculate the reqired size for a stream, so that all information from data
+ * fit into it. type controls, if it is for validation or signing purposes.
+ */
+size_t req_stream_size(const struct rtr_bgpsec *data, enum align_type type);
+
+/* Get the length in bytes for a all signature segments */
+int get_sig_seg_size(const struct rtr_signature_seg *sig_segs, enum align_type type);
+
+/* Check, if there is at least one router key for each SKI from sig_segs. */
+int check_router_keys(const struct rtr_signature_seg *sig_segs, struct spki_table *table);
+
+/* Store the string representation of a BGPsec_PATH segment in buffer. */
+int bgpsec_segment_to_str(char *buffer, struct rtr_signature_seg *sig_seg, struct rtr_secure_path_seg *sec_path);
+
+/* Store the hex-string representation of a byte sequence in buffer. */
+int byte_sequence_to_str(char *buffer, uint8_t *bytes, unsigned int bytes_len, unsigned int tabstops);
+
+/* Takes a binary encoded SKI and stores it in ski_str as a human readable
+ * hex string.
+ */
+void ski_to_char(char *ski_str, uint8_t *ski);
+
+/* Align the BGPsec data as a byte sequence and store it in stream s. type
+ * controls, if the alignment is for validation or signing.
+ */
+int align_byte_sequence(const struct rtr_bgpsec *data, struct stream *s, enum align_type type);
+
+/* Hash a byte sequence and store it in result_buffer. */
+int hash_byte_sequence(uint8_t *bytes, size_t bytes_len, uint8_t alg_suite_id, unsigned char **result_buffer);
+
+/* Validate a signature sig. */
+int validate_signature(const unsigned char *hash, const struct rtr_signature_seg *sig, struct spki_record *record);
+
+/* Load a binary private key bytes_key and store it in the openssl EC_KEY
+ * priv_key.
+ */
+int load_private_key(EC_KEY **priv_key, uint8_t *bytes_key);
+
+/* Load a binary public key spki and store it in the openssl EC_KEY
+ * pub_key.
+ */
+int load_public_key(EC_KEY **pub_key, uint8_t *spki);
+
+/* Sign a byte sequence, depending on the algorithm suite. The signature and
+ * its length are stored in new_signature.
+ */
+int sign_byte_sequence(uint8_t *hash_result, EC_KEY *priv_key, uint8_t alg, struct rtr_signature_seg *new_signature);
+
+/* Check, if all elements of a SKI are 0. */
+int ski_is_empty(uint8_t *ski);
+
+#endif

--- a/rtrlib/config.h.cmake
+++ b/rtrlib/config.h.cmake
@@ -11,8 +11,8 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_H
-#define CONFIG_H
+#ifndef RTR_CONFIG_H
+#define RTR_CONFIG_H
 
 #cmakedefine RTRLIB_BGPSEC_ENABLED
 

--- a/rtrlib/config.h.cmake
+++ b/rtrlib/config.h.cmake
@@ -1,0 +1,24 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#cmakedefine RTRLIB_BGPSEC_ENABLED
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/rtrlib/lib/alloc_utils.c
+++ b/rtrlib/lib/alloc_utils.c
@@ -35,7 +35,6 @@ inline void *lrtr_malloc(size_t size)
 	return MALLOC_PTR(size);
 }
 
-/* cppcheck-suppress unusedFunction */
 void *lrtr_calloc(size_t nmemb, size_t size)
 {
 	int bytes = 0;

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -9,6 +9,7 @@
 
 #include "packets_private.h"
 
+#include "rtrlib/config.h"
 #include "rtrlib/lib/alloc_utils_private.h"
 #include "rtrlib/lib/convert_byte_order_private.h"
 #include "rtrlib/lib/log_private.h"
@@ -17,6 +18,9 @@
 #include "rtrlib/rtr/rtr_private.h"
 #include "rtrlib/spki/hashtable/ht-spkitable_private.h"
 #include "rtrlib/transport/transport_private.h"
+#ifdef RTRLIB_BGPSEC_ENABLED
+#include "rtrlib/bgpsec/bgpsec_utils_private.h"
+#endif
 
 #include <assert.h>
 #include <stdint.h>

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <signal.h>
+#include <time.h>
 #include <unistd.h>
 
 static void rtr_purge_outdated_records(struct rtr_socket *rtr_socket);

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -9,6 +9,7 @@
 
 #include "rtr_mgr_private.h"
 
+#include "rtrlib/config.h"
 #include "rtrlib/lib/alloc_utils_private.h"
 #include "rtrlib/lib/log_private.h"
 #include "rtrlib/pfx/pfx_private.h"
@@ -16,6 +17,9 @@
 #include "rtrlib/rtrlib_export_private.h"
 #include "rtrlib/spki/hashtable/ht-spkitable_private.h"
 #include "rtrlib/transport/transport_private.h"
+#ifdef RTRLIB_BGPSEC_ENABLED
+#include "rtrlib/bgpsec/bgpsec_private.h"
+#endif
 
 #include <arpa/inet.h>
 #include <pthread.h>
@@ -673,3 +677,128 @@ RTRLIB_EXPORT inline void rtr_mgr_for_each_ipv6_record(struct rtr_mgr_config *co
 {
 	pfx_table_for_each_ipv6_record(config->pfx_table, fp, data);
 }
+
+#ifdef RTRLIB_BGPSEC_ENABLED
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT int rtr_mgr_bgpsec_validate_as_path(const struct rtr_bgpsec *data, struct rtr_mgr_config *config)
+{
+	int retval = rtr_bgpsec_validate_as_path(data, config->spki_table);
+
+	return retval;
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT int rtr_mgr_bgpsec_generate_signature(const struct rtr_bgpsec *data, uint8_t *private_key,
+						    struct rtr_signature_seg **new_signature)
+{
+	int retval = rtr_bgpsec_generate_signature(data, private_key, new_signature);
+
+	return retval;
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT int rtr_mgr_bgpsec_get_version(void)
+{
+	return rtr_bgpsec_get_version();
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT int rtr_mgr_bgpsec_has_algorithm_suite(uint8_t alg_suite)
+{
+	return rtr_bgpsec_has_algorithm_suite(alg_suite);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT int rtr_mgr_bgpsec_get_algorithm_suites(const uint8_t **algs_arr)
+{
+	return rtr_bgpsec_get_algorithm_suites(algs_arr);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT void rtr_mgr_bgpsec_free_signatures(struct rtr_signature_seg *seg)
+{
+	rtr_bgpsec_free_signatures(seg);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT struct rtr_secure_path_seg *rtr_mgr_bgpsec_new_secure_path_seg(uint8_t pcount, uint8_t flags,
+									     uint32_t asn)
+{
+	return rtr_bgpsec_new_secure_path_seg(pcount, flags, asn);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT void rtr_mgr_bgpsec_prepend_sec_path_seg(struct rtr_bgpsec *bgpsec, struct rtr_secure_path_seg *new_seg)
+{
+	rtr_bgpsec_prepend_sec_path_seg(bgpsec, new_seg);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT struct rtr_signature_seg *rtr_mgr_bgpsec_new_signature_seg(uint8_t *ski, uint16_t sig_len,
+									 uint8_t *signature)
+{
+	return rtr_bgpsec_new_signature_seg(ski, sig_len, signature);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT int rtr_mgr_bgpsec_prepend_sig_seg(struct rtr_bgpsec *bgpsec, struct rtr_signature_seg *new_seg)
+{
+	return rtr_bgpsec_prepend_sig_seg(bgpsec, new_seg);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT struct rtr_bgpsec *rtr_mgr_bgpsec_new(uint8_t alg, uint8_t safi, uint16_t afi, uint32_t my_as,
+						    uint32_t target_as, struct rtr_bgpsec_nlri *nlri)
+{
+	return rtr_bgpsec_new(alg, safi, afi, my_as, target_as, nlri);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT void rtr_mgr_bgpsec_free(struct rtr_bgpsec *bgpsec)
+{
+	rtr_bgpsec_free(bgpsec);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT void rtr_mgr_free_secure_path(struct rtr_secure_path_seg *seg)
+{
+	rtr_bgpsec_free_secure_path(seg);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT struct rtr_secure_path_seg *rtr_mgr_bgpsec_pop_secure_path_seg(struct rtr_bgpsec *bgpsec)
+{
+	return rtr_bgpsec_pop_secure_path_seg(bgpsec);
+}
+
+/* cppcheck-suppress unusedFunction */
+RTRLIB_EXPORT struct rtr_signature_seg *rtr_mgr_bgpsec_pop_signature_seg(struct rtr_bgpsec *bgpsec)
+{
+	return rtr_bgpsec_pop_signature_seg(bgpsec);
+}
+
+RTRLIB_EXPORT void rtr_mgr_bgpsec_append_sec_path_seg(struct rtr_bgpsec *bgpsec, struct rtr_secure_path_seg *new_seg)
+{
+	rtr_bgpsec_append_sec_path_seg(bgpsec, new_seg);
+}
+
+RTRLIB_EXPORT int rtr_mgr_bgpsec_append_sig_seg(struct rtr_bgpsec *bgpsec, struct rtr_signature_seg *new_seg)
+{
+	return rtr_bgpsec_append_sig_seg(bgpsec, new_seg);
+}
+
+RTRLIB_EXPORT struct rtr_bgpsec_nlri *rtr_mgr_bgpsec_nlri_new(int nlri_len)
+{
+	return rtr_bgpsec_nlri_new(nlri_len);
+}
+
+RTRLIB_EXPORT void rtr_mgr_bgpsec_nlri_free(struct rtr_bgpsec_nlri *nlri)
+{
+	rtr_bgpsec_nlri_free(nlri);
+}
+
+RTRLIB_EXPORT void rtr_mgr_bgpsec_add_spki_record(struct rtr_mgr_config *config, struct spki_record *record)
+{
+	rtr_bgpsec_add_spki_record(config->spki_table, record);
+}
+#endif

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -33,8 +33,13 @@
 #ifndef RTR_MGR
 #define RTR_MGR
 
+#include "config.h"
+
 #include "rtrlib/pfx/pfx.h"
 #include "rtrlib/spki/spkitable.h"
+#ifdef RTRLIB_BGPSEC_ENABLED
+#include "rtrlib/bgpsec/bgpsec.h"
+#endif
 
 #include <pthread.h>
 #include <stdint.h>
@@ -257,5 +262,160 @@ struct rtr_mgr_group *rtr_mgr_get_first_group(struct rtr_mgr_config *config);
 
 int rtr_mgr_for_each_group(struct rtr_mgr_config *config, void (*fp)(const struct rtr_mgr_group *group, void *data),
 			   void *data);
+/* @} */
+
+/**
+ * @defgroup mod_bgpsec_h BGPsec AS path validation
+ * @brief BGPsec allows for validation of the BGPsec_PATH attribute of a
+ * BGPsec update.
+ * @{
+ */
+#ifdef RTRLIB_BGPSEC_ENABLED
+/**
+ * @brief Validation function for AS path validation.
+ * @param[in] data Data required for AS path validation. See @ref rtr_bgpsec.
+ * @param[in] config The rtr_mgr_config containing a SPKI table.
+ * @return RTR_BGPSEC_VALID If the AS path was valid.
+ * @return RTR_BGPSEC_NOT_VALID If the AS path was not valid.
+ * @return RTR_BGPSEC_ERROR If an error occurred. Refer to error codes for
+ *			more details.
+ */
+int rtr_mgr_bgpsec_validate_as_path(const struct rtr_bgpsec *data, struct rtr_mgr_config *config);
+
+/**
+ * @brief Signing function for a BGPsec_PATH.
+ * @param[in] data Data required for AS path validation. See @ref rtr_bgpsec.
+ * @param[in] private_key The raw bytes of the private key that is used for signing.
+ * @param[out] new_signature Contains the generated signature and its length if
+ *			     successful. Must not be allocated.
+ * @return RTR_BGPSEC_SUCCESS If the signature was successfully generated.
+ * @return RTR_BGPSEC_ERROR If an error occurred. Refer to error codes for
+ *			    more details.
+ */
+int rtr_mgr_bgpsec_generate_signature(const struct rtr_bgpsec *data, uint8_t *private_key,
+				      struct rtr_signature_seg **new_signature);
+
+/**
+ * @brief Returns the highest supported BGPsec version.
+ * @return RTR_BGPSEC_VERSION The currently supported BGPsec version.
+ */
+int rtr_mgr_bgpsec_get_version(void);
+
+/**
+ * @brief Check, if an algorithm suite is supported by RTRlib.
+ * @param[in] alg_suite The algorithm suite that is to be checked.
+ * @return RTR_BGPSEC_SUCCESS If the algorithm suite is supported.
+ * @return RTR_BGPSEC_ERROR If the algorithm suite is not supported.
+ */
+int rtr_mgr_bgpsec_has_algorithm_suite(uint8_t alg_suite);
+
+/**
+ * @brief Returns pointer to a list that holds all supported algorithm suites.
+ * @param[out] algs_arr A char pointer that contains all supported suites.
+ * @return ALGORITHM_SUITES_COUNT The size of algs_arr
+ */
+int rtr_mgr_bgpsec_get_algorithm_suites(const uint8_t **algs_arr);
+
+/**
+ * @brief Free a signature and any signatures that are pointed to.
+ * @param[in] seg The signature that has been passed to the signing
+ *	      function.
+ */
+void rtr_mgr_bgpsec_free_signatures(struct rtr_signature_seg *seg);
+
+/**
+ * @brief Return an allocated and initialized Secure Path Segment.
+ * @param[in] pcount The pcount field.
+ * @param[in] flags The flags field.
+ * @param[in] asn The ASN of the segment.
+ * @return A pointer to an initialized rtr_secure_path_seg struct
+ */
+struct rtr_secure_path_seg *rtr_mgr_bgpsec_new_secure_path_seg(uint8_t pcount, uint8_t flags, uint32_t asn);
+
+/**
+ * @brief Prepend a given Secure Path Segment to @ref rtr_bgpsec.path.
+ * @param[in] bgpsec The rtr_bgpsec struct that holds the path.
+ * @param[in] new_seg The Secure Path Segment that is appended to the path.
+ */
+void rtr_mgr_bgpsec_prepend_sec_path_seg(struct rtr_bgpsec *bgpsec, struct rtr_secure_path_seg *new_seg);
+
+/**
+ * @brief Return an allocated and initialized Signature.
+ * @param[in] ski The Subject Key Identifier as byte representation.
+ * @param[in] sig_len The length of the signature.
+ * @param[in] signature The signature itself.
+ * @return A pointer to an initialized rtr_secure_path_seg struct.
+ *	   @ref rtr_signature_seg.signature is allocated with sig_len
+ *	   bytes.
+ */
+struct rtr_signature_seg *rtr_mgr_bgpsec_new_signature_seg(uint8_t *ski, uint16_t sig_len, uint8_t *signature);
+
+/**
+ * @brief Prepend a given Signature Segment to @ref rtr_bgpsec.sigs. All fields
+ *	  of the new_seg must be filled.
+ * @param[in] bgpsec The rtr_bgpsec struct that holds the signatures.
+ * @param[in] new_seg The Signature Segment that is appended to the signatures.
+ * @return RTR_BGPSEC_SUCCESS If the signature was successfully prepended.
+ * @return RTR_BGPSEC_ERROR If an error occurred during prepending, e.g. one
+ *			    or more fields of new_seg was missing.
+ */
+int rtr_mgr_bgpsec_prepend_sig_seg(struct rtr_bgpsec *bgpsec, struct rtr_signature_seg *new_seg);
+
+/**
+ * @brief Initializes and returns a pointer to a rtr_bgpsec struct.
+ * @param[in] alg The Algorithm Suite Identifier.
+ * @param[in] safi The Subsequent Address Family Identifier.
+ * @param[in] afi The Address Family Identifier.
+ * @param[in] my_as The AS that is currently performing validation (you).
+ * @param[in] target_as The AS where the update should be sent to.
+ * @param[in] nlri The Network Layer Reachability Information.
+ * @return A pointer to an initialized rtr_bgpsec struct.
+ */
+struct rtr_bgpsec *rtr_mgr_bgpsec_new(uint8_t alg, uint8_t safi, uint16_t afi, uint32_t my_as, uint32_t target_as,
+				      struct rtr_bgpsec_nlri *nlri);
+
+/**
+ * @brief Free a rtr_bgpsec struct and any Secure Path and Signature
+ *	  Segments it holds.
+ * @param[in] bgpsec The rtr_bgpsec struct that is to be freed.
+ */
+void rtr_mgr_bgpsec_free(struct rtr_bgpsec *bgpsec);
+
+/**
+ * @brief Free a Secure Path Segment and any segments that are pointed to
+ *	  by @ref rtr_secure_path_seg.next.
+ * @param[in] seg The Secure Path Segment that is to be freed.
+ */
+void rtr_mgr_free_secure_path(struct rtr_secure_path_seg *seg);
+
+/**
+ * @brief Retrieve a pointer to the last appended Secure Path Segment
+ *	  from a bgpsec struct.
+ * @param[in] bgpsec The bgpsec struct that contains the Secure Path.
+ * @return *rtr_secure_path_seg If @ref rtr_bgpsec.path_len > 0.
+ * @return NULL If @ref rtr_bgpsec.path_len = 0.
+ */
+struct rtr_secure_path_seg *rtr_mgr_bgpsec_pop_secure_path_seg(struct rtr_bgpsec *bgpsec);
+
+/**
+ * @brief Retrieve a pointer to the last appended Signature Segment from
+ *	  a bgpsec struct.
+ * @param[in] bgpsec The bgpsec struct that contains the Signatures.
+ * @return *rtr_signature_seg If @ref rtr_bgpsec.sigs_len > 0.
+ * @return NULL if @ref rtr_bgpsec.sigs_len = 0.
+ */
+struct rtr_signature_seg *rtr_mgr_bgpsec_pop_signature_seg(struct rtr_bgpsec *bgpsec);
+
+void rtr_mgr_bgpsec_append_sec_path_seg(struct rtr_bgpsec *bgpsec, struct rtr_secure_path_seg *new_seg);
+
+int rtr_mgr_bgpsec_append_sig_seg(struct rtr_bgpsec *bgpsec, struct rtr_signature_seg *new_seg);
+
+struct rtr_bgpsec_nlri *rtr_mgr_bgpsec_nlri_new(int nlri_len);
+
+void rtr_mgr_bgpsec_nlri_free(struct rtr_bgpsec_nlri *nlri);
+
+void rtr_mgr_bgpsec_add_spki_record(struct rtr_mgr_config *config, struct spki_record *record);
+#endif
+
 #endif
 /** @} */

--- a/rtrlib/rtrlib.h.cmake
+++ b/rtrlib/rtrlib.h.cmake
@@ -19,6 +19,7 @@ extern "C" {
 #define RTRLIB_VERSION_MINOR @RTRLIB_VERSION_MINOR@
 #define RTRLIB_VERSION_PATCH @RTRLIB_VERSION_PATCH@
 
+#include "config.h"
 #include "lib/alloc_utils.h"
 #include "lib/ip.h"
 #include "lib/ipv4.h"
@@ -31,6 +32,9 @@ extern "C" {
 #include "transport/transport.h"
 #ifdef RTRLIB_HAVE_LIBSSH
 #include "rtrlib/transport/ssh/ssh_transport.h"
+#endif
+#ifdef RTRLIB_BGPSEC_ENABLED
+#include "rtrlib/bgpsec/bgpsec.h"
 #endif
 
 #endif

--- a/scripts/check-coding-style.sh
+++ b/scripts/check-coding-style.sh
@@ -26,7 +26,7 @@ cd $SCRIPT_DIR/..
 for i in $CHECKSOURCE; do
 	echo "> check coding style of $i ..."
     IGNORE="PREFER_KERNEL_TYPES,CONST_STRUCT,OPEN_BRACE,SPDX_LICENSE_TAG,OPEN_ENDED_LINE,UNNECESSARY_PARENTHESES,PREFER_PRINTF,GLOBAL_INITIALISERS,PREFER_PACKED,BOOL_MEMBER,STATIC_CONST_CHAR_ARRAY,LONG_LINE_STRING"
-    if [[ $i == *"unittest"* ]]; then
+    if [[ $i == *"unittest"* ]] || [[ $i == *"bgpsec"* ]]; then
         IGNORE="${IGNORE},CAMELCASE"
     fi
         $SCRIPT_DIR/checkpatch.pl -f --strict --no-tree --terse --show-types \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,11 @@ add_coverage(test_getbits)
 add_executable(test_dynamic_groups test_dynamic_groups.c)
 target_link_libraries(test_dynamic_groups rtrlib_static)
 add_coverage(test_dynamic_groups)
+if(RTRLIB_BGPSEC_ENABLED)
+    add_executable(test_bgpsec test_bgpsec.c)
+    target_link_libraries(test_bgpsec rtrlib_static)
+    add_coverage(test_bgpsec)
+endif(RTRLIB_BGPSEC_ENABLED)
 
 
 if(UNIT_TESTING AND NOT APPLE)

--- a/tests/test_bgpsec.c
+++ b/tests/test_bgpsec.c
@@ -1,0 +1,416 @@
+#include "rtrlib/bgpsec/bgpsec.h"
+#include "rtrlib/bgpsec/bgpsec_private.h"
+#include "rtrlib/bgpsec/bgpsec_utils_private.h"
+#include "rtrlib/rtr_mgr.h"
+#include "rtrlib/rtrlib.h"
+#include "rtrlib/spki/hashtable/ht-spkitable_private.h"
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Below are the SKIs, signatures, public keys and the private key that
+ * are required to build a valid BGPsec path of length two. They all are
+ * in binary form.
+ */
+static uint8_t ski1[] = {0x47, 0xF2, 0x3B, 0xF1, 0xAB, 0x2F, 0x8A, 0x9D, 0x26, 0x86,
+			 0x4E, 0xBB, 0xD8, 0xDF, 0x27, 0x11, 0xC7, 0x44, 0x06, 0xEC};
+
+static uint8_t sig1[] = {0x30, 0x46, 0x02, 0x21, 0x00, 0xEF, 0xD4, 0x8B, 0x2A, 0xAC, 0xB6, 0xA8, 0xFD, 0x11, 0x40,
+			 0xDD, 0x9C, 0xD4, 0x5E, 0x81, 0xD6, 0x9D, 0x2C, 0x87, 0x7B, 0x56, 0xAA, 0xF9, 0x91, 0xC3,
+			 0x4D, 0x0E, 0xA8, 0x4E, 0xAF, 0x37, 0x16, 0x02, 0x21, 0x00, 0x90, 0xF2, 0xC1, 0x29, 0xAB,
+			 0xB2, 0xF3, 0x9B, 0x6A, 0x07, 0x96, 0x3B, 0xD5, 0x55, 0xA8, 0x7A, 0xB2, 0xB7, 0x33, 0x3B,
+			 0x7B, 0x91, 0xF1, 0x66, 0x8F, 0xD8, 0x61, 0x8C, 0x83, 0xFA, 0xC3, 0xF1};
+
+static uint8_t spki1[] = {0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
+			  0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+			  0x04, 0x28, 0xFC, 0x5F, 0xE9, 0xAF, 0xCF, 0x5F, 0x4C, 0xAB, 0x3F, 0x5F, 0x85,
+			  0xCB, 0x21, 0x2F, 0xC1, 0xE9, 0xD0, 0xE0, 0xDB, 0xEA, 0xEE, 0x42, 0x5B, 0xD2,
+			  0xF0, 0xD3, 0x17, 0x5A, 0xA0, 0xE9, 0x89, 0xEA, 0x9B, 0x60, 0x3E, 0x38, 0xF3,
+			  0x5F, 0xB3, 0x29, 0xDF, 0x49, 0x56, 0x41, 0xF2, 0xBA, 0x04, 0x0F, 0x1C, 0x3A,
+			  0xC6, 0x13, 0x83, 0x07, 0xF2, 0x57, 0xCB, 0xA6, 0xB8, 0xB5, 0x88, 0xF4, 0x1F};
+
+static uint8_t ski2[] = {0xAB, 0x4D, 0x91, 0x0F, 0x55, 0xCA, 0xE7, 0x1A, 0x21, 0x5E,
+			 0xF3, 0xCA, 0xFE, 0x3A, 0xCC, 0x45, 0xB5, 0xEE, 0xC1, 0x54};
+
+static uint8_t sig2[] = {0x30, 0x46, 0x02, 0x21, 0x00, 0xEF, 0xD4, 0x8B, 0x2A, 0xAC, 0xB6, 0xA8, 0xFD, 0x11, 0x40,
+			 0xDD, 0x9C, 0xD4, 0x5E, 0x81, 0xD6, 0x9D, 0x2C, 0x87, 0x7B, 0x56, 0xAA, 0xF9, 0x91, 0xC3,
+			 0x4D, 0x0E, 0xA8, 0x4E, 0xAF, 0x37, 0x16, 0x02, 0x21, 0x00, 0x8E, 0x21, 0xF6, 0x0E, 0x44,
+			 0xC6, 0x06, 0x6C, 0x8B, 0x8A, 0x95, 0xA3, 0xC0, 0x9D, 0x3A, 0xD4, 0x37, 0x95, 0x85, 0xA2,
+			 0xD7, 0x28, 0xEE, 0xAD, 0x07, 0xA1, 0x7E, 0xD7, 0xAA, 0x05, 0x5E, 0xCA};
+
+static uint8_t spki2[] = {0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
+			  0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+			  0x04, 0x73, 0x91, 0xBA, 0xBB, 0x92, 0xA0, 0xCB, 0x3B, 0xE1, 0x0E, 0x59, 0xB1,
+			  0x9E, 0xBF, 0xFB, 0x21, 0x4E, 0x04, 0xA9, 0x1E, 0x0C, 0xBA, 0x1B, 0x13, 0x9A,
+			  0x7D, 0x38, 0xD9, 0x0F, 0x77, 0xE5, 0x5A, 0xA0, 0x5B, 0x8E, 0x69, 0x56, 0x78,
+			  0xE0, 0xFA, 0x16, 0x90, 0x4B, 0x55, 0xD9, 0xD4, 0xF5, 0xC0, 0xDF, 0xC5, 0x88,
+			  0x95, 0xEE, 0x50, 0xBC, 0x4F, 0x75, 0xD2, 0x05, 0xA2, 0x5B, 0xD3, 0x6F, 0xF5};
+
+static uint8_t private_key[] = {0x30, 0x77, 0x02, 0x01, 0x01, 0x04, 0x20, 0xD8, 0xAA, 0x4D, 0xFB, 0xE2, 0x47, 0x8F,
+				0x86, 0xE8, 0x8A, 0x74, 0x51, 0xBF, 0x07, 0x55, 0x65, 0x70, 0x9C, 0x57, 0x5A, 0xC1,
+				0xC1, 0x36, 0xD0, 0x81, 0xC5, 0x40, 0x25, 0x4C, 0xA4, 0x40, 0xB9, 0xA0, 0x0A, 0x06,
+				0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0xA1, 0x44, 0x03, 0x42, 0x00,
+				0x04, 0x73, 0x91, 0xBA, 0xBB, 0x92, 0xA0, 0xCB, 0x3B, 0xE1, 0x0E, 0x59, 0xB1, 0x9E,
+				0xBF, 0xFB, 0x21, 0x4E, 0x04, 0xA9, 0x1E, 0x0C, 0xBA, 0x1B, 0x13, 0x9A, 0x7D, 0x38,
+				0xD9, 0x0F, 0x77, 0xE5, 0x5A, 0xA0, 0x5B, 0x8E, 0x69, 0x56, 0x78, 0xE0, 0xFA, 0x16,
+				0x90, 0x4B, 0x55, 0xD9, 0xD4, 0xF5, 0xC0, 0xDF, 0xC5, 0x88, 0x95, 0xEE, 0x50, 0xBC,
+				0x4F, 0x75, 0xD2, 0x05, 0xA2, 0x5B, 0xD3, 0x6F, 0xF5};
+
+/* To test potential error sources, a wrong signature, public key and
+ * private key are used. RTRlib should respond with appropriate error codes.
+ */
+static uint8_t wrong_sig[] = {0x30, 0x46, 0x02, 0x21, 0x00, 0xEF, 0xD4, 0x8B, 0x2A, 0xAC, 0xB6, 0xA8, 0xFD, 0x11, 0x40,
+			      0xDD, 0x9C, 0xD4, 0x5E, 0x81, 0xD6, 0x9D, 0x2C, 0x87, 0x7B, 0x56, 0xAA, 0xF9, 0x91, 0xC3,
+			      0x4D, 0x0E, 0xA8, 0x4E, 0xAF, 0x37, 0x16, 0x02, 0x21, 0x00, 0x8E, 0x21, 0xF6, 0x0E, 0x44,
+			      0xC6, 0x06, 0x6C, 0x8B, 0x8A, 0x95, 0xA3, 0xC0, 0x9D, 0x3A, 0xD4, 0x37, 0x95, 0x85, 0xA2,
+			      0xD7, 0x28, 0xEE, 0xAD, 0x07, 0xA1, 0x7E, 0xD7, 0xAA, 0x05, 0x5E, 0xCB};
+
+static uint8_t wrong_private_key[] = {
+	0x30, 0x77, 0x02, 0x01, 0x01, 0x04, 0x20, 0xD8, 0xAA, 0x4D, 0xFB, 0xE2, 0x47, 0x8F, 0x86, 0xE8, 0x8A, 0x74,
+	0x51, 0xBF, 0x07, 0x55, 0x65, 0x70, 0x9C, 0x57, 0x5A, 0xC1, 0xC1, 0x36, 0xD0, 0x81, 0xC5, 0x40, 0x25, 0x4C,
+	0xA4, 0x40, 0xBA, 0xA0, 0x0A, 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0xA1, 0x44, 0x03,
+	0x42, 0x00, 0x04, 0x73, 0x91, 0xBA, 0xBB, 0x92, 0xA0, 0xCB, 0x3B, 0xE1, 0x0E, 0x59, 0xB1, 0x9E, 0xBF, 0xFB,
+	0x21, 0x4E, 0x04, 0xA9, 0x1E, 0x0C, 0xBA, 0x1B, 0x13, 0x9A, 0x7D, 0x38, 0xD9, 0x0F, 0x77, 0xE5, 0x5A, 0xA0,
+	0x5B, 0x8E, 0x69, 0x56, 0x78, 0xE0, 0xFA, 0x16, 0x90, 0x4B, 0x55, 0xD9, 0xD4, 0xF5, 0xC0, 0xDF, 0xC5, 0x88,
+	0x95, 0xEE, 0x50, 0xBC, 0x4F, 0x75, 0xD2, 0x05, 0xA2, 0x5B, 0xD3, 0x6F, 0xF5};
+
+/* Helper function to create a spki_record */
+static struct spki_record *create_record(int ASN, uint8_t *ski, uint8_t *spki)
+{
+	struct spki_record *record = malloc(sizeof(struct spki_record));
+
+	memset(record, 0, sizeof(*record));
+	record->asn = ASN;
+	memcpy(record->ski, ski, SKI_SIZE);
+	memcpy(record->spki, spki, SPKI_SIZE);
+	record->socket = NULL;
+	return record;
+}
+
+/* Test function to validate a BGPsec path. Multiple scenarios are tested
+ * regarding validation.
+ */
+static void validate_bgpsec_path_test(void)
+{
+	struct rtr_bgpsec *bgpsec = NULL;
+	struct rtr_bgpsec_nlri *pfx = NULL;
+	int pfx_int = 0;
+
+	struct spki_table table;
+	struct spki_record *record1;
+	struct spki_record *record2;
+	struct spki_record *duplicate_record;
+
+	enum rtr_bgpsec_rtvals result;
+
+	struct rtr_signature_seg *ss = NULL;
+	struct rtr_secure_path_seg *sps = NULL;
+
+	uint8_t alg = 1;
+	uint8_t safi = 1;
+	uint16_t afi = 1;
+	uint32_t my_as = 65537;
+
+	pfx = rtr_mgr_bgpsec_nlri_new(3);
+	pfx->nlri_len = 24;
+	pfx->afi = 1; /* LRTR_IPV4 */
+	pfx_int = htonl(3221225984); /* 192.0.2.0 */
+
+	memcpy(pfx->nlri, &pfx_int, 3);
+
+	bgpsec = rtr_mgr_bgpsec_new(alg, safi, afi, my_as, my_as, pfx);
+
+	/* init the rtr_signature_seg and rtr_secure_path_seg structs. */
+
+	uint8_t pcount = 1;
+	uint8_t flags = 0;
+	uint32_t asn = 64496;
+
+	sps = rtr_mgr_bgpsec_new_secure_path_seg(pcount, flags, asn);
+	rtr_mgr_bgpsec_prepend_sec_path_seg(bgpsec, sps);
+
+	asn = 65536;
+	sps = rtr_mgr_bgpsec_new_secure_path_seg(pcount, flags, asn);
+	rtr_mgr_bgpsec_prepend_sec_path_seg(bgpsec, sps);
+
+	uint16_t sig_len = 72;
+
+	ss = rtr_mgr_bgpsec_new_signature_seg(ski2, sig_len, sig2);
+	result = rtr_mgr_bgpsec_prepend_sig_seg(bgpsec, ss);
+	assert(result == RTR_BGPSEC_SUCCESS);
+
+	ss = rtr_mgr_bgpsec_new_signature_seg(ski1, sig_len, sig1);
+	result = rtr_mgr_bgpsec_prepend_sig_seg(bgpsec, ss);
+	assert(result == RTR_BGPSEC_SUCCESS);
+
+	/* init the SPKI table and store two valid router keys and one duplicate
+	 * key in it.
+	 */
+	spki_table_init(&table, NULL);
+	record1 = create_record(65536, ski1, spki1);
+	record2 = create_record(64496, ski2, spki2);
+	duplicate_record = create_record(64497, ski2, spki1);
+
+	/* Pass all data to the validation function. The result is either
+	 * RTR_BGPSEC_VALID or RTR_BGPSEC_NOT_VALID.
+	 * Test with 2 AS hops.
+	 * (table = record1, record2)
+	 */
+	spki_table_add_entry(&table, record1);
+	spki_table_add_entry(&table, record2);
+	result = rtr_bgpsec_validate_as_path(bgpsec, &table);
+
+	assert(result == RTR_BGPSEC_VALID);
+
+	/* Pass a wrong signature.
+	 * (table = record1, record2)
+	 */
+	memcpy(bgpsec->sigs->next->signature, wrong_sig, sizeof(wrong_sig));
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, &table);
+
+	assert(result == RTR_BGPSEC_NOT_VALID);
+
+	memcpy(bgpsec->sigs->next->signature, sig2, sizeof(sig2));
+
+	/* Public key not in SPKI table
+	 * (table = record2)
+	 */
+	spki_table_remove_entry(&table, record1);
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, &table);
+
+	assert(result == RTR_BGPSEC_ROUTER_KEY_NOT_FOUND);
+
+	/* What if there are mulitple SPKI entries for a SKI in the SPKI table.
+	 * (table = record1, record2, duplicate_record)
+	 */
+	spki_table_add_entry(&table, duplicate_record);
+	spki_table_add_entry(&table, record1);
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, &table);
+
+	assert(result == RTR_BGPSEC_VALID);
+
+	/* Pass an unsupported algorithm suite. */
+	bgpsec->alg = 2;
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, &table);
+
+	assert(result == RTR_BGPSEC_UNSUPPORTED_ALGORITHM_SUITE);
+
+	/* Free all allocated memory. */
+	spki_table_free(&table);
+	free(record1);
+	free(record2);
+	free(duplicate_record);
+	rtr_mgr_bgpsec_free(bgpsec);
+}
+
+/* Test function for generating signatures. Since signing does not depend
+ * on the SPKI table, all error sources regarding public keys can be
+ * disregarded.
+ */
+static void generate_signature_test(void)
+{
+	/* AS(64496)--->AS(65536)--->AS(65537) */
+	struct rtr_bgpsec *bgpsec = NULL;
+	struct rtr_bgpsec_nlri *pfx = NULL;
+	int pfx_int = 0;
+
+	struct spki_table table;
+	struct spki_record *record1;
+	struct spki_record *record2;
+
+	struct rtr_signature_seg *new_sig = NULL;
+	struct rtr_secure_path_seg *new_sec = NULL;
+
+	enum rtr_bgpsec_rtvals result;
+
+	struct rtr_signature_seg *ss = NULL;
+	struct rtr_secure_path_seg *sps = NULL;
+
+	uint8_t alg = 1;
+	uint8_t safi = 1;
+	uint16_t afi = 1;
+	uint32_t my_as = 65537;
+	uint32_t target_as = 65538;
+
+	pfx = rtr_mgr_bgpsec_nlri_new(3);
+	pfx->nlri_len = 24;
+	pfx->afi = 1; /* LRTR_IPV4 */
+	pfx_int = htonl(3221225984); /* 192.0.2.0 */
+
+	memcpy(pfx->nlri, &pfx_int, 3);
+
+	bgpsec = rtr_mgr_bgpsec_new(alg, safi, afi, my_as, target_as, pfx);
+
+	/* init the rtr_signature_seg and rtr_secure_path_seg structs. */
+
+	uint8_t pcount = 1;
+	uint8_t flags = 0;
+	uint32_t asn = 64496;
+
+	sps = rtr_mgr_bgpsec_new_secure_path_seg(pcount, flags, asn);
+	rtr_mgr_bgpsec_prepend_sec_path_seg(bgpsec, sps);
+
+	asn = 65536;
+	sps = rtr_mgr_bgpsec_new_secure_path_seg(pcount, flags, asn);
+	rtr_mgr_bgpsec_prepend_sec_path_seg(bgpsec, sps);
+
+	uint16_t sig_len = 72;
+
+	ss = rtr_mgr_bgpsec_new_signature_seg(ski2, sig_len, sig2);
+	result = rtr_mgr_bgpsec_prepend_sig_seg(bgpsec, ss);
+	assert(result == RTR_BGPSEC_SUCCESS);
+
+	ss = rtr_mgr_bgpsec_new_signature_seg(ski1, sig_len, sig1);
+	result = rtr_mgr_bgpsec_prepend_sig_seg(bgpsec, ss);
+	assert(result == RTR_BGPSEC_SUCCESS);
+
+	new_sec = rtr_mgr_bgpsec_new_secure_path_seg(pcount, flags, my_as);
+	rtr_mgr_bgpsec_prepend_sec_path_seg(bgpsec, new_sec);
+
+	/* init the SPKI table and store two router keys in it. */
+	spki_table_init(&table, NULL);
+	record2 = create_record(65536, ski1, spki1);
+	record1 = create_record(64496, ski2, spki2);
+
+	spki_table_add_entry(&table, record1);
+	spki_table_add_entry(&table, record2);
+
+	/* Pass all data to the validation function. The result is either
+	 * RTR_BGPSEC_VALID or RTR_BGPSEC_NOT_VALID.
+	 * Test with 1 AS hop.
+	 */
+
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_sig);
+
+	assert(new_sig->sig_len > 0);
+
+	rtr_mgr_bgpsec_free_signatures(new_sig);
+
+	new_sig = NULL;
+
+	result = rtr_bgpsec_generate_signature(bgpsec, wrong_private_key, &new_sig);
+
+	assert(result == RTR_BGPSEC_LOAD_PRIV_KEY_ERROR);
+
+	assert(!new_sig);
+
+	/* Free all allocated memory. */
+	spki_table_free(&table);
+	free(record1);
+	free(record2);
+	rtr_mgr_bgpsec_free(bgpsec);
+	rtr_mgr_bgpsec_free_signatures(new_sig);
+}
+
+/* Another test for creating a signature. This time, there are no prior
+ * BGPsec path elements that need to be signed.
+ */
+static void originate_and_validate_test(void)
+{
+	/* AS(64496)--->AS(65536)--->AS(65537) */
+	struct rtr_bgpsec *bgpsec = NULL;
+	struct rtr_bgpsec_nlri *pfx = NULL;
+	int pfx_int = 0;
+
+	struct spki_table table;
+	struct spki_record *record1;
+	struct spki_record *record2;
+
+	struct rtr_signature_seg *new_sig = NULL;
+	struct rtr_secure_path_seg *new_sec = NULL;
+
+	enum rtr_bgpsec_rtvals result;
+
+	uint8_t alg = 1;
+	uint8_t safi = 1;
+	uint16_t afi = 1;
+	uint32_t my_as = 64496;
+	uint32_t target_as = 65536;
+
+	pfx = rtr_mgr_bgpsec_nlri_new(3);
+	pfx->nlri_len = 24;
+	pfx->afi = 1; /* LRTR_IPV4 */
+	pfx_int = htonl(3221225984); /* 192.0.2.0 */
+
+	memcpy(pfx->nlri, &pfx_int, 3);
+
+	bgpsec = rtr_mgr_bgpsec_new(alg, safi, afi, my_as, target_as, pfx);
+
+	/* init the rtr_signature_seg and rtr_secure_path_seg structs. */
+
+	uint8_t pcount = 1;
+	uint8_t flags = 0;
+
+	new_sec = rtr_mgr_bgpsec_new_secure_path_seg(pcount, flags, my_as);
+	rtr_mgr_bgpsec_prepend_sec_path_seg(bgpsec, new_sec);
+
+	/* init the SPKI table and store two router keys in it. */
+	spki_table_init(&table, NULL);
+	record2 = create_record(65536, ski1, spki1);
+	record1 = create_record(64496, ski2, spki2);
+
+	spki_table_add_entry(&table, record1);
+	spki_table_add_entry(&table, record2);
+
+	/* Generate a signature... */
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_sig);
+	assert(new_sig->sig_len > 0);
+
+	/* ... copy the SKI to the new_sig struct... */
+	memcpy(new_sig->ski, ski2, SKI_SIZE);
+
+	/* ... prepend the new signature to bgpsec... */
+	result = rtr_mgr_bgpsec_prepend_sig_seg(bgpsec, new_sig);
+	assert(result == RTR_BGPSEC_SUCCESS);
+
+	/* ... and validate the freshly generated signature. */
+	result = rtr_bgpsec_validate_as_path(bgpsec, &table);
+	assert(result == RTR_BGPSEC_VALID);
+
+	/* Free all allocated memory. */
+	spki_table_free(&table);
+	free(record1);
+	free(record2);
+	rtr_mgr_bgpsec_free(bgpsec);
+}
+
+/* Test function for version and algorithm suites. Basic tests to
+ * cover the rest of the public API.
+ */
+static void bgpsec_version_and_algorithms_test(void)
+{
+	/* BGPsec version tests */
+	assert(rtr_bgpsec_get_version() == 0);
+
+	assert(rtr_bgpsec_get_version() != 1);
+
+	/* BGPsec algorithm suite tests */
+	assert(rtr_bgpsec_has_algorithm_suite(1) == RTR_BGPSEC_SUCCESS);
+
+	assert(rtr_bgpsec_has_algorithm_suite(2) == RTR_BGPSEC_ERROR);
+
+	/* BGPsec algorithm suites array test */
+	const uint8_t *suites = NULL;
+	unsigned int suites_len = rtr_bgpsec_get_algorithm_suites(&suites);
+
+	assert(suites_len == 1);
+	for (unsigned int i = 0; i < suites_len; i++)
+		assert(suites[i] == 1);
+}
+
+int main(void)
+{
+	validate_bgpsec_path_test();
+	generate_signature_test();
+	originate_and_validate_test();
+	bgpsec_version_and_algorithms_test();
+	printf("Test Sucessful!\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -5,3 +5,13 @@ wrap_functions(test_packets_static lrtr_get_monotonic_time tr_send_all)
 
 add_rtr_unit_test(test_packets test_packets.c rtrlib_static cmocka)
 wrap_functions(test_packets rtr_change_socket_state tr_send_all)
+
+if(RTRLIB_BGPSEC_ENABLED)
+    add_rtr_unit_test(test_bgpsec_utils test_bgpsec_utils.c rtrlib_static cmocka)
+
+    add_rtr_unit_test(test_bgpsec_validation test_bgpsec_validation.c rtrlib_static cmocka)
+    wrap_functions(test_bgpsec_validation check_router_keys req_stream_size align_byte_sequence hash_byte_sequence validate_signature spki_table_search_by_ski)
+
+    add_rtr_unit_test(test_bgpsec_signing test_bgpsec_signing.c rtrlib_static cmocka)
+    wrap_functions(test_bgpsec_signing load_private_key req_stream_size align_byte_sequence hash_byte_sequence ECDSA_size sign_byte_sequence)
+endif(RTRLIB_BGPSEC_ENABLED)

--- a/tests/unittests/test_bgpsec_signing.c
+++ b/tests/unittests/test_bgpsec_signing.c
@@ -1,0 +1,286 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include "rtrlib_unittests.h"
+#include "test_bgpsec_signing.h"
+
+#include "rtrlib/bgpsec/bgpsec.c"
+
+#include <assert.h>
+
+struct rtr_bgpsec *setup_bgpsec(void)
+{
+	struct rtr_bgpsec *bgpsec = NULL;
+	uint8_t alg = 1;
+	uint8_t safi = 1;
+	uint16_t afi = 1;
+	uint32_t my_as = 65537;
+	uint32_t target_as = 65538;
+	struct rtr_bgpsec_nlri *pfx = NULL;
+	int pfx_int = 0;
+
+	pfx = rtr_bgpsec_nlri_new(3);
+	pfx->nlri_len = 24;
+	pfx->afi = 1; /* LRTR_IPV4 */
+	pfx_int = htonl(3221225984); /* 192.0.2.0 */
+
+	memcpy(pfx->nlri, &pfx_int, 3);
+
+	bgpsec = rtr_bgpsec_new(alg, safi, afi, my_as, target_as, pfx);
+	bgpsec->path = lrtr_malloc(sizeof(struct rtr_secure_path_seg));
+	bgpsec->sigs = lrtr_malloc(sizeof(struct rtr_signature_seg));
+	bgpsec->path->next = NULL;
+	bgpsec->sigs->next = NULL;
+	bgpsec->sigs->sig_len = 0;
+
+	return bgpsec;
+}
+
+int __wrap_load_private_key(EC_KEY **priv_key, uint8_t *bytes_key)
+{
+	UNUSED(priv_key);
+	UNUSED(bytes_key);
+	return (int)mock();
+}
+
+int __wrap_ECDSA_size(const EC_KEY *key)
+{
+	UNUSED(key);
+	return (int)mock();
+}
+
+int __wrap_align_byte_sequence(const struct rtr_bgpsec *data, struct stream *s, enum align_type type)
+{
+	UNUSED(data);
+	UNUSED(s);
+	UNUSED(type);
+	return (int)mock();
+}
+
+unsigned int __wrap_req_stream_size(const struct rtr_bgpsec *data, enum align_type type)
+{
+	UNUSED(data);
+	UNUSED(type);
+	return (int)mock();
+}
+
+int __wrap_hash_byte_sequence(uint8_t *bytes, unsigned int bytes_len, uint8_t alg_suite_id, unsigned char **hash_result)
+{
+	UNUSED(bytes);
+	UNUSED(bytes_len);
+	UNUSED(alg_suite_id);
+	UNUSED(hash_result);
+	return (int)mock();
+}
+
+int __wrap_sign_byte_sequence(uint8_t *hash_result, EC_KEY *priv_key, uint8_t alg,
+			      struct rtr_signature_seg *new_signature)
+{
+	UNUSED(hash_result);
+	UNUSED(priv_key);
+	UNUSED(alg);
+	UNUSED(new_signature);
+	return (int)mock();
+}
+
+static void test_sanity_checks(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	uint8_t *private_key = lrtr_malloc(20);
+	struct rtr_signature_seg *new_signature = NULL;
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+	struct rtr_signature_seg *not_empty = lrtr_malloc(sizeof(struct rtr_signature_seg));
+
+	UNUSED(state);
+
+	bgpsec->path_len = 2;
+	bgpsec->sigs_len = 1;
+
+	result = rtr_bgpsec_generate_signature(NULL, private_key, &new_signature);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	result = rtr_bgpsec_generate_signature(bgpsec, NULL, &new_signature);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	result = rtr_bgpsec_generate_signature(NULL, NULL, &new_signature);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	bgpsec->path_len = 1;
+	bgpsec->sigs_len = 1;
+
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_signature);
+	assert_int_equal(RTR_BGPSEC_WRONG_SEGMENT_COUNT, result);
+
+	bgpsec->path_len = 2;
+	bgpsec->sigs_len = 1;
+
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &not_empty);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	bgpsec->path = NULL;
+
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_signature);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	lrtr_free(private_key);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+	lrtr_free(not_empty);
+	rtr_bgpsec_free_signatures(new_signature);
+}
+
+static void test_load_private_key(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	uint8_t *private_key = lrtr_malloc(20);
+	struct rtr_signature_seg *new_signature = NULL;
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	bgpsec->path_len = 2;
+	bgpsec->sigs_len = 1;
+
+	will_return(__wrap_load_private_key, RTR_BGPSEC_LOAD_PRIV_KEY_ERROR);
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_signature);
+	assert_int_equal(RTR_BGPSEC_LOAD_PRIV_KEY_ERROR, result);
+
+	lrtr_free(private_key);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+	rtr_bgpsec_free_signatures(new_signature);
+}
+
+static void test_ecdsa_size(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	uint8_t *private_key = lrtr_malloc(20);
+	struct rtr_signature_seg *new_signature = NULL;
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	bgpsec->path_len = 2;
+	bgpsec->sigs_len = 1;
+
+	will_return(__wrap_ECDSA_size, 0);
+	will_return(__wrap_load_private_key, RTR_BGPSEC_SUCCESS);
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_signature);
+	assert_int_equal(RTR_BGPSEC_LOAD_PRIV_KEY_ERROR, result);
+
+	lrtr_free(private_key);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+	rtr_bgpsec_free_signatures(new_signature);
+}
+
+static void test_align_byte_sequence(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	uint8_t *private_key = lrtr_malloc(20);
+	struct rtr_signature_seg *new_signature = NULL;
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	bgpsec->path_len = 2;
+	bgpsec->sigs_len = 1;
+
+	will_return(__wrap_align_byte_sequence, RTR_BGPSEC_ERROR);
+	will_return(__wrap_req_stream_size, 20);
+	will_return(__wrap_ECDSA_size, 10);
+	will_return(__wrap_load_private_key, RTR_BGPSEC_SUCCESS);
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_signature);
+	assert_int_equal(RTR_BGPSEC_ERROR, result);
+
+	lrtr_free(private_key);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+	rtr_bgpsec_free_signatures(new_signature);
+}
+
+static void test_hash_byte_sequence(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	uint8_t *private_key = lrtr_malloc(20);
+	struct rtr_signature_seg *new_signature = NULL;
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	bgpsec->path_len = 2;
+	bgpsec->sigs_len = 1;
+
+	will_return(__wrap_hash_byte_sequence, RTR_BGPSEC_ERROR);
+	will_return(__wrap_align_byte_sequence, RTR_BGPSEC_SUCCESS);
+	will_return(__wrap_req_stream_size, 20);
+	will_return(__wrap_ECDSA_size, 10);
+	will_return(__wrap_load_private_key, RTR_BGPSEC_SUCCESS);
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_signature);
+	assert_int_equal(RTR_BGPSEC_ERROR, result);
+
+	lrtr_free(private_key);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+	rtr_bgpsec_free_signatures(new_signature);
+}
+
+static void test_sign_byte_sequence(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	uint8_t *private_key = lrtr_malloc(20);
+	struct rtr_signature_seg *new_signature = NULL;
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	bgpsec->path_len = 2;
+	bgpsec->sigs_len = 1;
+
+	will_return(__wrap_sign_byte_sequence, RTR_BGPSEC_SIGNING_ERROR);
+	will_return(__wrap_hash_byte_sequence, RTR_BGPSEC_SUCCESS);
+	will_return(__wrap_align_byte_sequence, RTR_BGPSEC_SUCCESS);
+	will_return(__wrap_req_stream_size, 20);
+	will_return(__wrap_ECDSA_size, 10);
+	will_return(__wrap_load_private_key, RTR_BGPSEC_SUCCESS);
+	result = rtr_bgpsec_generate_signature(bgpsec, private_key, &new_signature);
+	assert_int_equal(RTR_BGPSEC_SIGNING_ERROR, result);
+
+	lrtr_free(private_key);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_sanity_checks),	   cmocka_unit_test(test_load_private_key),
+		cmocka_unit_test(test_ecdsa_size),	   cmocka_unit_test(test_align_byte_sequence),
+		cmocka_unit_test(test_hash_byte_sequence), cmocka_unit_test(test_sign_byte_sequence),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unittests/test_bgpsec_signing.h
+++ b/tests/unittests/test_bgpsec_signing.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#ifndef TEST_BGPSEC_SIGNING_H
+#define TEST_BGPSEC_SIGNING_H
+
+#include "rtrlib/bgpsec/bgpsec_utils_private.h"
+
+#include <openssl/x509.h>
+#include <stdint.h>
+
+struct rtr_bgpsec *setup_bgpsec(void);
+
+int __wrap_load_private_key(EC_KEY **priv_key, uint8_t *bytes_key);
+
+int __wrap_ECDSA_size(const EC_KEY *key);
+
+int __wrap_align_byte_sequence(const struct rtr_bgpsec *data, struct stream *s, enum align_type type);
+
+unsigned int __wrap_req_stream_size(const struct rtr_bgpsec *data, enum align_type type);
+
+int __wrap_hash_byte_sequence(uint8_t *bytes, unsigned int bytes_len, uint8_t alg_suite_id,
+			      unsigned char **hash_result);
+
+int __wrap_sign_byte_sequence(uint8_t *hash_result, EC_KEY *priv_key, uint8_t alg,
+			      struct rtr_signature_seg *new_signature);
+#endif

--- a/tests/unittests/test_bgpsec_utils.c
+++ b/tests/unittests/test_bgpsec_utils.c
@@ -1,0 +1,435 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include "rtrlib_unittests.h"
+#include "test_bgpsec_utils.h"
+
+#include "rtrlib/bgpsec/bgpsec_private.h"
+#include "rtrlib/bgpsec/bgpsec_utils.c"
+
+#include <assert.h>
+
+/* Setup and return a bgpsec struct */
+struct rtr_bgpsec *setup_bgpsec(void)
+{
+	struct rtr_bgpsec *bgpsec = NULL;
+	uint8_t alg = 1;
+	uint8_t safi = 1;
+	uint16_t afi = 1;
+	uint32_t my_as = 65537;
+	uint32_t target_as = 65538;
+	struct rtr_bgpsec_nlri *pfx = NULL;
+	long pfx_int = 0;
+
+	pfx = rtr_bgpsec_nlri_new(3);
+	pfx->nlri_len = 24;
+	pfx->afi = BGPSEC_IPV4;
+	pfx_int = 3221225984; /* 192.0.2.0 */
+
+	memcpy(pfx->nlri, &pfx_int, 3);
+
+	bgpsec = rtr_bgpsec_new(alg, safi, afi, my_as, target_as, pfx);
+	return bgpsec;
+}
+
+/* Setup and return a signature segment */
+struct rtr_signature_seg *setup_sig_seg(void)
+{
+	struct rtr_signature_seg *sig_seg = NULL;
+
+	const char *ski = "aaaaaaaaaaaaaaaaaaaa"; // 20 times 'a'
+	uint16_t sig_len = 10;
+	const char *sig = "bbbbbbbbbb"; // 10 times 'b'
+
+	sig_seg = rtr_bgpsec_new_signature_seg((uint8_t *)ski, sig_len, (uint8_t *)sig);
+	return sig_seg;
+}
+
+/* Setup and return a secure path segment */
+struct rtr_secure_path_seg *setup_sec_seg(void)
+{
+	struct rtr_secure_path_seg *sec_path = NULL;
+	uint8_t pcount = 1;
+	uint8_t flags = 0;
+	uint32_t my_as = 65537;
+
+	sec_path = rtr_bgpsec_new_secure_path_seg(pcount, flags, my_as);
+	return sec_path;
+}
+
+/* Test all stream functions */
+static void test_bgpsec_streams(void **state)
+{
+	UNUSED(state);
+
+	uint16_t size = 8;
+	struct stream *s = init_stream(size);
+
+	uint16_t exp_size = get_stream_size(s);
+	uint8_t *stream_start = get_stream_start(s);
+
+	/* Test, if stream is initialized correctly */
+	assert_int_equal(size, exp_size);
+	assert_int_equal(0, s->w_head);
+	assert_int_equal(0, s->r_head);
+	assert(stream_start == s->stream);
+
+	/* Write 8 bytes to the stream */
+	const char *data = "abcdefgh";
+
+	write_stream(s, (uint8_t *)data, 8);
+
+	/* Check, if the write head moved to position 8 */
+	assert_int_equal(s->w_head, 8);
+
+	/* Read 8 bytes from stream. Must be identical to data. */
+	for (size_t i = 0; i < s->size; i++)
+		assert_int_equal(read_stream(s), data[i]);
+
+	/* Check, if the read head moved to position 8 */
+	assert_int_equal(s->r_head, 8);
+
+	struct stream *s_cpy = copy_stream(s);
+
+	assert_int_equal(s->size, s_cpy->size);
+	assert_int_equal(s->r_head, s_cpy->r_head);
+	assert_int_equal(s->w_head, s_cpy->w_head);
+
+	// Reset read/write heads.
+	s_cpy->w_head = 0;
+	s_cpy->r_head = 0;
+
+	/* Repeat the read test, this time on the stream copy */
+	for (size_t i = 0; i < s_cpy->size; i++)
+		assert_int_equal(read_stream(s_cpy), data[i]);
+
+	s->w_head = 0; // Reset write heads.
+
+	/* Read 3 bytes from the stream at current read position 2 */
+	s->r_head = 2;
+	uint8_t buffer_a[3] = {'\0'};
+
+	read_n_bytes_stream(buffer_a, s, 3);
+
+	for (int i = 0; i < 3; i++)
+		assert_int_equal(buffer_a[i], data[i + 2]);
+
+	/* Read 6 bytes from the stream starting at position 3.
+	 * If you want to read more bytes from the stream than it holds,
+	 * bytes are only read till the end of the stream.
+	 */
+	uint8_t buffer_b[6] = {'\0'};
+
+	read_stream_at(buffer_b, s, 3, 6);
+
+	for (int i = 0; i < 6; i++)
+		assert_int_equal(buffer_b[i], data[i + 3]);
+
+	s->r_head = 0;
+
+	uint8_t buffer_c[10] = {'\0'};
+
+	buffer_c[8] = 8;
+	buffer_c[9] = 9;
+
+	/* Reading more bytes than are held by the stream should not
+	 * exceed the maximum size of the stream. Thus, the last values of
+	 * buffer_c should not get overwritten.
+	 */
+	read_n_bytes_stream(buffer_c, s, 10);
+
+	assert_int_equal(buffer_c[8], 8);
+	assert_int_equal(buffer_c[9], 9);
+
+	/* Free the stream and its copy */
+	free_stream(s_cpy);
+	free_stream(s);
+}
+
+/* Test the size calculator functions */
+static void test_bgpsec_constructors(void **state)
+{
+	UNUSED(state);
+
+	enum rtr_bgpsec_rtvals retval = RTR_BGPSEC_SUCCESS;
+
+	struct rtr_bgpsec *bgpsec = NULL;
+	struct rtr_secure_path_seg *sec_path = NULL;
+	struct rtr_signature_seg *sig_seg = NULL;
+
+	struct rtr_signature_seg *mal_sig_seg = NULL;
+
+	struct rtr_bgpsec_nlri *pfx = NULL;
+	long pfx_int = 0;
+
+	pfx = rtr_bgpsec_nlri_new(3);
+	pfx->nlri_len = 24;
+	pfx->afi = BGPSEC_IPV4;
+	pfx_int = 3221225984; /* 192.0.2.0 */
+
+	memcpy(pfx->nlri, &pfx_int, 3);
+
+	/* The signature is not valid, but this is not relevant for the
+	 * test. We only check if the information are copied correctly.
+	 */
+	const char *ski = "aaaaaaaaaaaaaaaaaaaa"; // 20 times 'a'
+	uint16_t sig_len = 10;
+	const char *sig = "bbbbbbbbbb"; // 10 times 'b'
+	const char *mal_ski = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+	bgpsec = setup_bgpsec();
+
+	/* Check every single field in bgpsec that contains a numeric value.
+	 * Do the same for the secure path and signature segment.
+	 */
+	assert_int_equal(1, bgpsec->alg);
+	assert_int_equal(1, bgpsec->safi);
+	assert_int_equal(1, bgpsec->afi);
+	assert_int_equal(65537, bgpsec->my_as);
+	assert_int_equal(65538, bgpsec->target_as);
+	assert_int_equal(0, bgpsec->path_len);
+	assert_int_equal(0, bgpsec->sigs_len);
+	assert_int_equal(24, bgpsec->nlri->nlri_len);
+	assert_int_equal(1, bgpsec->nlri->afi);
+	assert(memcmp(pfx->nlri, bgpsec->nlri->nlri, 3) == 0);
+
+	sec_path = setup_sec_seg();
+
+	assert_int_equal(1, sec_path->pcount);
+	assert_int_equal(0, sec_path->flags);
+	assert_int_equal(65537, sec_path->asn);
+
+	rtr_bgpsec_prepend_sec_path_seg(bgpsec, sec_path);
+
+	/* Check, if the path was appeded to the bgpsec struct. If so,
+	 * the information of the first bgpsec path element must be
+	 * identical to the information of sec_path.
+	 */
+	assert_int_equal(1, bgpsec->path_len);
+	assert_int_equal(sec_path->pcount, bgpsec->path->pcount);
+	assert_int_equal(sec_path->flags, bgpsec->path->flags);
+	assert_int_equal(sec_path->asn, bgpsec->path->asn);
+
+	sig_seg = setup_sig_seg();
+
+	assert_int_equal(sig_len, sig_seg->sig_len);
+
+	/* Check, if each byte of ski and signature was copied correctly */
+	for (int i = 0; i < SKI_SIZE; i++)
+		assert_int_equal('a', sig_seg->ski[i]);
+
+	for (int i = 0; i < sig_len; i++)
+		assert_int_equal('b', sig_seg->signature[i]);
+
+	retval = rtr_bgpsec_prepend_sig_seg(bgpsec, sig_seg);
+	assert_int_equal(RTR_BGPSEC_SUCCESS, retval);
+
+	/* Same append check as for the secure path segment, but this time
+	 * for the signature.
+	 */
+	assert_int_equal(1, bgpsec->sigs_len);
+	assert_int_equal(sig_seg->sig_len, bgpsec->sigs->sig_len);
+	for (int i = 0; i < SKI_SIZE; i++)
+		assert_int_equal(ski[i], bgpsec->sigs->ski[i]);
+	for (int i = 0; i < sig_len; i++)
+		assert_int_equal(sig[i], bgpsec->sigs->signature[i]);
+
+	mal_sig_seg = setup_sig_seg();
+	memcpy(mal_sig_seg->ski, mal_ski, SKI_SIZE);
+
+	assert_int_equal(1, ski_is_empty((uint8_t *)mal_ski));
+
+	retval = rtr_bgpsec_prepend_sig_seg(bgpsec, mal_sig_seg);
+	assert_int_equal(RTR_BGPSEC_ERROR, retval);
+
+	/* Append a segment to the last position of the path. */
+	sec_path = setup_sec_seg();
+	sec_path->asn = 12345;
+	rtr_bgpsec_append_sec_path_seg(bgpsec, sec_path);
+	assert_int_equal(2, bgpsec->path_len);
+
+	/* Check, if the element was appended at the last position */
+	assert_int_equal(12345, bgpsec->path->next->asn);
+
+	/* Do the same appending process with a signature segment */
+	sig_seg = setup_sig_seg();
+	sig_seg->sig_len = 42;
+	retval = rtr_bgpsec_append_sig_seg(bgpsec, sig_seg);
+	assert_int_equal(RTR_BGPSEC_SUCCESS, retval);
+
+	assert_int_equal(42, bgpsec->sigs->next->sig_len);
+
+	/* Do the same appending process with an invalid signature segment */
+	retval = rtr_bgpsec_append_sig_seg(bgpsec, mal_sig_seg);
+	assert_int_equal(RTR_BGPSEC_ERROR, retval);
+
+	/* Free the bgpsec struct and all signatures and secure paths */
+	rtr_bgpsec_nlri_free(pfx);
+	rtr_bgpsec_free(bgpsec);
+	rtr_bgpsec_free_signatures(mal_sig_seg);
+}
+
+/* Test size calculator functions */
+static void test_bgpsec_sizes(void **state)
+{
+	UNUSED(state);
+
+	struct rtr_bgpsec *bgpsec = NULL;
+	struct rtr_secure_path_seg *sec_path = NULL;
+	struct rtr_signature_seg *sig_seg = NULL;
+
+	bgpsec = setup_bgpsec();
+
+	/* Generate five secure path and signature segments and append
+	 * them to bgpsec.
+	 */
+	for (int i = 0; i < 5; i++) {
+		sec_path = setup_sec_seg();
+		rtr_bgpsec_prepend_sec_path_seg(bgpsec, sec_path);
+
+		sig_seg = setup_sig_seg();
+		rtr_bgpsec_prepend_sig_seg(bgpsec, sig_seg);
+	}
+
+	/* When calculating the required stream size for validation, the
+	 * last appended signature segment is skipped. The calculation goes:
+	 * five secure path segments +
+	 * four signature segments +
+	 * the size of rest (afi, nlri, ...)
+	 */
+	unsigned int exp_stream_size = (5 * 6) + (4 * 32) + 12;
+	size_t result = req_stream_size(bgpsec, VALIDATION);
+
+	assert_int_equal(exp_stream_size, result);
+
+	/* For singing, the length of all secure path and signature segments
+	 * matters. The calculation goes:
+	 * five secure path segments +
+	 * five signature segments +
+	 * the size of rest (afi, nlri, ...)
+	 */
+	exp_stream_size = (5 * 6) + (5 * 32) + 12;
+	result = req_stream_size(bgpsec, SIGNING);
+	assert_int_equal(exp_stream_size, result);
+
+	/* Calculate the signature size only (validation). Again, the first
+	 * segment is skipped.
+	 */
+	int size = get_sig_seg_size(bgpsec->sigs, VALIDATION);
+
+	assert_int_equal((4 * 32), size);
+
+	/* Calculate the signature size only (signing) */
+	size = get_sig_seg_size(bgpsec->sigs, SIGNING);
+	assert_int_equal((5 * 32), size);
+
+	/* Free the bgpsec struct and all signatures and secure paths */
+	rtr_bgpsec_free(bgpsec);
+}
+
+/* Test size calculator functions */
+static void test_bgpsec_prepend_pop(void **state)
+{
+	UNUSED(state);
+
+	enum rtr_bgpsec_rtvals retval;
+
+	struct rtr_bgpsec *bgpsec = NULL;
+	struct rtr_secure_path_seg *sec_path = NULL;
+	struct rtr_signature_seg *sig_seg = NULL;
+
+	bgpsec = setup_bgpsec();
+	sec_path = setup_sec_seg();
+	sig_seg = setup_sig_seg();
+
+	/* Path length = signature length = 1 */
+	rtr_bgpsec_prepend_sec_path_seg(bgpsec, sec_path);
+	retval = rtr_bgpsec_prepend_sig_seg(bgpsec, sig_seg);
+
+	assert_int_equal(RTR_BGPSEC_SUCCESS, retval);
+	assert_int_equal(1, bgpsec->path_len);
+	assert_int_equal(1, bgpsec->sigs_len);
+
+	sec_path = setup_sec_seg();
+	sig_seg = setup_sig_seg();
+
+	/* Change some values so we can later validate that these
+	 * specific segments were returned.
+	 */
+	sec_path->asn = 12345;
+	sig_seg->sig_len = 80;
+
+	/* Path length = signature length = 2 */
+	rtr_bgpsec_prepend_sec_path_seg(bgpsec, sec_path);
+	retval = rtr_bgpsec_prepend_sig_seg(bgpsec, sig_seg);
+
+	assert_int_equal(RTR_BGPSEC_SUCCESS, retval);
+	assert_int_equal(2, bgpsec->path_len);
+	assert_int_equal(2, bgpsec->sigs_len);
+
+	sec_path = NULL;
+	sig_seg = NULL;
+
+	/* Path length = signature length = 1 */
+	sec_path = rtr_bgpsec_pop_secure_path_seg(bgpsec);
+	sig_seg = rtr_bgpsec_pop_signature_seg(bgpsec);
+
+	assert_int_equal(1, bgpsec->path_len);
+	assert_int_equal(1, bgpsec->sigs_len);
+	assert_int_equal(12345, sec_path->asn);
+	assert_int_equal(80, sig_seg->sig_len);
+	assert(sec_path);
+	assert(sig_seg);
+	assert(!sec_path->next);
+	assert(!sig_seg->next);
+
+	rtr_bgpsec_free_secure_path(sec_path);
+	rtr_bgpsec_free_signatures(sig_seg);
+
+	sec_path = NULL;
+	sig_seg = NULL;
+
+	/* Path length = signature length = 0 */
+	sec_path = rtr_bgpsec_pop_secure_path_seg(bgpsec);
+	sig_seg = rtr_bgpsec_pop_signature_seg(bgpsec);
+
+	assert_int_equal(0, bgpsec->path_len);
+	assert_int_equal(0, bgpsec->sigs_len);
+	assert_int_equal(65537, sec_path->asn);
+	assert_int_equal(10, sig_seg->sig_len);
+	assert(sec_path);
+	assert(sig_seg);
+	assert(!sec_path->next);
+	assert(!sig_seg->next);
+
+	rtr_bgpsec_free_secure_path(sec_path);
+	rtr_bgpsec_free_signatures(sig_seg);
+
+	sec_path = NULL;
+	sig_seg = NULL;
+
+	/* Path length = signature length = 0 */
+	sec_path = rtr_bgpsec_pop_secure_path_seg(bgpsec);
+	sig_seg = rtr_bgpsec_pop_signature_seg(bgpsec);
+	assert(!sec_path);
+	assert(!sig_seg);
+
+	rtr_bgpsec_free(bgpsec);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_bgpsec_streams),
+		cmocka_unit_test(test_bgpsec_constructors),
+		cmocka_unit_test(test_bgpsec_sizes),
+		cmocka_unit_test(test_bgpsec_prepend_pop),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unittests/test_bgpsec_utils.h
+++ b/tests/unittests/test_bgpsec_utils.h
@@ -1,0 +1,20 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#ifndef TEST_BGPSEC_UTILS_H
+#define TEST_BGPSEC_UTILS_H
+
+#include "rtrlib/bgpsec/bgpsec.h"
+
+struct rtr_bgpsec *setup_bgpsec(void);
+
+struct rtr_signature_seg *setup_sig_seg(void);
+
+struct rtr_secure_path_seg *setup_sec_seg(void);
+#endif

--- a/tests/unittests/test_bgpsec_validation.c
+++ b/tests/unittests/test_bgpsec_validation.c
@@ -1,0 +1,248 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include "rtrlib_unittests.h"
+#include "test_bgpsec_validation.h"
+
+#include "rtrlib/bgpsec/bgpsec_private.h"
+#include "rtrlib/bgpsec/bgpsec_utils.c"
+
+#include <assert.h>
+
+struct rtr_bgpsec *setup_bgpsec(void)
+{
+	struct rtr_bgpsec *bgpsec = NULL;
+	uint8_t alg = 1;
+	uint8_t safi = 1;
+	uint16_t afi = 1;
+	uint32_t my_as = 65537;
+	uint32_t target_as = 65538;
+	struct rtr_bgpsec_nlri *pfx = NULL;
+	int pfx_int = 0;
+
+	pfx = rtr_bgpsec_nlri_new(3);
+	pfx->nlri_len = 24;
+	pfx->afi = 1; /* LRTR_IPV4 */
+	pfx_int = htonl(3221225984); /* 192.0.2.0 */
+
+	memcpy(pfx->nlri, &pfx_int, 3);
+
+	bgpsec = rtr_bgpsec_new(alg, safi, afi, my_as, target_as, pfx);
+	bgpsec->path = lrtr_malloc(sizeof(struct rtr_secure_path_seg));
+	bgpsec->sigs = lrtr_malloc(sizeof(struct rtr_signature_seg));
+	bgpsec->path->next = NULL;
+	bgpsec->sigs->next = NULL;
+	bgpsec->sigs->sig_len = 0;
+	return bgpsec;
+}
+
+int __wrap_check_router_keys(const struct rtr_signature_seg *sig_segs, struct spki_table *table)
+{
+	UNUSED(sig_segs);
+	UNUSED(table);
+	return (int)mock();
+}
+
+int __wrap_align_byte_sequence(const struct rtr_bgpsec *data, struct stream *s, enum align_type type)
+{
+	UNUSED(data);
+	UNUSED(s);
+	UNUSED(type);
+	return (int)mock();
+}
+
+unsigned int __wrap_req_stream_size(const struct rtr_bgpsec *data, enum align_type type)
+{
+	UNUSED(data);
+	UNUSED(type);
+	return (int)mock();
+}
+
+int __wrap_hash_byte_sequence(uint8_t *bytes, unsigned int bytes_len, uint8_t alg_suite_id, unsigned char **hash_result)
+{
+	UNUSED(bytes);
+	UNUSED(bytes_len);
+	UNUSED(alg_suite_id);
+	UNUSED(hash_result);
+	return (int)mock();
+}
+
+int __wrap_validate_signature(const unsigned char *hash, const struct rtr_signature_seg *sig,
+			      struct spki_record *record)
+{
+	UNUSED(hash);
+	UNUSED(sig);
+	UNUSED(record);
+	return (int)mock();
+}
+
+int __wrap_spki_table_search_by_ski(struct spki_table *spki_table, uint8_t *ski, struct spki_record **result,
+				    unsigned int *result_size)
+{
+	UNUSED(spki_table);
+	UNUSED(ski);
+	UNUSED(result);
+	*result_size = 1;
+	return (int)mock();
+}
+
+static void test_sanity_checks(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	struct spki_table *table = lrtr_malloc(16);
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	result = rtr_bgpsec_validate_as_path(NULL, table);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, NULL);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	result = rtr_bgpsec_validate_as_path(NULL, NULL);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	bgpsec->path_len = 1;
+	bgpsec->sigs_len = 2;
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, table);
+	assert_int_equal(RTR_BGPSEC_WRONG_SEGMENT_COUNT, result);
+
+	bgpsec->path_len = 0;
+	bgpsec->sigs_len = 0;
+	bgpsec->alg = 3;
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, table);
+	assert_int_equal(RTR_BGPSEC_UNSUPPORTED_ALGORITHM_SUITE, result);
+
+	bgpsec->alg = 1;
+	bgpsec->nlri->afi = 8;
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, table);
+	assert_int_equal(RTR_BGPSEC_UNSUPPORTED_AFI, result);
+
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+
+	bgpsec->path = NULL;
+	bgpsec->sigs = NULL;
+
+	result = rtr_bgpsec_validate_as_path(bgpsec, table);
+	assert_int_equal(RTR_BGPSEC_INVALID_ARGUMENTS, result);
+
+	lrtr_free(table);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+}
+
+static void test_check_router_keys(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	struct spki_table *table = lrtr_malloc(16);
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	will_return(__wrap_check_router_keys, RTR_BGPSEC_ROUTER_KEY_NOT_FOUND);
+	result = rtr_bgpsec_validate_as_path(bgpsec, table);
+
+	assert_int_equal(RTR_BGPSEC_ROUTER_KEY_NOT_FOUND, result);
+
+	lrtr_free(table);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+}
+
+static void test_align_byte_sequence(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	struct spki_table *table = lrtr_malloc(16);
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	will_return(__wrap_align_byte_sequence, RTR_BGPSEC_ERROR);
+	will_return(__wrap_req_stream_size, 12);
+	will_return(__wrap_check_router_keys, RTR_BGPSEC_SUCCESS);
+	result = rtr_bgpsec_validate_as_path(bgpsec, table);
+
+	assert_int_equal(RTR_BGPSEC_ERROR, result);
+
+	lrtr_free(table);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+}
+
+static void test_hash_byte_sequence(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	struct spki_table *table = lrtr_malloc(16);
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	will_return(__wrap_hash_byte_sequence, RTR_BGPSEC_ERROR);
+	will_return(__wrap_align_byte_sequence, RTR_BGPSEC_SUCCESS);
+	will_return(__wrap_req_stream_size, 12);
+	will_return(__wrap_check_router_keys, RTR_BGPSEC_SUCCESS);
+	result = rtr_bgpsec_validate_as_path(bgpsec, table);
+
+	assert_int_equal(RTR_BGPSEC_ERROR, result);
+
+	lrtr_free(table);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+}
+
+static void test_validate_signature(void **state)
+{
+	struct rtr_bgpsec *bgpsec = setup_bgpsec();
+	struct spki_table *table = lrtr_malloc(16);
+	enum rtr_bgpsec_rtvals result = RTR_BGPSEC_SUCCESS;
+
+	UNUSED(state);
+
+	will_return(__wrap_validate_signature, RTR_BGPSEC_ERROR);
+	will_return(__wrap_spki_table_search_by_ski, SPKI_SUCCESS);
+	will_return(__wrap_hash_byte_sequence, RTR_BGPSEC_SUCCESS);
+	will_return(__wrap_align_byte_sequence, RTR_BGPSEC_SUCCESS);
+	will_return(__wrap_req_stream_size, 12);
+	will_return(__wrap_check_router_keys, RTR_BGPSEC_SUCCESS);
+	result = rtr_bgpsec_validate_as_path(bgpsec, table);
+
+	assert_int_equal(RTR_BGPSEC_ERROR, result);
+
+	lrtr_free(table);
+	lrtr_free(bgpsec->path);
+	lrtr_free(bgpsec->sigs);
+	lrtr_free(bgpsec->nlri->nlri);
+	lrtr_free(bgpsec->nlri);
+	lrtr_free(bgpsec);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_sanity_checks),	    cmocka_unit_test(test_check_router_keys),
+		cmocka_unit_test(test_align_byte_sequence), cmocka_unit_test(test_hash_byte_sequence),
+		cmocka_unit_test(test_validate_signature),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unittests/test_bgpsec_validation.h
+++ b/tests/unittests/test_bgpsec_validation.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#ifndef TEST_BGPSEC_VALIDATION_H
+#define TEST_BGPSEC_VALIDATION_H
+
+#include "rtrlib/bgpsec/bgpsec_utils_private.h"
+
+#include <stdint.h>
+
+struct rtr_bgpsec *setup_bgpsec(void);
+
+int __wrap_check_router_keys(const struct rtr_signature_seg *sig_segs, struct spki_table *table);
+
+int __wrap_align_byte_sequence(const struct rtr_bgpsec *data, struct stream *s, enum align_type type);
+
+unsigned int __wrap_req_stream_size(const struct rtr_bgpsec *data, enum align_type type);
+
+int __wrap_hash_byte_sequence(uint8_t *bytes, unsigned int bytes_len, uint8_t alg_suite_id,
+			      unsigned char **hash_result);
+
+int __wrap_validate_signature(const unsigned char *hash, const struct rtr_signature_seg *sig,
+			      struct spki_record *record);
+
+int __wrap_spki_table_search_by_ski(struct spki_table *spki_table, uint8_t *ski, struct spki_record **result,
+				    unsigned int *result_size);
+#endif


### PR DESCRIPTION
<!--
The RTRlib community cares about code quality. Therefore, before
describing what your contribution is about, we would like you to make sure
that your modifications are compliant with the RTRlib coding conventions, see
https://github.com/rtrlib/rtrlib/blob/master/CONTRIBUTING.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RTRlib is (are) involved
- if this is a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR offers BGPsec validation and signing routines. It extends the current API with functions for
* validating a BGPsec path
* generating a signature for a BGPsec path
* getter functions for BGPsec version and algorithm suites.

The implementation relies on OpenSSL and is compatible with version 1.0 and 1.1. BGPsec functionality is optional. RTRlib can still be build without it. BGPsec features are enabled by default, so no further arguments must be passed to `cmake`. There are however options to disable BGPsec, see the README for more information on this. When building in `Debug` mode, RTRlib will output more information on validation procedures.

```bash
cmake -D CMAKE_BUILD_TYPE=Debug
```

The usage of the API is similar to that of prefix validation. First, RTRlib structures have to be filled with the necessary path information. These structures are then passed to the validation/signing function. The validation function will either return valid/not valid or an appropriate error code. The signing function will generate a signature and its length, or again an error code.

This code has been reviewed by @mroethke, @smlng and @reuteran so far. I am open to more review and suggestions.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile and is there a 'test' command
- how to know that it was not working/available in master
- the expected success of the test output
-->
When RTRlib is compiled with BGPsec support, simply run

```bash
make test
```

to run all tests, including `test_bgpsec`. To view the results of every validation, run the test manually. This implies that RTRlib was build in `Debug` mode. Otherwise, there is not much to see.

### Issues/PRs references

<!--
Examples: Fixes #212. See also #196. Depends on PR #188.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved. This way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

