### PR TITLE
rtrlib: ability to pass configured socket in tcp/ssh attribute

### DIFF
--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -20,6 +20,8 @@ int main()
 		ssh_user,
 		ssh_hostkey, //Server hostkey
 		ssh_privkey, //Private key
+		NULL, // data
+		NULL, // new_socket()
 	};
 	tr_ssh_init(&config, &tr_ssh);
 
@@ -31,7 +33,9 @@ int main()
 	struct tr_tcp_config tcp_config = {
 		tcp_host, //IP
 		tcp_port, //Port
-		NULL //Source address
+		NULL, //Source address
+		NULL, //data
+		NULL, //get_socket()
 	};
 	tr_tcp_init(&tcp_config, &tr_tcp);
 

--- a/doxygen/examples/ssh_tr.c
+++ b/doxygen/examples/ssh_tr.c
@@ -11,7 +11,7 @@ int main()
 	char ssh_privkey[] = "/etc/rpki-rtr/client.priv";
 
 	struct tr_ssh_config config = {
-		ssh_host, 22, NULL, ssh_user, ssh_hostkey, ssh_privkey,
+		ssh_host, 22, NULL, ssh_user, ssh_hostkey, ssh_privkey, NULL, NULL
 	};
 
 	tr_ssh_init(&config, &ssh_socket);

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -74,6 +74,17 @@ int tr_ssh_open(void *socket)
 
 	if (config->client_privkey_path)
 		ssh_options_set(ssh_socket->session, SSH_OPTIONS_IDENTITY, config->client_privkey_path);
+	if (config->new_socket) {
+		int fd;
+
+		fd = config->new_socket(config->data);
+		if (fd >= 0) {
+			ssh_options_set(ssh_socket->session, SSH_OPTIONS_FD, &fd);
+		} else {
+			SSH_DBG1("tr_ssh_init: opening SSH connection failed", ssh_socket);
+			goto error;
+		}
+	}
 
 	if (ssh_connect(ssh_socket->session) == SSH_ERROR) {
 		SSH_DBG1("tr_ssh_init: opening SSH connection failed", ssh_socket);
@@ -249,6 +260,8 @@ RTRLIB_EXPORT int tr_ssh_init(const struct tr_ssh_config *config, struct tr_sock
 		ssh_socket->config.server_hostkey_path = NULL;
 
 	ssh_socket->ident = NULL;
+	ssh_socket->config.data = config->data;
+	ssh_socket->config.new_socket = config->new_socket;
 	;
 
 	return TR_SUCCESS;

--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -38,6 +38,13 @@
  * don't verify host authenticity.
  * @param client_privkey_path Path to private key of the authentication keypair
  *                            or NULL to use ~/.ssh/id_rsa.
+ * @param data Information to pass to callback function
+ *	  in charge of retrieving socket
+ * @param new_socket(void *opaque_info) callback routine, that
+ *	  Pointer to the function that is called every time a new connection
+ *	  is made. The returned socket is expected to be ready for use (e.g.
+ *	  in state established), and must use a reliably stream-oriented transport.
+ *	  When new_socket() is used, host, port, and bindaddr are not used.
  */
 struct tr_ssh_config {
 	char *host;
@@ -46,6 +53,8 @@ struct tr_ssh_config {
 	char *username;
 	char *server_hostkey_path;
 	char *client_privkey_path;
+	void *data;
+	int (*new_socket)(void *data);
 };
 
 /**

--- a/rtrlib/transport/tcp/tcp_transport.h
+++ b/rtrlib/transport/tcp/tcp_transport.h
@@ -28,11 +28,20 @@
  * @param bindaddr Hostname or IP address to connect from. NULL for
  *		   determination by OS.
  * to use the source address of the system's default route to the server
+ * @param data Information to pass to callback function
+ *	  in charge of retrieving socket
+ * @param new_socket(void *opaque_info) callback routine, that
+ *	  Pointer to the function that is called every time a new connection
+ *	  is made. The returned socket is expected to be ready for use (e.g.
+ *	  in state established), and must use a reliably stream-oriented transport.
+ *	  When new_socket() is used, host, port, and bindaddr are not used.
  */
 struct tr_tcp_config {
 	char *host;
 	char *port;
 	char *bindaddr;
+	void *data;
+	int (*new_socket)(void *data);
 };
 
 /**

--- a/tests/test_dynamic_groups.c
+++ b/tests/test_dynamic_groups.c
@@ -30,7 +30,9 @@ int main(void)
 	struct tr_tcp_config tcp_config = {
 		tcp_host, //IP
 		tcp_port, //Port
-		NULL //Source address
+		NULL, //Source address
+		NULL, //data
+		NULL, //new_socket()
 	};
 	tr_tcp_init(&tcp_config, &tr_tcp);
 

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -59,7 +59,7 @@ int main(void)
 {
 	/* create a TCP transport socket */
 	struct tr_socket tr_tcp;
-	struct tr_tcp_config tcp_config = {RPKI_CACHE_HOST, RPKI_CACHE_POST, NULL};
+	struct tr_tcp_config tcp_config = {RPKI_CACHE_HOST, RPKI_CACHE_POST, NULL, NULL, NULL};
 	struct rtr_socket rtr_tcp;
 	struct rtr_mgr_group groups[1];
 

--- a/tools/rpki-rov.c
+++ b/tools/rpki-rov.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 	}
 
 	struct tr_socket tr_tcp;
-	struct tr_tcp_config tcp_config = {argv[1], argv[2], NULL};
+	struct tr_tcp_config tcp_config = {argv[1], argv[2], NULL, NULL, NULL};
 	struct rtr_socket rtr_tcp;
 	struct rtr_mgr_config *conf;
 	struct rtr_mgr_group groups[1];

--- a/tools/rtrclient.c
+++ b/tools/rtrclient.c
@@ -755,9 +755,9 @@ static void init_sockets(void)
 {
 	for (size_t i = 0; i < socket_count; ++i) {
 		struct socket_config *config = socket_config[i];
-		struct tr_tcp_config tcp_config;
+		struct tr_tcp_config tcp_config = {};
 #ifdef RTRLIB_HAVE_LIBSSH
-		struct tr_ssh_config ssh_config;
+		struct tr_ssh_config ssh_config = {};
 #endif
 
 		switch (config->type) {


### PR DESCRIPTION
a new attribute socket is given in tr_ssh_config and tr_tcp_config
structures. as the structures are visible for configuration by the
caller, it becomes possible to create early the socket that will be
used later by rtrlib. some scenarios like vrf usage can be possible.
for instance, the socket is first created in the appropriate vrf, then
submitted to rtrlib that uses it to connect to the target.
Also, tr_ident_fp is modified so as to return the configured socket
ctxt. this is helpful to retrieve the context.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
