### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/rtrlib/lib/utils.c
+++ b/rtrlib/lib/utils.c
@@ -13,14 +13,14 @@
 #include <stdint.h>
 #include <time.h>
 
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #include <mach/mach_time.h>
 static double timeconvert = 0.0;
 #endif
 
 int lrtr_get_monotonic_time(time_t *seconds)
 {
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 	if (timeconvert == 0.0) {
 		mach_timebase_info_data_t time_base;
 		(void)mach_timebase_info(&time_base);


### PR DESCRIPTION
### Contribution description

Hurd also uses Mach.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```


### Testing procedure

Try to compile rtrlib on Hurd.


### Issues/PRs references

N/A

