### PR TITLE
rtrlib: support for vrf 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif(NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
 include(GNUInstallDirs) # for man page install path
 
 set(RTRLIB_SRC rtrlib/rtr_mgr.c rtrlib/lib/utils.c rtrlib/lib/alloc_utils.c rtrlib/lib/convert_byte_order.c
-    rtrlib/lib/ip.c rtrlib/lib/ipv4.c rtrlib/lib/ipv6.c rtrlib/lib/log.c
+    rtrlib/lib/lrtr_vrf.c rtrlib/lib/ip.c rtrlib/lib/ipv4.c rtrlib/lib/ipv6.c rtrlib/lib/log.c
     rtrlib/pfx/trie/trie.c rtrlib/pfx/trie/trie-pfx.c rtrlib/transport/transport.c
     rtrlib/transport/tcp/tcp_transport.c rtrlib/rtr/rtr.c rtrlib/rtr/packets.c
     rtrlib/spki/hashtable/ht-spkitable.c ${tommyds})
@@ -66,6 +66,16 @@ if (NOT DEFINED RTRLIB_TRANSPORT_SSH OR RTRLIB_TRANSPORT_SSH)
         message(WARNING "libssh >= 0.5.0 not found")
     endif(LIBSSH_FOUND)
 endif(NOT DEFINED RTRLIB_TRANSPORT_SSH OR RTRLIB_TRANSPORT_SSH)
+
+if(CAP_FOUND)
+  set(RTRLIB_HAVE_CAPABILITIES)
+  include_directories(${CAP_INCLUDE_DIRS})
+endif(CAP_FOUND)
+
+include (CheckFunctionExists)
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+set(CMAKE_REQUIRED_INCLUDES sched.h)
+check_function_exists(setns RTRLIB_HAVE_NETNS)
 
 #doxygen target
 find_package(Doxygen)

--- a/cmake/modules/FindCAP.cmake
+++ b/cmake/modules/FindCAP.cmake
@@ -1,0 +1,35 @@
+# - Try to find capabilities
+# Find the native CAP includes and library
+#
+#  CAP_FOUND - system has capabilities available
+#  CAP_INCLUDE_DIRS - where to find capabilities.h
+#
+#  Copyright (c) 2019 6WIND
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+if (CAP_INCLUDE_DIRS)
+  # Already in cache, be silent
+  SET(CAP_FIND_QUIETLY TRUE)
+ENDIF (CAP_INCLUDE_DIRS)
+
+find_package(PkgConfig)
+pkg_search_module(CAP libcap)
+
+FIND_PATH(CAP_INCLUDE_DIR sys/capability.h)
+  HINTS ${CAP_LIBDIR}
+)
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(CAP DEFAULT_MSG CAP_INCLUDE_DIR)
+
+IF(CAP_FOUND)
+  SET( CAP_INCLUDE_DIRS ${CAP_INCLUDE_DIR} )
+ELSE(CAP_FOUND)
+  SET( CAP_INCLUDE_DIRS)
+ENDIF(CAP_FOUND)
+
+MARK_AS_ADVANCED( CAP_INCLUDE_DIRS )

--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -20,6 +20,7 @@ int main()
 		ssh_user,
 		ssh_hostkey, //Server hostkey
 		ssh_privkey, //Private key
+		NULL, //Vrfname
 	};
 	tr_ssh_init(&config, &tr_ssh);
 
@@ -31,7 +32,8 @@ int main()
 	struct tr_tcp_config tcp_config = {
 		tcp_host, //IP
 		tcp_port, //Port
-		NULL //Source address
+		NULL, //Source address
+		NULL, //Vrfname
 	};
 	tr_tcp_init(&tcp_config, &tr_tcp);
 

--- a/doxygen/examples/ssh_tr.c
+++ b/doxygen/examples/ssh_tr.c
@@ -11,7 +11,7 @@ int main()
 	char ssh_privkey[] = "/etc/rpki-rtr/client.priv";
 
 	struct tr_ssh_config config = {
-		ssh_host, 22, NULL, ssh_user, ssh_hostkey, ssh_privkey,
+          ssh_host, 22, NULL, ssh_user, ssh_hostkey, ssh_privkey, NULL,
 	};
 
 	tr_ssh_init(&config, &ssh_socket);

