### PR TITLE
Github templates: fix inconsistent layout of captions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,31 +4,31 @@ about: Create a report to help us improve
 
 ---
 
-#### Description
+### Description
 <!--
 Example: Uninitialized use of stack variables in rtr_sync_receive_and_store_pdus.
 -->
 
-#### Steps to reproduce the issue
+### Steps to reproduce the issue
 <!--
 Try to describe as precisely as possible the steps required to reproduce
 the issue. Here, you can also describe your RTRlib configuration (e.g., to
 which cache server you connect).
 -->
 
-#### Expected results
+### Expected results
 <!--
 Example: The variables `pfx_shadow_table` and `spki_shadow_table` in
 `packets.c:rtr_sync_receive_and_store_pdus` should be initialized at least
 with `NULL`.
 -->
 
-#### Actual results
+### Actual results
 <!--
 Please paste or specifically describe the actual output and implications.
 -->
 
-#### Versions
+### Versions
 <!--
 Operating system: Mac OSX, Linux
 Build environment: GCC

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -4,10 +4,10 @@ about: Ask for the enhancement of an existing feature.
 
 ---
 
-#### Description of current state
+### Description of current state
 <!-- Please describe the current state and why it is important to enhance. -->
 
-#### Improvement
+### Improvement
 <!-- Please describe the enhancement. -->
 
 ### Useful links

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Ask for missing features.
 
 ---
 
-#### Description
+### Description
 <!-- Please describe your use case, why you need this feature, and why this
 feature is important for RTRlib. -->
 


### PR DESCRIPTION
### Contribution description

Captions are formatted differently (### vs. ####). This PR formats all captions as third level captions.