### PR TITLE
rtrlib/rtr: Fix cancellation while waiting for retry interval

### DIFF
--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -202,7 +202,9 @@ void *rtr_fsm_start(struct rtr_socket *rtr_socket)
             tr_close(rtr_socket->tr_socket);
             rtr_change_socket_state(rtr_socket, RTR_CONNECTING);
             RTR_DBG("Waiting %u", rtr_socket->retry_interval);
+            pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &oldcancelstate);
             sleep(rtr_socket->retry_interval);
+            pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldcancelstate);
         }
 
         else if(rtr_socket->state == RTR_ERROR_FATAL) {
@@ -210,7 +212,9 @@ void *rtr_fsm_start(struct rtr_socket *rtr_socket)
             tr_close(rtr_socket->tr_socket);
             rtr_change_socket_state(rtr_socket, RTR_CONNECTING);
             RTR_DBG("Waiting %u", rtr_socket->retry_interval);
+            pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &oldcancelstate);
             sleep(rtr_socket->retry_interval);
+            pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldcancelstate);
         }
 
         else if(rtr_socket->state == RTR_SHUTDOWN) {


### PR DESCRIPTION
### Contribution description
Since the sleep calls are not cancellable sections, it would take up to
$retry_interval seconds until an rtr_socket experiencing problems (a
socket waiting for the retry interval to expire) would terminate.

