### PR TITLE
SSH fixes

### DIFF
--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -23,6 +23,7 @@ int main()
 		NULL, // data
 		NULL, // new_socket()
 		0, // connect timeout
+		NULL, // password
 	};
 	tr_ssh_init(&config, &tr_ssh);
 

--- a/doxygen/examples/ssh_tr.c
+++ b/doxygen/examples/ssh_tr.c
@@ -11,7 +11,7 @@ int main()
 	char ssh_privkey[] = "/etc/rpki-rtr/client.priv";
 
 	struct tr_ssh_config config = {
-		ssh_host, 22, NULL, ssh_user, ssh_hostkey, ssh_privkey, NULL, NULL, 0,
+		ssh_host, 22, NULL, ssh_user, ssh_hostkey, ssh_privkey, NULL, NULL, 0, NULL
 	};
 
 	tr_ssh_init(&config, &ssh_socket);

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -299,6 +299,9 @@ RTRLIB_EXPORT int tr_ssh_init(const struct tr_ssh_config *config, struct tr_sock
 	ssh_socket->config.port = config->port;
 	ssh_socket->config.username = lrtr_strdup(config->username);
 
+	if ((config->password && config->client_privkey_path) || (!config->password && !config->client_privkey_path))
+		return TR_ERROR;
+
 	if (config->bindaddr)
 		ssh_socket->config.bindaddr = lrtr_strdup(config->bindaddr);
 	else

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -330,7 +330,6 @@ RTRLIB_EXPORT int tr_ssh_init(const struct tr_ssh_config *config, struct tr_sock
 	ssh_socket->ident = NULL;
 	ssh_socket->config.data = config->data;
 	ssh_socket->config.new_socket = config->new_socket;
-	;
 
 	return TR_SUCCESS;
 }

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -256,7 +256,7 @@ int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const 
 		return TR_ERROR;
 
 	if (ssh_channel_is_eof(((struct tr_ssh_socket *)tr_ssh_sock)->channel) != 0)
-		return SSH_ERROR;
+		return TR_ERROR;
 
 	if (!rchans[0])
 		return TR_WOULDBLOCK;
@@ -267,7 +267,12 @@ int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const 
 int tr_ssh_send(const void *tr_ssh_sock, const void *pdu, const size_t len,
 		const time_t timeout __attribute__((unused)))
 {
-	return ssh_channel_write(((struct tr_ssh_socket *)tr_ssh_sock)->channel, pdu, len);
+	int ret = ssh_channel_write(((struct tr_ssh_socket *)tr_ssh_sock)->channel, pdu, len);
+
+	if (ret == SSH_ERROR)
+		return TR_ERROR;
+
+	return ret;
 }
 
 const char *tr_ssh_ident(void *tr_ssh_sock)

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -243,11 +243,10 @@ int tr_ssh_recv_async(const struct tr_ssh_socket *tr_ssh_sock, void *buf, const 
 	return rtval;
 }
 
-int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len,
-		const time_t timeout __attribute__((unused)))
+int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const time_t timeout)
 {
 	ssh_channel rchans[2] = {((struct tr_ssh_socket *)tr_ssh_sock)->channel, NULL};
-	struct timeval timev = {1, 0};
+	struct timeval timev = {timeout, 0};
 
 	if (ssh_channel_select(rchans, NULL, NULL, &timev) == SSH_EINTR)
 		return TR_INTR;

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -247,9 +247,13 @@ int tr_ssh_recv(const void *tr_ssh_sock, void *buf, const size_t buf_len, const 
 {
 	ssh_channel rchans[2] = {((struct tr_ssh_socket *)tr_ssh_sock)->channel, NULL};
 	struct timeval timev = {timeout, 0};
+	int ret;
 
-	if (ssh_channel_select(rchans, NULL, NULL, &timev) == SSH_EINTR)
+	ret = ssh_channel_select(rchans, NULL, NULL, &timev);
+	if (ret == SSH_EINTR)
 		return TR_INTR;
+	else if (ret == SSH_ERROR)
+		return TR_ERROR;
 
 	if (ssh_channel_is_eof(((struct tr_ssh_socket *)tr_ssh_sock)->channel) != 0)
 		return SSH_ERROR;

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -59,7 +59,7 @@ int tr_ssh_open(void *socket)
 
 	ssh_socket->session = ssh_new();
 	if (!ssh_socket->session) {
-		SSH_DBG1("tr_ssh_init: can't create ssh_session", ssh_socket);
+		SSH_DBG("%s: can't create ssh_session", ssh_socket, __func__);
 		goto error;
 	}
 
@@ -96,7 +96,7 @@ int tr_ssh_open(void *socket)
 		ret = ssh_connect(ssh_socket->session);
 
 		if (ret == SSH_ERROR) {
-			SSH_DBG1("tr_ssh_init: opening SSH connection failed", ssh_socket);
+			SSH_DBG("%s: opening SSH connection failed", ssh_socket, __func__);
 			goto error;
 		} else if (ret == SSH_AGAIN) {
 			socket_t fd = ssh_get_fd(ssh_socket->session);
@@ -133,7 +133,7 @@ int tr_ssh_open(void *socket)
 
 	// check server identity
 	if ((config->server_hostkey_path) && (ssh_is_server_known(ssh_socket->session) != SSH_SERVER_KNOWN_OK)) {
-		SSH_DBG1("tr_ssh_init: Wrong hostkey", ssh_socket);
+		SSH_DBG("%s: Wrong hostkey", ssh_socket, __func__);
 		goto error;
 	}
 
@@ -143,7 +143,7 @@ int tr_ssh_open(void *socket)
 	const int rtval = ssh_userauth_autopubkey(ssh_socket->session, NULL);
 #endif
 	if (rtval != SSH_AUTH_SUCCESS) {
-		SSH_DBG1("tr_ssh_init: Authentication failed", ssh_socket);
+		SSH_DBG("%s: Authentication failed", ssh_socket, __func__);
 		goto error;
 	}
 
@@ -155,7 +155,7 @@ int tr_ssh_open(void *socket)
 		goto error;
 
 	if (ssh_channel_request_subsystem(ssh_socket->channel, "rpki-rtr") == SSH_ERROR) {
-		SSH_DBG1("tr_ssh_init: Error requesting subsystem rpki-rtr", ssh_socket);
+		SSH_DBG("%s: Error requesting subsystem rpki-rtr", ssh_socket, __func__);
 		goto error;
 	}
 	SSH_DBG1("Connection established", ssh_socket);

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -132,7 +132,11 @@ int tr_ssh_open(void *socket)
 	ssh_set_blocking(ssh_socket->session, 1);
 
 	// check server identity
+#if LIBSSH_VERSION_MAJOR > 0 || LIBSSH_VERSION_MINOR > 8
+	if ((config->server_hostkey_path) && (ssh_session_is_known_server(ssh_socket->session) != SSH_KNOWN_HOSTS_OK)) {
+#else
 	if ((config->server_hostkey_path) && (ssh_is_server_known(ssh_socket->session) != SSH_SERVER_KNOWN_OK)) {
+#endif
 		SSH_DBG("%s: Wrong hostkey", ssh_socket, __func__);
 		goto error;
 	}

--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -58,6 +58,7 @@ struct tr_ssh_config {
 	void *data;
 	int (*new_socket)(void *data);
 	unsigned int connect_timeout;
+	char *password;
 };
 
 /**

--- a/tools/rtrclient.1
+++ b/tools/rtrclient.1
@@ -24,7 +24,7 @@ rtrclient \- rtr rpki client
 .IR HOST
 .IR PORT
 .IR USERNAME
-.IR PRIVATE_KEY
+(\fIPRIVATE_KEY\fR|\fIPASSWORD\fR)
 [\fIHOST_KEY\fR]
 .SH DESCRIPTION
 \fBrtrclient\fR connects to an RPKI/RTR cache server and prints prefix, origin AS, and router key updates.
@@ -33,7 +33,8 @@ The amount is not limited and different transport types can be mixed arbitrarily
 .LP
 For \fBtcp\fR you must specify the \fIHOST\fR and \fIPORT\fR.
 .LP
-For \fBssh\fR you must specify the \fIHOST\fR, \fIPORT\fR, \fIUSERNAME\fR and a file containing the \fIPRIVATE_KEY\fR.
+For \fBssh\fR you must specify the \fIHOST\fR, \fIPORT\fR, \fIUSERNAME\fR and a file containing the \fIPRIVATE_KEY\fR or a \fIPASSWORD\fR.
+By default the rtrclient will try to guess which of the two was entered. If you want to explicitly specify this see \fB-w\fR and \fB-s\fR.
 You may specify a file containing a list of \fIHOST_KEY\fRs, in the well known
 .B SSH_KNOWN_HOSTS
 file format. See \fIsshd(8)\fR for details.
@@ -53,6 +54,7 @@ Print information about router key updates
 \fB-p\fR
 .RS 4
 Print information about prefix and origin AS updates
+.RE
 \fB-s\fR
 .RS 4
 Print information about connection status updates
@@ -72,6 +74,14 @@ Print available templates and exit. Prints specified templated, when used with -
 \fB-o\fR
 .RS 4
 Output file for export
+.RE
+\fB-w\fR
+.RS 4
+force ssh authentication information to be interpreted as a password
+.RE
+\fB-s\fR
+.RS 4
+force ssh authentication information to be interpreted as a private key
 .SH TEMPLATES
 Templates can be used to export ROA information in a custom format. They are written in the \fBmustache\fR(\fIhttps://mustache.github.io/\fR) templating language.
 


### PR DESCRIPTION
### Contribution description
Several fixes for the ssh transport
- the log prefix did sometimes indicate the wrong function
- add support for password authentication
- properly check malloc return values in ssh init
- fix a deprecation warning from libssh
- fix constant spinning on send
- check return values of libssh functions better and translate them explicitly to our internal ones

### Issues/PRs references
fixes #212 
fixes #250 