### PR TITLE
Fix: transport: fix bad copy-paste in `tr_ssh_init`

### DIFF
--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -341,7 +341,7 @@ RTRLIB_EXPORT int tr_ssh_init(const struct tr_ssh_config *config, struct tr_sock
 	if (config->server_hostkey_path) {
 		ssh_socket->config.server_hostkey_path = lrtr_strdup(config->server_hostkey_path);
 
-		if (!ssh_socket->config.client_privkey_path)
+		if (!ssh_socket->config.server_hostkey_path)
 			goto error;
 
 	} else {


### PR DESCRIPTION
### Contribution description

#295 reports a bad copy-paste which leads to undefined behavior or at least an invalid error return when the `ssh_socket->config.client_privkey_path` is set to `NULL` and `config->server_hostkey_path` exists. This pull request fixes the incorrect check by changing the condition from `if (!ssh_socket->config.client_privkey_path)` to `if (!ssh_socket->config.server_hostkey_path)`.

### Testing procedure

n/a

### Issues/PRs references

Fixes #295

