### PR TITLE
tests: change cache server

### DIFF
--- a/tests/test_dynamic_groups.c
+++ b/tests/test_dynamic_groups.c
@@ -24,7 +24,7 @@ int main(void)
 	int retval = 0;
 	struct tr_socket tr_tcp;
 	char tcp_host[] = "rpki-validator.realmv6.org";
-	char tcp_port[] = "8282";
+	char tcp_port[] = "8283";
 
 	struct tr_tcp_config tcp_config = {
 	tcp_host, //IP

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -14,7 +14,7 @@
 #include "rtrlib/rtrlib.h"
 
 #define RPKI_CACHE_HOST "rpki-validator.realmv6.org"
-#define RPKI_CACHE_POST "8282"
+#define RPKI_CACHE_POST "8283"
 
 struct test_validity_query {
 	char *pfx;


### PR DESCRIPTION
This changes the cache server used by some tests. Because the old one
has been quite unstable in the recent past.

