### PR TITLE
tests: add missing prototype

### DIFF
--- a/tests/unittests/test_packets_static.h
+++ b/tests/unittests/test_packets_static.h
@@ -8,3 +8,7 @@
  */
 
 int __wrap_lrtr_get_monotonic_time(time_t *seconds);
+
+int __wrap_tr_send_all(const struct tr_socket *socket,
+	       const void *pdu, const size_t len,
+	       const time_t timeout);


### PR DESCRIPTION
### Contribution description
Due to making missing-prototype a error compilation of the test fails
with newer gcc versions

