### PR TITLE
Update rpki-cache server for testing

### DIFF
--- a/tests/test_dynamic_groups.c
+++ b/tests/test_dynamic_groups.c
@@ -24,8 +24,8 @@ int main(void)
 	//create a TCP transport socket
 	int retval = 0;
 	struct tr_socket tr_tcp;
-	char tcp_host[] = "rpki-validator.realmv6.org";
-	char tcp_port[] = "8283";
+	char tcp_host[] = "rpki-cache.netd.cs.tu-dresden.de";
+	char tcp_port[] = "3323";
 
 	struct tr_tcp_config tcp_config = {
 		tcp_host, //IP

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -57,12 +57,12 @@ int main(void)
 	/* These variables are not in the global scope
 	 * because it would cause warnings about discarding constness
 	 */
-	char RPKI_CACHE_HOST[] = "rpki-validator.realmv6.org";
-	char RPKI_CACHE_POST[] = "8283";
+	char RPKI_CACHE_HOST[] = "rpki-cache.netd.cs.tu-dresden.de";
+	char RPKI_CACHE_PORT[] = "3323";
 
 	/* create a TCP transport socket */
 	struct tr_socket tr_tcp;
-	struct tr_tcp_config tcp_config = {RPKI_CACHE_HOST, RPKI_CACHE_POST, NULL, NULL, NULL, 0};
+	struct tr_tcp_config tcp_config = {RPKI_CACHE_HOST, RPKI_CACHE_PORT, NULL, NULL, NULL, 0};
 	struct rtr_socket rtr_tcp;
 	struct rtr_mgr_group groups[1];
 


### PR DESCRIPTION
<!--
The RTRlib community cares about code quality. Therefore, before
describing what your contribution is about, we would like you to make sure
that your modifications are compliant with the RTRlib coding conventions, see
https://github.com/rtrlib/rtrlib/blob/master/CONTRIBUTING.
-->

### Contribution description
The current live tests fail because the cache server used is not running anymore.
This PR changes the name and port of the cache server used for live validation tests and dynamic group tests.

<!--
Put here the description of your contribution:
- describe which part(s) of RTRlib is (are) involved
- if this is a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Details steps to test your contribution:
- `make test` all tests should pass now.

<!--
Examples: Fixes #212. See also #196. Depends on PR #188.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved. This way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

