### PR TITLE
rtr: fix race condition on rtr_start/rtr_close

### DIFF
--- a/rtrlib/rtr/rtr.h
+++ b/rtrlib/rtr/rtr.h
@@ -112,6 +112,7 @@ typedef void (*rtr_connection_state_fp)(const struct rtr_socket *rtr_socket, con
  * @param version Protocol version used by this socket
  * @param has_received_pdus True, if this socket has already received PDUs
  * @param spki_table spki_table that stores the router keys obtained from the connected rtr server
+ * @param mutex mutex to protect members of this struct that are accesed from multiple threads
  */
 struct rtr_socket {
 	struct tr_socket *tr_socket;
@@ -133,6 +134,7 @@ struct rtr_socket {
 	bool has_received_pdus;
 	struct spki_table *spki_table;
 	bool is_resetting;
+	pthread_mutex_t mutex;
 };
 
 /**

--- a/rtrlib/rtr/rtr_private.h
+++ b/rtrlib/rtr/rtr_private.h
@@ -85,4 +85,10 @@ int rtr_start(struct rtr_socket *rtr_socket);
  */
 void rtr_stop(struct rtr_socket *rtr_socket);
 
+/**
+ * @brief Frees resources held by this rtr socket
+ * @paran[in] rtr_socket rtr_socket that will be freed
+ */
+void rtr_free(struct rtr_socket *rtr_socket);
+
 #endif

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -466,7 +466,7 @@ RTRLIB_EXPORT void rtr_mgr_free(struct rtr_mgr_config *config)
 
 		head = head->next;
 		for (unsigned int j = 0; j < group_node->group->sockets_len; j++)
-			tr_free(group_node->group->sockets[j]->tr_socket);
+			rtr_free(group_node->group->sockets[j]);
 
 		lrtr_free(group_node->group);
 		lrtr_free(group_node);


### PR DESCRIPTION
It was possible for two threads to be started for the same socket
because the check supposed to prevent this used an unsynchronized
variable.

Fix #271 