--- a/rtrlib/lib/lrtr_vrf.c
+++ b/rtrlib/lib/lrtr_vrf.c
@@ -1,0 +1,217 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * Copyright (c) 2019, 6WIND
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#include "rtrlib/lib/lrtr_vrf.h"
+
+#include "rtrlib/lib/lrtr_vrf_private.h"
+#include "rtrlib/rtrlib_export_private.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifdef RTRLIB_HAVE_CAPABILITIES
+#include <sys/capability.h>
+#endif
+
+#define _GNU_SOURCE
+#include <sched.h>
+
+#define LRTR_VRF_NETNS_DEFAULT_NAME    "/proc/self/ns/net"
+#define LRTR_VRF_NETNS_RUNDIR_NAME    "/var/run/netns/"
+
+#define LRTR_VRF_MODE_NONE 0
+#define LRTR_VRF_MODE_CAPS 1
+#define LRTR_VRF_MODE_UID 2
+
+static int lrtr_vrf_netns_default_fd;
+static int lrtr_vrf_netns_current_fd;
+static int lrtr_vrf_netns_activate;
+static int lrtr_vrf_rights_mode;
+static uid_t lrtr_admin_uid;
+static uid_t lrtr_user_uid;
+#ifdef RTRLIB_HAVE_CAPABILITIES
+static cap_value_t *lrtr_admin_cap;
+static cap_t lrtr_user_cap;
+static int lrtr_admin_num;
+#endif
+
+static void lrtr_vrf_raise_rights(void)
+{
+	if (lrtr_vrf_rights_mode == LRTR_VRF_MODE_NONE)
+		return;
+	if (lrtr_vrf_rights_mode == LRTR_VRF_MODE_UID)
+		seteuid(lrtr_admin_uid);
+#ifdef RTRLIB_HAVE_CAPABILITIES
+	else
+		cap_set_flag(&lrtr_user_cap, CAP_EFFECTIVE,
+			     lrtr_admin_num, lrtr_admin_cap,
+			     CAP_SET);
+#endif
+}
+
+static void lrtr_vrf_lower_rights(void)
+{
+	if (lrtr_vrf_rights_mode == LRTR_VRF_MODE_NONE)
+		return;
+	if (lrtr_vrf_rights_mode == LRTR_VRF_MODE_UID)
+		seteuid(lrtr_user_uid);
+#ifdef RTRLIB_HAVE_CAPABILITIES
+	else
+		cap_set_flag(&lrtr_user_cap, CAP_EFFECTIVE,
+			     lrtr_admin_num, lrtr_admin_cap,
+			     CAP_CLEAR);
+#endif
+}
+
+static char *lrtr_vrf_netns_pathname(const char *netns_name)
+{
+	static char pathname[PATH_MAX];
+	char *result;
+
+	if (netns_name[0] == '/') /* absolute pathname */
+		result = realpath(netns_name, pathname);
+	else {
+		/* relevant pathname */
+		char tmp_name[PATH_MAX];
+
+		snprintf(tmp_name, PATH_MAX, "%s%s",
+			 LRTR_VRF_NETNS_RUNDIR_NAME, netns_name);
+		result = realpath(tmp_name, pathname);
+	}
+
+	if (!result)
+		return NULL;
+	return pathname;
+}
+
+RTRLIB_EXPORT void lrtr_vrf_init_capabilities(void **_cap_admin __attribute__((unused)),
+					      void *_cap_user __attribute__((unused)),
+					      int num __attribute__((unused)),
+					      void *_uid_admin, void *_uid_user,
+					      bool netns_mode)
+{
+#ifdef RTRLIB_HAVE_CAPABILITIES
+	cap_value_t **cap_admin = (cap_value_t **)_cap_admin;
+	cap_t *cap_user = (cap_t *)_cap_user;
+#endif
+	uid_t *uid_admin = (uid_t *)_uid_admin;
+	uid_t *uid_user = (uid_t *)_uid_user;
+
+	if (netns_mode) {
+		lrtr_vrf_netns_default_fd = open(LRTR_VRF_NETNS_DEFAULT_NAME, O_RDONLY);
+		if (lrtr_vrf_netns_default_fd < 0)
+			lrtr_vrf_netns_activate = 0;
+		else
+			lrtr_vrf_netns_activate = 1;
+	}
+
+	if (uid_admin && uid_user) {
+		lrtr_admin_uid = *uid_admin;
+		lrtr_user_uid = *uid_user;
+		lrtr_vrf_rights_mode = LRTR_VRF_MODE_UID;
+#ifdef RTRLIB_HAVE_CAPABILITIES
+	} else if (cap_admin && cap_user) {
+		lrtr_admin_cap = *cap_admin;
+		lrtr_user_cap = *cap_user;
+		lrtr_vrf_rights_mode = LRTR_VRF_MODE_CAPS;
+		lrtr_admin_num = num;
+#endif
+	} else
+		lrtr_vrf_rights_mode = LRTR_VRF_MODE_NONE;
+}
+
+int lrtr_vrf_switch_to(const char *name)
+{
+	int ret, fd;
+	char *path;
+
+	/* ignore errors */
+	if (!lrtr_vrf_netns_activate || !name ||
+	   lrtr_vrf_netns_default_fd == -1)
+		return 0;
+	path = lrtr_vrf_netns_pathname(name);
+	if (!path)
+		return -1;
+	fd = open(path, O_RDONLY);
+	if (fd == -1) {
+		errno = EINVAL;
+		return -1;
+	}
+	lrtr_vrf_raise_rights();
+#ifndef RTRLIB_HAVE_NETNS
+	ret = -1;
+#else
+	ret = setns(fd, CLONE_NEWNET);
+#endif
+	if (ret < 0)
+		return ret;
+	lrtr_vrf_netns_current_fd = fd;
+	close(fd);
+	return ret;
+}
+
+int lrtr_vrf_api_usable(const char *name)
+{
+	char path[255];
+	int fd;
+
+	if (!name)
+		return 1;
+	/* if netns is not enabled, return true */
+	if (!lrtr_vrf_netns_activate)
+		return 1;
+	snprintf(path, sizeof(path), "%s%s",
+		 LRTR_VRF_NETNS_RUNDIR_NAME, name);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	close(fd);
+	return 1;
+}
+
+int lrtr_vrf_switchback(void)
+{
+	int ret = 0;
+
+	if (!lrtr_vrf_netns_activate)
+		return ret;
+	if (lrtr_vrf_netns_current_fd != -1 && lrtr_vrf_netns_default_fd != -1) {
+#ifndef RTRLIB_HAVE_NETNS
+		ret = -1;
+#else
+		ret = setns(lrtr_vrf_netns_default_fd, CLONE_NEWNET);
+#endif
+		lrtr_vrf_netns_current_fd = -1;
+		lrtr_vrf_lower_rights();
+	}
+	return ret;
+}
+
+int lrtr_vrf_bind(int socket, const char *vrfname)
+{
+	int ret = 0;
+
+	if (lrtr_vrf_netns_activate || !vrfname)
+		return ret;
+#ifdef SO_BINDTODEVICE
+	ret = setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, vrfname, strlen(vrfname) + 1);
+#endif /* SO_BINDTODEVICE */
+	return ret;
+}

