### PR TITLE
Improve handling of error pdus

### DIFF
--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -730,11 +730,8 @@ static int rtr_handle_error_pdu(struct rtr_socket *rtr_socket, const void *buf)
         if ((sizeof(pdu->ver) + sizeof(pdu->type) + sizeof(pdu->error_code) + sizeof(pdu->len) + sizeof(pdu->len_enc_pdu) + pdu->len_enc_pdu + 4 + len_err_txt) != pdu->len)
             RTR_DBG1("error: Length of error text contains an incorrect value");
         else {
-            //assure that the error text contains an terminating \0 char
-            char txt[len_err_txt + 1];
-            char *pdu_txt = (char *) pdu->rest + pdu->len_enc_pdu + 4;
-            snprintf(txt, len_err_txt + 1, "%s", pdu_txt);
-            RTR_DBG("Error PDU included the following error msg: \'%s\'", txt);
+            char *pdu_txt = (char *) pdu->rest + pdu->len_enc_pdu + sizeof(len_err_txt);
+            RTR_DBG("Error PDU included the following error msg: \'%.*s\'", len_err_txt, pdu_txt);
         }
     }
 

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -495,10 +495,6 @@ static bool rtr_pdu_check_size (const struct pdu_header *pdu) {
       break;
     }
 
-    if ((err_msg_len > 0) && (((uint8_t*)err_pdu)[min_size-1] != 0)) {
-        RTR_DBG1("Error msg is not null terminated!");
-        break;
-    }
     retval = true;
     break;
   case SERIAL_QUERY:

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -725,7 +725,7 @@ static int rtr_handle_error_pdu(struct rtr_socket *rtr_socket, const void *buf)
         break;
     }
 
-    const uint32_t len_err_txt = ntohl(*((uint32_t *) (pdu->rest + pdu->len_enc_pdu)));
+    const uint32_t len_err_txt = *((uint32_t *) (pdu->rest + pdu->len_enc_pdu));
     if (len_err_txt > 0) {
         if ((sizeof(pdu->ver) + sizeof(pdu->type) + sizeof(pdu->error_code) + sizeof(pdu->len) + sizeof(pdu->len_enc_pdu) + pdu->len_enc_pdu + 4 + len_err_txt) != pdu->len)
             RTR_DBG1("error: Length of error text contains an incorrect value");

--- a/tests/unittests/test_packets_static.c
+++ b/tests/unittests/test_packets_static.c
@@ -271,12 +271,6 @@ static void test_rtr_pdu_check_size(void **state)
 	error->len = 24;
 	error->rest[11] = 0xA;
 	assert_false(rtr_pdu_check_size((struct pdu_header *)error));
-
-	/* test error pdu error string termination */
-	error->len = 25;
-	error->rest[11] = 0x1;
-	error->rest[12] = 0x20;
-	assert_false(rtr_pdu_check_size((struct pdu_header *)error));
 }
 
 static void test_rtr_send_error_pdu(void **state)


### PR DESCRIPTION
<!--
The RTRlib community cares about code quality. Therefore, before
describing what your contribution is about, we would like you to make sure
that your modifications are compliant with the RTRlib coding conventions, see
https://github.com/rtrlib/rtrlib/blob/master/CONTRIBUTING.
-->

### Contribution description
This PR improves handling of error pdus in several ways.

- Remove null termination check for the diagnostic error message, the RFC does not demand it and it does not make sense to demand it anyway. ( Fix #234 )
- Print diagnostic message without copying it onto the stack. This fixes a potential security vulnerability in case the maximal pdu length is ever raised.
- Remove duplicated byte order conversion 

### Issues/PRs references

Fix #234 
<!--
Examples: Fixes #212. See also #196. Depends on PR #188.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved. This way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

