### PR TITLE
tools: generate template.h in build folder

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -32,5 +32,6 @@ endforeach()
 
 string(STRIP ${TEMPLATES} TEMPLATES)
 
-CONFIGURE_FILE("templates.h.cmake" "${CMAKE_CURRENT_SOURCE_DIR}/templates.h")
+CONFIGURE_FILE(templates.h.cmake templates.h)
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION


<!--
The RTRlib community cares about code quality. Therefore, before
describing what your contribution is about, we would like you to make sure
that your modifications are compliant with the RTRlib coding conventions, see
https://github.com/rtrlib/rtrlib/blob/master/CONTRIBUTING.
-->

### Contribution description

The template.h is generated when building the rtr tools.
The resulting file is now create in the build and not the
source directory. This avoids that template.h shows up in
`git status` and also that someone might commit the file
in to the repo by accident.


### Testing procedure

Build rtrlib on master:

```
mkdir build
cd build
cmake ../
```

Then run `git status` which will show a new file `tools/template.h` that was
created.

Now do the same with this PR and you'll that this file is not created in `tools/` anymore, 
but in `build/tools/`.


### Issues/PRs references

<!--
Examples: Fixes #212. See also #196. Depends on PR #188.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved. This way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

