### PR TITLE
redhat: Add new changelog entry to fix rpmlint changelog error

### DIFF
--- a/redhat/SPECS/librtr.spec
+++ b/redhat/SPECS/librtr.spec
@@ -111,5 +111,8 @@ export LD_LIBRARY_PATH=.; make test
 %doc LICENSE
 
 %changelog
-* Thu Dec 14 2017 Martin Winter <mwinter@opensourcerouting.org> - %{version}-%{release}
+* Sun Mar 15 2020 Martin Winter <mwinter@opensourcerouting.org> - %{version}-%{release}
+- Update RPM spec changelog to fix changelog error
+
+* Thu Dec 14 2017 Martin Winter <mwinter@opensourcerouting.org> - 0.5.0
 - RPM Packaging added


### PR DESCRIPTION
Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>

### Contribution description

This is a silly fix for the rpmlint error as seen on newer Fedora Versions.
It fixes the `no-changelogname-tag` error which happens if there is new 
recent changelog entry
