### PR TITLE
rtrlib/rtr_mgr: properly cleanup rtr_sockets on stop

### DIFF
--- a/rtrlib/rtr/rtr.c
+++ b/rtrlib/rtr/rtr.c
@@ -241,6 +241,7 @@ void rtr_stop(struct rtr_socket *rtr_socket)
 		pfx_table_src_remove(rtr_socket->pfx_table, rtr_socket);
 		spki_table_src_remove(rtr_socket->spki_table, rtr_socket);
 		rtr_socket->thread_id = 0;
+		rtr_socket->state = RTR_CLOSED;
 	}
 	RTR_DBG1("Socket shut down");
 }


### PR DESCRIPTION
Previously rtr_sockets could not be restarted because their state
remained on SHUTDOWN, which they can, by design, not recover from
themselves.

fix #267 