### PR TITLE
scripts/travis: fix syntax error

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -25,7 +25,7 @@ function checkpatch {
 	git diff $TRAVIS_BRANCH '*.[ch]' > /tmp/patch
 	run_command scripts/checkpatch.pl --ignore FILE_PATH_CHANGES,PREFER_KERNEL_TYPES,CONST_STRUCT,OPEN_BRACE,SPDX_LICENSE_TAG,OPEN_ENDED_LINE,UNNECESSARY_PARENTHESES --terse --no-tree --strict --show-types /tmp/patch
 	ret=$?
-	if [ $ret != 0]; then
+	if [ $ret != 0 ]; then
 		cat -n /tmp/patch
 	fi
 }


### PR DESCRIPTION
### Contribution description
The patch to master should be displayed for PR runs on travis if the style checker found issues. This does not work right now because of a syntax error.