--- a/rtrlib/lib/lrtr_vrf.h
+++ b/rtrlib/lib/lrtr_vrf.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * Copyright (c) 2019, 6WIND
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+#ifndef LRTR_UTILS_VRF_H
+#define LRTR_UTILS_VRF_H
+
+#include <stdbool.h>
+
+/**
+ * @brief This API sets up the VRF mode to be used, as well as permission rights
+ * if not called, vrf-lite mechanism is chosen
+ * for permission rights, user rights and caps rights are passed as param
+ * if none of the permission rights are given, or if not called, no permission right is chose
+ * @param[cap_admin] caps rights used to raise privileges
+ * @param[cap_user] initial caps rights of user
+ * @param[num] number of caps rights pointed by cap_admin
+ * @param[uid_admin] admin user rights, when caps are not used
+ * @param[uid_user] original user rights, when caps are not used
+ * @param[netns_mode] boolean set to true if vrf netns backend is used
+ * @return none
+ */
+void lrtr_vrf_init_capabilities(void **cap_admin, void *cap_user, int num,
+				void  *uid_admin, void *uid_user,
+				bool netns_mode);
+
+#endif

--- a/rtrlib/lib/lrtr_vrf_private.h
+++ b/rtrlib/lib/lrtr_vrf_private.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * Copyright (c) 2019, 6WIND
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+#ifndef LRTR_UTILS_VRF_PRIVATE_H
+#define LRTR_UTILS_VRF_PRIVATE_H
+
+#include "lrtr_vrf.h"
+
+/**
+ * @brief Tells if the passed vrfname is reachable, or can be ignored
+ * if name is NULL, or vrf support not needed, then return 1
+ * if vrf name can be accessed, then return 1
+ * @param[name] vrf name
+ * @return 1 on successs
+ * @return -1 on error
+ */
+int lrtr_vrf_api_usable(const char *name);
+
+/**
+ * @brief switchback to initial context, this call is needed after operating on vrf
+ * operating on vrf here stands for either create socket ( socket()), or call
+ * specific function calls ( getaddrinfo()).
+ * this call lowers permission rights if needed
+ * @param[name] vrf name
+ * @return >=0 on success
+ * @return -1 on error
+ */
+int lrtr_vrf_switchback(void);
+
+/**
+ * @brief switch from context, this call is needed to operate on vrf
+ * operating on vrf here stands for either create socket ( socket()), or call
+ * specific function calls ( getaddrinfo()).
+ * if name is NULL, or vrf support not needed, then return 0
+ * this call also raises permission rights if needed
+ * @param[name] vrf name
+ * @return >=0 on success
+ * @return -1 on error
+ */
+int lrtr_vrf_switch_to(const char *name);
+
+/**
+ * @brief with vrf-lite, socket must be bound to vrf. bind() is called if needed.
+ * @param[socket] socket created
+ * @param[name] vrf name
+ * @return >=0 on success
+ * @return -1 on error
+ */
+int lrtr_vrf_bind(int socket, const char *vrfname);
+
+#endif

