### PR TITLE
Fix rtr_stop blocking behavior of tr_open

### DIFF
--- a/doxygen/examples/rtr_mgr.c
+++ b/doxygen/examples/rtr_mgr.c
@@ -22,6 +22,7 @@ int main()
 		ssh_privkey, //Private key
 		NULL, // data
 		NULL, // new_socket()
+		0, // connect timeout
 	};
 	tr_ssh_init(&config, &tr_ssh);
 
@@ -36,6 +37,7 @@ int main()
 		NULL, //Source address
 		NULL, //data
 		NULL, //get_socket()
+		0, // connect timeout
 	};
 	tr_tcp_init(&tcp_config, &tr_tcp);
 

--- a/doxygen/examples/ssh_tr.c
+++ b/doxygen/examples/ssh_tr.c
@@ -11,7 +11,7 @@ int main()
 	char ssh_privkey[] = "/etc/rpki-rtr/client.priv";
 
 	struct tr_ssh_config config = {
-		ssh_host, 22, NULL, ssh_user, ssh_hostkey, ssh_privkey, NULL, NULL
+		ssh_host, 22, NULL, ssh_user, ssh_hostkey, ssh_privkey, NULL, NULL, 0,
 	};
 
 	tr_ssh_init(&config, &ssh_socket);

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -105,8 +105,7 @@ int tr_ssh_open(void *socket)
 
 			FD_ZERO(&rfds);
 			FD_SET(fd, &rfds);
