### PR TITLE
[FIX] Building with strict aliasing

### DIFF
--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -128,8 +128,8 @@ static void mass_test(void)
 		pfx.min_len = 128;
 		pfx.max_len = 128;
 		pfx.prefix.ver = LRTR_IPV6;
-		((uint64_t *)pfx.prefix.u.addr6.addr)[1] = max_i;
-		((uint64_t *)pfx.prefix.u.addr6.addr)[0] = min_i + i;
+		((uint32_t *)pfx.prefix.u.addr6.addr)[2] = max_i;
+		((uint32_t *)pfx.prefix.u.addr6.addr)[0] = min_i + i;
 		assert(pfx_table_add(&pfxt, &pfx) == PFX_SUCCESS);
 	}
 
@@ -148,8 +148,8 @@ static void mass_test(void)
 		pfx.min_len = 128;
 		pfx.max_len = 128;
 		pfx.prefix.ver = LRTR_IPV6;
-		((uint64_t *)pfx.prefix.u.addr6.addr)[1] = max_i;
-		((uint64_t *)pfx.prefix.u.addr6.addr)[0] = min_i + i;
+		((uint32_t *)pfx.prefix.u.addr6.addr)[2] = max_i;
+		((uint32_t *)pfx.prefix.u.addr6.addr)[0] = min_i + i;
 
 		assert(pfx_table_validate(&pfxt, i + 1, &pfx.prefix, pfx.min_len, &res) == PFX_SUCCESS);
 		assert(res == BGP_PFXV_STATE_VALID);
@@ -172,8 +172,8 @@ static void mass_test(void)
 		pfx.prefix.ver = LRTR_IPV6;
 		pfx.min_len = 128;
 		pfx.max_len = 128;
-		((uint64_t *)pfx.prefix.u.addr6.addr)[1] = max_i;
-		((uint64_t *)pfx.prefix.u.addr6.addr)[0] = min_i + i;
+		((uint32_t *)pfx.prefix.u.addr6.addr)[2] = max_i;
+		((uint32_t *)pfx.prefix.u.addr6.addr)[0] = min_i + i;
 		assert(pfx_table_remove(&pfxt, &pfx) == PFX_SUCCESS);
 	}
 


### PR DESCRIPTION
### Contribution description

Motivation
  - building with strict aliasing flags failed
  - used additional flags shown below

```
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto=4 -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing")
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FORTIFY_SOURCE=3 -fdiagnostics-color=always -frecord-gcc-switches")
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-clash-protection -march=native -O2 -pipe -U_FORTIFY_SOURCE")
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=format-security -Werror=implicit-int -Werror=int-conversion -Wformat")
```

How:
  - modify casted variable type in test case to initialized type

### Issues/PRs references
  - Fixes #287