--- a/rtrlib/rtrlib.h.cmake
+++ b/rtrlib/rtrlib.h.cmake
@@ -15,6 +15,8 @@ extern "C" {
 #define RTRLIB_H
 
 #cmakedefine RTRLIB_HAVE_LIBSSH
+#cmakedefine RTRLIB_HAVE_NETNS
+#cmakedefine RTRLIB_HAVE_CAPABILITIES
 #define RTRLIB_VERSION_MAJOR @RTRLIB_VERSION_MAJOR@
 #define RTRLIB_VERSION_MINOR @RTRLIB_VERSION_MINOR@
 #define RTRLIB_VERSION_PATCH @RTRLIB_VERSION_PATCH@
@@ -23,6 +25,7 @@ extern "C" {
 #include "lib/ip.h"
 #include "lib/ipv4.h"
 #include "lib/ipv6.h"
+#include "lib/lrtr_vrf.h"
 #include "pfx/pfx.h"
 #include "rtr/rtr.h"
 #include "rtr_mgr.h"

--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -46,6 +46,7 @@ struct tr_ssh_config {
 	char *username;
 	char *server_hostkey_path;
 	char *client_privkey_path;
+	char *vrfname;
 };
 
 /**

--- a/rtrlib/transport/tcp/tcp_transport.h
+++ b/rtrlib/transport/tcp/tcp_transport.h
@@ -33,6 +33,7 @@ struct tr_tcp_config {
 	char *host;
 	char *port;
 	char *bindaddr;
+	char *vrfname;
 };
 
 /**

--- a/rtrlib/transport/transport.h
+++ b/rtrlib/transport/transport.h
@@ -85,6 +85,12 @@ typedef int (*tr_send_fp)(const void *socket, const void *pdu, const size_t len,
 typedef const char *(*tr_ident_fp)(void *socket);
 
 /**
+ * @brief A function pointer to a technology specific info function.
+ * \sa tr_vrfname
+ */
+typedef const char *(*tr_vrfname_fp)(void *socket);
+
+/**
  * @brief A transport socket datastructure.
  *
  * @param socket A pointer to a technology specific socket.
@@ -102,6 +108,7 @@ struct tr_socket {
 	tr_send_fp send_fp;
 	tr_recv_fp recv_fp;
 	tr_ident_fp ident_fp;
+	tr_vrfname_fp vrfname_fp;
 };
 
 #endif

--- a/rtrlib/transport/transport_private.h
+++ b/rtrlib/transport/transport_private.h
@@ -103,5 +103,13 @@ int tr_recv_all(const struct tr_socket *socket, const void *buf, const size_t le
  */
 const char *tr_ident(struct tr_socket *socket);
 
+/**
+ * Returns the vrfname the socket has been configured for
+ * @param[in] socket
+ * return Pointer to a \0 terminated String
+ * return NULL on error
+ */
+const char *tr_vrfname(struct tr_socket *socket);
+
 #endif
 /** @} */

--- a/tests/test_dynamic_groups.c
+++ b/tests/test_dynamic_groups.c
@@ -28,7 +28,8 @@ int main(void)
 	struct tr_tcp_config tcp_config = {
 		tcp_host, //IP
 		tcp_port, //Port
-		NULL //Source address
+		NULL, //Source address
+		NULL //Vrfname
 	};
 	tr_tcp_init(&tcp_config, &tr_tcp);
 

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -57,7 +57,7 @@ int main(void)
 {
 	/* create a TCP transport socket */
 	struct tr_socket tr_tcp;
-	struct tr_tcp_config tcp_config = {RPKI_CACHE_HOST, RPKI_CACHE_POST, NULL};
+	struct tr_tcp_config tcp_config = {RPKI_CACHE_HOST, RPKI_CACHE_POST, NULL, NULL};
 	struct rtr_socket rtr_tcp;
 	struct rtr_mgr_group groups[1];
 

--- a/tools/rpki-rov.c
+++ b/tools/rpki-rov.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 	}
 
 	struct tr_socket tr_tcp;
-	struct tr_tcp_config tcp_config = {argv[1], argv[2], NULL};
+	struct tr_tcp_config tcp_config = { argv[1], NULL, argv[2], NULL};
 	struct rtr_socket rtr_tcp;
 	struct rtr_mgr_config *conf;
 	struct rtr_mgr_group groups[1];


### PR DESCRIPTION
vrf support helps user to create sessions on some vrfs.
a new lrtr_vrf api is available, and is extended enough to do:
-1 support for vrf with netns backend
-2 support for vrf lite
-3 api to give permission rights to the library

1 is implemented. While vrf is not available, the tcp/ssh connection is
not created. when vrf is created, then tcp/ssh connection will be tried.
retries are rescheduled as if there was a standard network error ( 600
seconds from bgp rpki side).

2 is not yet implemented. that is to say that for vrf-lite, an
additional bind() command should be operated over the vrf interface
name, once the socket created.

3 is implemented with linux capabilities or user capabilities.
when capabilities are not used in a system, the calling system should
have the user rights to change of netns(). in some daemons, it is usual
to start as root, then change the owner of the daemon to have less
privileges. Then, when some operations need some privileges, a quick
change of owner is operated. rtrlib has the vrf init API that is
expanded to provide 2 user ids, one which is the initial userid with all
the supposed rights, and the second which is the daemonized user. Like
that, when rtrlib will want to do some privileged operations to change
netns, then seteuid() will be called appropriately.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
