### PR TITLE
fix build w/ cmake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 project(rtrlib C)
 
 set(PROJECT_DESCRIPTION "Lightweight C library that implements the RPKI/RTR protocol and prefix origin validation.")


### PR DESCRIPTION
### Contribution description

Cmake 4 is released and being tested downstream for integration.  Increasing the minimum required cmake version allows to compile rtrlib with cmake 4.

### Testing procedure

- install cmake 4
- compile

### Issues/PRs references

https://bugs.gentoo.org/953446