### PR TITLE
Fix: including missing header

### DIFF
--- a/rtrlib/aspa/aspa_private.h
+++ b/rtrlib/aspa/aspa_private.h
@@ -91,8 +91,8 @@
 #define RTR_ASPA_PRIVATE_H
 
 #include "aspa.h"
-
 #include "rtrlib/rtr/rtr.h"
+#include "rtrlib/lib/log_private.h"
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/rtrlib/pfx/trie/trie_private.h
+++ b/rtrlib/pfx/trie/trie_private.h
@@ -11,6 +11,7 @@
 #define RTR_TRIE_PRIVATE
 
 #include "rtrlib/lib/ip_private.h"
+#include "rtrlib/lib/log_private.h"
 
 #include <inttypes.h>
 


### PR DESCRIPTION
- the debug macro needs a function defined inside the rtrlib/lib/log_private.h header which was not included.

<!--
The RTRlib community cares about code quality. Therefore, before
describing what your contribution is about, we would like you to make sure
that your modifications are compliant with the RTRlib coding conventions, see
https://github.com/rtrlib/rtrlib/blob/master/CONTRIBUTING.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RTRlib is (are) involved
- if this is a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile and is there a 'test' command
- how to know that it was not working/available in master
- the expected success of the test output
-->


### Issues/PRs references

<!--
Examples: Fixes #212. See also #196. Depends on PR #188.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved. This way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

