### PR TITLE
Update compiler args in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,22 @@ cmake_minimum_required(VERSION 2.6)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=gnu99 -fstack-protector-all")
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra -Wformat-security -Wmissing-prototypes -Wmissing-declarations -Wdeclaration-after-statement -Winit-self -Waggregate-return -Wmissing-format-attribute -Wundef -Wbad-function-cast -Wwrite-strings -Wformat=2")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra -Wformat-security -Winit-self -Wundef -Wwrite-strings")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat=2 -Werror=missing-prototypes -Werror=missing-declarations")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-format-attribute -Werror=implicit-function-declaration")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=bad-function-cast -Werror=return-type")
+
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
     if(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wfree-nonheap-object")
+    endif()
+
+    if(GCC_VERSION VERSION_GREATER 5.1 OR GCC_VERSION VERSION_EQUAL 5.1)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=incompatible-pointer-types")
+    endif()
+
+    if(GCC_VERSION VERSION_GREATER 8.0 OR GCC_VERSION VERSION_EQUAL 8.0)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=cast-function-type")
     endif()
 
     set(DOCS_EXCLUDE_PATTERN "")

--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <arpa/inet.h>
+#include <unistd.h>
 #include "rtrlib/rtrlib.h"
 
 int main(){
@@ -56,7 +57,7 @@ int main(){
 
     //initialize all rtr_sockets in the server pool with the same settings
     struct rtr_mgr_config *conf;
-    int ret = rtr_mgr_init(&conf, groups, 2, 30, 600, 600, NULL, NULL, NULL, NULL);
+    rtr_mgr_init(&conf, groups, 2, 30, 600, 600, NULL, NULL, NULL, NULL);
 
     //start the connection manager
     rtr_mgr_start(conf);

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -1010,7 +1010,7 @@ void recv_loop_cleanup(void *p) {
 
 
 /* WARNING: This Function has cancelable sections*/
-int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
+static int rtr_sync_receive_and_store_pdus(struct rtr_socket *rtr_socket){
     char pdu[RTR_MAX_PDU_LEN];
     enum pdu_type type;
     int retval = RTR_SUCCESS;

--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -22,7 +22,7 @@
 #include "rtrlib/transport/transport_private.h"
 
 static void rtr_purge_outdated_records(struct rtr_socket *rtr_socket);
-static void rtr_fsm_start(struct rtr_socket *rtr_socket);
+static void *rtr_fsm_start(struct rtr_socket *rtr_socket);
 
 static const char *socket_str_states[] = {
     [RTR_CONNECTING] = "RTR_CONNECTING",
@@ -111,10 +111,10 @@ void rtr_purge_outdated_records(struct rtr_socket *rtr_socket)
 }
 
 /* WARNING: This Function has cancelable sections*/
-void rtr_fsm_start(struct rtr_socket *rtr_socket)
-{ 
+void *rtr_fsm_start(struct rtr_socket *rtr_socket)
+{
    if (rtr_socket->state == RTR_SHUTDOWN)
-	return;
+	return NULL;
 
     // We don't care about the old state, but POSIX demands a non null value for setcancelstate
     int oldcancelstate;

--- a/tests/test_ht_spkitable.c
+++ b/tests/test_ht_spkitable.c
@@ -542,7 +542,7 @@ static void test_ht_7(void)
 	printf("test_ht_7() complete\n");
 }
 
-void test_table_swap(void)
+static void test_table_swap(void)
 {
 	struct spki_table table1;
 	struct spki_table table2;
@@ -646,7 +646,7 @@ static void update_spki(struct spki_table *s __attribute__((unused)),
 		assert(added);
 }
 
-void test_table_diff(void)
+static void test_table_diff(void)
 {
 	struct spki_table table1;
 	struct spki_table table2;

--- a/tests/test_ht_spkitable_locks.c
+++ b/tests/test_ht_spkitable_locks.c
@@ -79,7 +79,7 @@ static struct spki_record *create_record(int ASN,
  * Add 'args->count' records to the spki table 'args->table', start with
  * ASN 'args->start_asn'.
  */
-static void add_records(struct add_records_args *args)
+static void *add_records(struct add_records_args *args)
 {
 	printf("Add %i records: ASN [%i..%i]\n",
 	       args->count, args->start_asn, args->count + args->start_asn - 1);
@@ -90,13 +90,15 @@ static void add_records(struct add_records_args *args)
 		assert(ret == SPKI_SUCCESS);
 		free(record);
 	}
+
+	return NULL;
 }
 
 /**
  * @brief remove records from spki table
  * Remove 'args->count' records from the spki table 'args->table'.
  */
-static void remove_records(struct remove_records_args *args)
+static void *remove_records(struct remove_records_args *args)
 {
 	printf("Remove %i records: ASN [%i..%i]\n",
 	       args->count, args->start_asn, args->count + args->start_asn - 1);
@@ -107,6 +109,8 @@ static void remove_records(struct remove_records_args *args)
 		assert(ret == SPKI_SUCCESS);
 		free(record);
 	}
+
+	return NULL;
 }
 
 /**

--- a/tests/test_ipaddr.c
+++ b/tests/test_ipaddr.c
@@ -224,7 +224,7 @@ static void test_v6(void)
 /*
  * @brief test ip comparsions
  */
-void test_cmp(void)
+static void test_cmp(void)
 {
 	struct lrtr_ip_addr addr1, addr2;
 

--- a/tests/test_pfx_locks.c
+++ b/tests/test_pfx_locks.c
@@ -26,7 +26,7 @@ uint32_t max_i = 0xFFFFFFF0;
 /**
  * @brief Add records to prefix table
  */
-static void rec_add(struct pfx_table *pfxt)
+static void *rec_add(struct pfx_table *pfxt)
 {
 	const int tid = getpid();
 	struct pfx_record rec;
@@ -56,12 +56,14 @@ static void rec_add(struct pfx_table *pfxt)
 		pfx_table_add(pfxt, &rec);
 		usleep(rand() / (RAND_MAX / 20));
 	}
+
+	return NULL;
 }
 
 /**
  * @brief Validate records in prefix table
  */
-static void rec_val(struct pfx_table *pfxt)
+static void *rec_val(struct pfx_table *pfxt)
 {
 	const int tid = getpid();
 	struct pfx_record rec;
@@ -92,12 +94,14 @@ static void rec_val(struct pfx_table *pfxt)
 				   &rec.prefix, rec.min_len, &res);
 		usleep(rand() / (RAND_MAX / 20));
 	}
+
+	return NULL;
 }
 
 /**
  * @brief Delete records from prefix table
  */
-static void rec_del(struct pfx_table *pfxt)
+static void *rec_del(struct pfx_table *pfxt)
 {
 	const int tid = getpid();
 	struct pfx_record rec;
@@ -128,6 +132,8 @@ static void rec_del(struct pfx_table *pfxt)
 		usleep(rand() / (RAND_MAX / 20));
 	}
 	printf("Done\n");
+
+	return NULL;
 }
 
 /**

--- a/tools/rpki-rov.c
+++ b/tools/rpki-rov.c
@@ -25,7 +25,7 @@ static void connection_status_callback(const struct rtr_mgr_group *group,
 		connection_status = status;
 }
 
-int connection_error(enum rtr_mgr_status status)
+static int connection_error(enum rtr_mgr_status status)
 {
 	if (status == RTR_MGR_ERROR) {
 	/*


### PR DESCRIPTION
### Contribution description

Disable two compiler warnings that nobody cares for and produced
quite a lot of output (-Wdeclaration-after-statement,
-Waggregate-return) and makes some warnings explicit errors.

It furthermore fixes issues causing errors with the new arguments.

### Issues/PRs references
Fix #205

