### PR TITLE
*: fix warnings of compilation with gcc 5.4

### DIFF
--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -173,10 +173,10 @@ int tr_ssh_recv_async(const struct tr_ssh_socket *tr_ssh_sock, void *buf, const 
 	return rtval;
 }
 
-int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const time_t timeout)
+int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len,
+		const time_t timeout __attribute__((unused)))
 {
 	ssh_channel rchans[2] = {((struct tr_ssh_socket *)tr_ssh_sock)->channel, NULL};
-
 	struct timeval timev = {1, 0};
 
 	if (ssh_channel_select(rchans, NULL, NULL, &timev) == SSH_EINTR)

--- a/tests/test_dynamic_groups.c
+++ b/tests/test_dynamic_groups.c
@@ -11,8 +11,10 @@
 const int connection_timeout = 20;
 enum rtr_mgr_status connection_status = -1;
 
-static void connection_status_callback(const struct rtr_mgr_group *group, enum rtr_mgr_status status,
-				       const struct rtr_socket *socket, void *data)
+static void connection_status_callback(const struct rtr_mgr_group *group __attribute__((unused)),
+				       enum rtr_mgr_status status,
+				       const struct rtr_socket *socket __attribute__((unused)),
+				       void *data __attribute__((unused)))
 {
 	connection_status = status;
 }

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -14,15 +14,15 @@
 #include <string.h>
 #include <unistd.h>
 
-#define RPKI_CACHE_HOST "rpki-validator.realmv6.org"
-#define RPKI_CACHE_POST "8283"
-
 struct test_validity_query {
-	char *pfx;
+	const char *pfx;
 	int len;
 	int asn;
-	int val;
+	unsigned int val;
 };
+
+static char *RPKI_CACHE_HOST = "rpki-validator.realmv6.org";
+static char *RPKI_CACHE_POST = "8283";
 
 /*
  * Verification is based on ROAs for RIPE RIS Routing Beacons, see:
@@ -40,8 +40,10 @@ const struct test_validity_query queries[] = {{"93.175.146.0", 24, 12654, BGP_PF
 const int connection_timeout = 20;
 enum rtr_mgr_status connection_status = -1;
 
-static void connection_status_callback(const struct rtr_mgr_group *group, enum rtr_mgr_status status,
-				       const struct rtr_socket *socket, void *data)
+static void connection_status_callback(const struct rtr_mgr_group *group __attribute__((unused)),
+				       enum rtr_mgr_status status,
+				       const struct rtr_socket *socket __attribute__((unused)),
+				       void *data __attribute__((unused)))
 {
 	if (status == RTR_MGR_ERROR)
 		connection_status = status;

--- a/tools/rpki-rov.c
+++ b/tools/rpki-rov.c
@@ -19,8 +19,10 @@
 const int connection_timeout = 20;
 enum rtr_mgr_status connection_status = -1;
 
-static void connection_status_callback(const struct rtr_mgr_group *group, enum rtr_mgr_status status,
-				       const struct rtr_socket *socket, void *data)
+static void connection_status_callback(const struct rtr_mgr_group *group __attribute__((unused)),
+				       enum rtr_mgr_status status,
+				       const struct rtr_socket *socket __attribute__((unused)),
+				       void *data __attribute__((unused)))
 {
 	if (status == RTR_MGR_ERROR)
 		connection_status = status;


### PR DESCRIPTION
some warnings are removed by adding some tiny modifications in the code.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
