### PR TITLE
scripts/check-exports: replace custom regex c parser with ctags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: c
 
 before_install:
     - sudo apt-get -qq update
-    - sudo apt-get -y install cppcheck doxygen libssh-dev
+    - sudo apt-get -y install cppcheck doxygen libssh-dev ctags
 
 install:
     - wget https://cmocka.org/files/1.1/cmocka-1.1.0.tar.xz

--- a/scripts/check-exports.sh
+++ b/scripts/check-exports.sh
@@ -11,15 +11,14 @@ ERROR=0
 
 # Functions annoted with RTRLIB_EXPORT
 EXPORTS=$(
-    grep -r '^RTRLIB_EXPORT' rtrlib |
-    grep -Po '(?<= ).*?(?=\(.*?)' | grep -o  '\w*$' | # extract function name
+    ctags -x --c-kinds=fp $(find rtrlib -iname '*.c' ! -name '*tommy*') |
+    grep  'RTRLIB_EXPORT' | awk '{ print $1 }' |
     sort)
 
 # Functions found in public headers
 HEADER_SYMBOLS=$(
-    cat $(find rtrlib -iname '*.h' -type f ! -name '*_private.h' ! -name '*tommy*') | # cat all public headers
-    gcc -o - -xc -fpreprocessed  -dD -E -P  - | # strip comments via gcc
-    grep -Po '(?<= ).*?(?=\(.*?)' | grep -o '\w*$' | # extract function name
+    ctags -x --c-kinds=fp  $(find rtrlib -iname '*.h' -type f ! -name '*_private.h' ! -name '*tommy*') |
+    awk '{ print $1 }' |
     sort)
 
 # Symbols found in librtrs dynamic export table


### PR DESCRIPTION
### Contribution description

This replaces the custom regex based c parser with ctags, this approach should be much more robust. 