-			// timeout of 30 seconds
-			struct timeval timeout = { .tv_sec = 30, .tv_usec = 0 };
+			struct timeval timeout = {.tv_sec = ssh_socket->config.connect_timeout, .tv_usec = 0};
 			int oldcancelstate;
 
 			/* Enable cancellability for the select call
@@ -299,6 +298,11 @@ RTRLIB_EXPORT int tr_ssh_init(const struct tr_ssh_config *config, struct tr_sock
 		ssh_socket->config.server_hostkey_path = lrtr_strdup(config->server_hostkey_path);
 	else
 		ssh_socket->config.server_hostkey_path = NULL;
+
+	if (config->connect_timeout == 0)
+		ssh_socket->config.connect_timeout = RTRLIB_TRANSPORT_CONNECT_TIMEOUT_DEFAULT;
+	else
+		ssh_socket->config.connect_timeout = config->connect_timeout;
 
 	ssh_socket->ident = NULL;
 	ssh_socket->config.data = config->data;

--- a/rtrlib/transport/ssh/ssh_transport.h
+++ b/rtrlib/transport/ssh/ssh_transport.h
@@ -45,6 +45,8 @@
  *	  is made. The returned socket is expected to be ready for use (e.g.
  *	  in state established), and must use a reliably stream-oriented transport.
  *	  When new_socket() is used, host, port, and bindaddr are not used.
+ * @param connect_timeout Time in seconds to wait for a successful connection.
+ *	  Defaults to #RTRLIB_TRANSPORT_CONNECT_TIMEOUT_DEFAULT
  */
 struct tr_ssh_config {
 	char *host;
@@ -55,6 +57,7 @@ struct tr_ssh_config {
 	char *client_privkey_path;
 	void *data;
 	int (*new_socket)(void *data);
+	unsigned int connect_timeout;
 };
 
 /**

--- a/rtrlib/transport/tcp/tcp_transport.c
+++ b/rtrlib/transport/tcp/tcp_transport.c
@@ -173,8 +173,8 @@ int tr_tcp_open(void *tr_socket)
 
 		FD_ZERO(&wfds);
 		FD_SET(tcp_socket->socket, &wfds);
-		// timeout of 30 seconds for select
-		struct timeval timeout = { .tv_sec = 30, .tv_usec = 0 };
+
+		struct timeval timeout = {.tv_sec = tcp_socket->config.connect_timeout, .tv_usec = 0};
 		int oldcancelstate;
 
 		/* Enable cancellability for the select call
@@ -354,6 +354,11 @@ RTRLIB_EXPORT int tr_tcp_init(const struct tr_tcp_config *config, struct tr_sock
 		tcp_socket->config.bindaddr = lrtr_strdup(config->bindaddr);
 	else
 		tcp_socket->config.bindaddr = NULL;
+
+	if (config->connect_timeout == 0)
+		tcp_socket->config.connect_timeout = RTRLIB_TRANSPORT_CONNECT_TIMEOUT_DEFAULT;
+	else
+		tcp_socket->config.connect_timeout = config->connect_timeout;
 
 	tcp_socket->ident = NULL;
 	tcp_socket->config.data = config->data;

--- a/rtrlib/transport/tcp/tcp_transport.h
+++ b/rtrlib/transport/tcp/tcp_transport.h
@@ -35,6 +35,8 @@
  *	  is made. The returned socket is expected to be ready for use (e.g.
  *	  in state established), and must use a reliably stream-oriented transport.
  *	  When new_socket() is used, host, port, and bindaddr are not used.
+ * @param connect_timeout Time in seconds to wait for a successful connection.
+ *	  Defaults to #RTRLIB_TRANSPORT_CONNECT_TIMEOUT_DEFAULT
  */
 struct tr_tcp_config {
 	char *host;
@@ -42,6 +44,7 @@ struct tr_tcp_config {
 	char *bindaddr;
 	void *data;
 	int (*new_socket)(void *data);
+	unsigned int connect_timeout;
 };
 
 /**

--- a/rtrlib/transport/transport.h
+++ b/rtrlib/transport/transport.h
@@ -26,6 +26,11 @@
 #include <time.h>
 
 /**
+ * @brief Default connect timeout
+ */
+#define RTRLIB_TRANSPORT_CONNECT_TIMEOUT_DEFAULT 30
+
+/**
  * @brief The return values for tr_ functions.
  */
 enum tr_rtvals {

--- a/tests/test_dynamic_groups.c
+++ b/tests/test_dynamic_groups.c
@@ -33,6 +33,7 @@ int main(void)
 		NULL, //Source address
 		NULL, //data
 		NULL, //new_socket()
+		0, // connect timeout
 	};
 	tr_tcp_init(&tcp_config, &tr_tcp);
 

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -62,7 +62,7 @@ int main(void)
 
 	/* create a TCP transport socket */
 	struct tr_socket tr_tcp;
-	struct tr_tcp_config tcp_config = {RPKI_CACHE_HOST, RPKI_CACHE_POST, NULL, NULL, NULL};
+	struct tr_tcp_config tcp_config = {RPKI_CACHE_HOST, RPKI_CACHE_POST, NULL, NULL, NULL, 0};
 	struct rtr_socket rtr_tcp;
 	struct rtr_mgr_group groups[1];
 

--- a/tools/rpki-rov.c
+++ b/tools/rpki-rov.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 	}
 
 	struct tr_socket tr_tcp;
-	struct tr_tcp_config tcp_config = {argv[1], argv[2], NULL, NULL, NULL};
+	struct tr_tcp_config tcp_config = {argv[1], argv[2], NULL, NULL, NULL, 0};
 	struct rtr_socket rtr_tcp;
 	struct rtr_mgr_config *conf;
 	struct rtr_mgr_group groups[1];


### PR DESCRIPTION
### Contribution description
Since the move from pthread_kill to pthread_cancel a rtr_socket could
not be stopped immediately if it was in the tr_open call.
cancelability could not be enabled for that function because it holds
local resources.
This enables cancalability locally for the only blocking call in
tr_tcp_open and tr_ssh_open respectively.

### Testing procedure

Call `rtr_mgr_stop` shortly after `rtr_mgr_start` and make sure that the connection attempt does not succeed or fail immediately. For instance by dropping the packets via the firewall.

Without this patch `rtr_mgr_stop` hangs until the connection attempts times out.

### Issues/PRs references
Fixes #254 

