### PR TITLE
Fix: Add missing memory allocation NULL-checks

### DIFF
--- a/rtrlib/aspa/aspa.c
+++ b/rtrlib/aspa/aspa.c
@@ -32,6 +32,11 @@ static enum aspa_status aspa_table_notify_clients(struct aspa_table *aspa_table,
 			size_t size = sizeof(uint32_t) * record->provider_count;
 
 			rec.provider_asns = lrtr_malloc(size);
+
+			if (rec.provider_asns == NULL) {
+				return ASPA_ERROR;
+			}
+
 			memcpy(rec.provider_asns, record->provider_asns, size);
 		} else {
 			rec.provider_asns = NULL;

--- a/rtrlib/aspa/aspa_array/aspa_array.c
+++ b/rtrlib/aspa/aspa_array/aspa_array.c
@@ -177,7 +177,18 @@ enum aspa_status aspa_array_remove(struct aspa_array *array, size_t index, bool 
 	// decreasing capacity if possible
 	const size_t SIZE_DECREASE_OFFSET = 1000;
 	if (array->size + SIZE_DECREASE_OFFSET < array->capacity) {
-		array->data = lrtr_realloc(array->data, array->size + SIZE_DECREASE_OFFSET);
+		struct aspa_record *tmp_data = lrtr_realloc(array->data, array->size + SIZE_DECREASE_OFFSET);
+
+		if (tmp_data == NULL) {
+			/*
+			 * Although reducing the array's capacity failed at this point,
+			 * the element at the given index has been removed and thus the
+			 * function's outcome can be considered successful.
+			 */
+			return ASPA_SUCCESS;
+		}
+
+		array->data = tmp_data;
 		array->capacity = array->size + SIZE_DECREASE_OFFSET;
 	}
 

--- a/rtrlib/bgpsec/bgpsec.c
+++ b/rtrlib/bgpsec/bgpsec.c
@@ -195,6 +195,11 @@ int rtr_bgpsec_validate_as_path(const struct rtr_bgpsec *data, struct spki_table
 
 		uint8_t *curr = lrtr_malloc(len);
 
+		if (!curr) {
+			retval = RTR_BGPSEC_ERROR;
+			goto err;
+		}
+
 		read_stream_at(curr, s, offset, len);
 
 		retval = hash_byte_sequence(curr, len, data->alg, &hash_result);
@@ -502,6 +507,10 @@ struct rtr_secure_path_seg *rtr_bgpsec_new_secure_path_seg(uint8_t pcount, uint8
 {
 	struct rtr_secure_path_seg *seg = lrtr_malloc(sizeof(struct rtr_secure_path_seg));
 
+	if (!seg) {
+		return NULL;
+	}
+
 	seg->pcount = pcount;
 	seg->flags = flags;
 	seg->asn = asn;
@@ -569,7 +578,17 @@ struct rtr_bgpsec_nlri *rtr_bgpsec_nlri_new(int nlri_len)
 {
 	struct rtr_bgpsec_nlri *nlri = lrtr_malloc(sizeof(struct rtr_bgpsec_nlri));
 
+	if (!nlri) {
+		return NULL;
+	}
+
 	nlri->nlri = lrtr_malloc(nlri_len);
+
+	if (!nlri->nlri) {
+		lrtr_free(nlri);
+		return NULL;
+	}
+
 	return nlri;
 }
 

--- a/rtrlib/bgpsec/bgpsec.h
+++ b/rtrlib/bgpsec/bgpsec.h
@@ -43,7 +43,7 @@ enum rtr_bgpsec_rtvals {
 	RTR_BGPSEC_VALID = 1,
 	/** An operation was successful. */
 	RTR_BGPSEC_SUCCESS = 0,
-	/** An operation was not sucessful. */
+	/** An operation was not successful. */
 	RTR_BGPSEC_ERROR = -1,
 	/** The public key could not be loaded. */
 	RTR_BGPSEC_LOAD_PUB_KEY_ERROR = -2,

--- a/rtrlib/bgpsec/bgpsec_private.h
+++ b/rtrlib/bgpsec/bgpsec_private.h
@@ -126,7 +126,7 @@ struct rtr_bgpsec *rtr_bgpsec_new(uint8_t alg, uint8_t safi, uint16_t afi, uint3
 /**
  * @brief Allocate memory for a rtr_bgpsec_nlri struct.
  * @return A pointer to an allocated rtr_bgpsec_nlri struct
- *         or NULL if the allocation failed.
+ *         or NULL if the memory allocation failed.
  */
 struct rtr_bgpsec_nlri *rtr_bgpsec_nlri_new(int nlri_len);
 

--- a/rtrlib/bgpsec/bgpsec_private.h
+++ b/rtrlib/bgpsec/bgpsec_private.h
@@ -76,6 +76,8 @@ void rtr_bgpsec_free_signatures(struct rtr_signature_seg *seg);
  * @param[in] flags The flags field.
  * @param[in] asn The ASN of the segment.
  * @return A pointer to an initialized rtr_secure_path_seg struct
+ *         or NULL if an error occurred, e.g. the memory allocation
+ *         failed.
  */
 struct rtr_secure_path_seg *rtr_bgpsec_new_secure_path_seg(uint8_t pcount, uint8_t flags, uint32_t asn);
 
@@ -123,7 +125,8 @@ struct rtr_bgpsec *rtr_bgpsec_new(uint8_t alg, uint8_t safi, uint16_t afi, uint3
 
 /**
  * @brief Allocate memory for a rtr_bgpsec_nlri struct.
- * @return A pointer to an allocated rtr_bgpsec_nlri struct.
+ * @return A pointer to an allocated rtr_bgpsec_nlri struct
+ *         or NULL if the allocation failed.
  */
 struct rtr_bgpsec_nlri *rtr_bgpsec_nlri_new(int nlri_len);
 

--- a/rtrlib/bgpsec/bgpsec_utils.c
+++ b/rtrlib/bgpsec/bgpsec_utils.c
@@ -25,30 +25,34 @@ struct stream {
 
 struct stream *init_stream(uint16_t size)
 {
-	struct stream *s = lrtr_calloc(sizeof(struct stream), 1);
+	struct stream *stream = lrtr_calloc(sizeof(struct stream), 1);
 
-	if (!s) {
+	if (stream == NULL) {
 		return NULL;
 	}
 
-	s->stream = lrtr_calloc(size, 1);
+	stream->stream = lrtr_calloc(size, 1);
 
-	if (!s->stream) {
-		lrtr_free(s);
+	if (stream->stream == NULL) {
+		lrtr_free(stream);
 		return NULL;
 	}
 
-	s->start = s->stream;
-	s->size = size;
-	s->w_head = 0;
-	s->r_head = 0;
-	return s;
+	stream->start = stream->stream;
+	stream->size = size;
+	stream->w_head = 0;
+	stream->r_head = 0;
+	return stream;
 }
 
 /* cppcheck-suppress unusedFunction */
 struct stream *copy_stream(struct stream *s)
 {
 	struct stream *cpy = init_stream(s->size);
+
+	if (cpy == NULL) {
+		return NULL;
+	}
 
 	memcpy(cpy->stream, s->stream, s->size);
 	cpy->w_head = s->w_head;

--- a/rtrlib/bgpsec/bgpsec_utils.c
+++ b/rtrlib/bgpsec/bgpsec_utils.c
@@ -27,7 +27,17 @@ struct stream *init_stream(uint16_t size)
 {
 	struct stream *s = lrtr_calloc(sizeof(struct stream), 1);
 
+	if (!s) {
+		return NULL;
+	}
+
 	s->stream = lrtr_calloc(size, 1);
+
+	if (!s->stream) {
+		lrtr_free(s);
+		return NULL;
+	}
+
 	s->start = s->stream;
 	s->size = size;
 	s->w_head = 0;

--- a/rtrlib/bgpsec/bgpsec_utils_private.h
+++ b/rtrlib/bgpsec/bgpsec_utils_private.h
@@ -43,10 +43,10 @@ enum align_type {
 /* Forward declaration of stream to make it opaque. */
 struct stream;
 
-/* Initialize a stream of size bytes */
+/* Initialize and return a stream of size bytes or NULL if the memory allocation failed */
 struct stream *init_stream(uint16_t size);
 
-/* Copy a stream s and return the copy */
+/* Copy a stream s and return the copy or NULL if the memory allocation failed */
 struct stream *copy_stream(struct stream *s);
 
 /* Free stream s */

--- a/rtrlib/rtr_mgr.h
+++ b/rtrlib/rtr_mgr.h
@@ -363,7 +363,8 @@ void rtr_mgr_bgpsec_free_signatures(struct rtr_signature_seg *seg);
  * @param[in] pcount The pcount field.
  * @param[in] flags The flags field.
  * @param[in] asn The ASN of the segment.
- * @return A pointer to an initialized rtr_secure_path_seg struct
+ * @return A pointer to an initialized rtr_secure_path_seg struct or
+ *         NULL if an error occurred, e.g. the memory allocation failed.
  */
 struct rtr_secure_path_seg *rtr_mgr_bgpsec_new_secure_path_seg(uint8_t pcount, uint8_t flags, uint32_t asn);
 

--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -305,6 +305,10 @@ RTRLIB_EXPORT int tr_ssh_init(const struct tr_ssh_config *config, struct tr_sock
 	socket->socket = lrtr_calloc(1, sizeof(struct tr_ssh_socket));
 	struct tr_ssh_socket *ssh_socket = socket->socket;
 
+	if (ssh_socket == NULL) {
+		return TR_ERROR;
+	}
+
 	ssh_socket->channel = NULL;
 	ssh_socket->session = NULL;
 	ssh_socket->config.host = lrtr_strdup(config->host);
@@ -317,7 +321,7 @@ RTRLIB_EXPORT int tr_ssh_init(const struct tr_ssh_config *config, struct tr_sock
 		goto error;
 
 	if ((config->password && config->client_privkey_path) || (!config->password && !config->client_privkey_path))
-		return TR_ERROR;
+		goto error;
 
 	if (config->bindaddr) {
 		ssh_socket->config.bindaddr = lrtr_strdup(config->bindaddr);

--- a/rtrlib/transport/tcp/tcp_transport.c
+++ b/rtrlib/transport/tcp/tcp_transport.c
@@ -339,6 +339,11 @@ RTRLIB_EXPORT int tr_tcp_init(const struct tr_tcp_config *config, struct tr_sock
 	socket->ident_fp = &tr_tcp_ident;
 
 	socket->socket = lrtr_malloc(sizeof(struct tr_tcp_socket));
+
+	if (socket->socket == NULL) {
+		return TR_ERROR;
+	}
+
 	struct tr_tcp_socket *tcp_socket = socket->socket;
 
 	tcp_socket->socket = -1;

--- a/tests/test_bgpsec.c
+++ b/tests/test_bgpsec.c
@@ -115,6 +115,7 @@ static void validate_bgpsec_path_test(void)
 	uint32_t my_as = 65537;
 
 	pfx = rtr_mgr_bgpsec_nlri_new(3);
+	assert(pfx != NULL);
 	pfx->nlri_len = 24;
 	pfx->afi = 1; /* LRTR_IPV4 */
 	pfx_int = htonl(3221225984); /* 192.0.2.0 */
@@ -240,6 +241,7 @@ static void generate_signature_test(void)
 	uint32_t target_as = 65538;
 
 	pfx = rtr_mgr_bgpsec_nlri_new(3);
+	assert(pfx != NULL);
 	pfx->nlri_len = 24;
 	pfx->afi = 1; /* LRTR_IPV4 */
 	pfx_int = htonl(3221225984); /* 192.0.2.0 */
@@ -335,6 +337,7 @@ static void originate_and_validate_test(void)
 	uint32_t target_as = 65536;
 
 	pfx = rtr_mgr_bgpsec_nlri_new(3);
+	assert(pfx != NULL);
 	pfx->nlri_len = 24;
 	pfx->afi = 1; /* LRTR_IPV4 */
 	pfx_int = htonl(3221225984); /* 192.0.2.0 */

--- a/tests/unittests/test_bgpsec_signing.c
+++ b/tests/unittests/test_bgpsec_signing.c
@@ -26,6 +26,7 @@ struct rtr_bgpsec *setup_bgpsec(void)
 	int pfx_int = 0;
 
 	pfx = rtr_bgpsec_nlri_new(3);
+	assert(pfx != NULL);
 	pfx->nlri_len = 24;
 	pfx->afi = 1; /* LRTR_IPV4 */
 	pfx_int = htonl(3221225984); /* 192.0.2.0 */

--- a/tests/unittests/test_bgpsec_utils.c
+++ b/tests/unittests/test_bgpsec_utils.c
@@ -28,6 +28,7 @@ struct rtr_bgpsec *setup_bgpsec(void)
 	long pfx_int = 0;
 
 	pfx = rtr_bgpsec_nlri_new(3);
+	assert(pfx != NULL);
 	pfx->nlri_len = 24;
 	pfx->afi = BGPSEC_IPV4;
 	pfx_int = 3221225984; /* 192.0.2.0 */
@@ -97,6 +98,7 @@ static void test_bgpsec_streams(void **state)
 
 	struct stream *s_cpy = copy_stream(s);
 
+	assert(s_cpy != NULL);
 	assert_int_equal(s->size, s_cpy->size);
 	assert_int_equal(s->r_head, s_cpy->r_head);
 	assert_int_equal(s->w_head, s_cpy->w_head);
@@ -169,6 +171,7 @@ static void test_bgpsec_constructors(void **state)
 	long pfx_int = 0;
 
 	pfx = rtr_bgpsec_nlri_new(3);
+	assert(pfx != NULL);
 	pfx->nlri_len = 24;
 	pfx->afi = BGPSEC_IPV4;
 	pfx_int = 3221225984; /* 192.0.2.0 */

--- a/tests/unittests/test_bgpsec_validation.c
+++ b/tests/unittests/test_bgpsec_validation.c
@@ -27,6 +27,7 @@ struct rtr_bgpsec *setup_bgpsec(void)
 	int pfx_int = 0;
 
 	pfx = rtr_bgpsec_nlri_new(3);
+	assert(pfx != NULL);
 	pfx->nlri_len = 24;
 	pfx->afi = 1; /* LRTR_IPV4 */
 	pfx_int = htonl(3221225984); /* 192.0.2.0 */


### PR DESCRIPTION
### Contribution description

#297 reports a missing NULL-check for a memory allocation in `/rtrlib/rtrlib/transport/tcp/tcp_transport.c` which results in undefined behavior / a segmentation fault due to dereferencing a NULL-pointer if the memory allocation failed.

After searching for the memory allocation functions `lrtr_malloc`, `lrtr_calloc`, and `lrtr_realloc` in the source code (i.e. within the `rtrlib/` directory) I found multiple other locations in the code (i.e. in the modules `bgpsec`, `aspa`, and `transport`) where the NULL-check was missing.

This pull request adds the missing NULL-checks, frees previously allocated data if necessary and returns an error code/`NULL` in case the memory allocation failed. In addition, it fixes a memory leak in `tr_ssh_init` which was caused by a premature return when either both the SSH password and path to the private key or none of them are configured.

### Testing procedure

n/a

### Issues/PRs references

Fixes #297 