### PR TITLE
rtrlib/transport/ssh/ssh_transport.c: fix ssh-rsa public key auth

### DIFF
--- a/rtrlib/transport/ssh/ssh_transport.c
+++ b/rtrlib/transport/ssh/ssh_transport.c
@@ -131,6 +131,10 @@ int tr_ssh_open(void *socket)
 
 	ssh_set_blocking(ssh_socket->session, 1);
 
+	// Attempting 'none' auth will make sure SSH_MSG_EXT_INFO is received
+	// from the server before proceeding with public key authentication
+	ssh_userauth_none(ssh_socket->session, NULL);
+
 	// check server identity
 #if LIBSSH_VERSION_MAJOR > 0 || LIBSSH_VERSION_MINOR > 8
 	if ((config->server_hostkey_path) && (ssh_session_is_known_server(ssh_socket->session) != SSH_KNOWN_HOSTS_OK)) {


### PR DESCRIPTION
### Contribution description

When SSH public key authentication is attempted right after `ssh_connect()`, there's a chance `SSH_MSG_EXT_INFO` message will not be received by the client in timely manner. In case if an `ssh-rsa` public key is being used, this in turn may lead to libssh picking SHA1 digest algorithm, which is disabled by default:
https://github.com/canonical/libssh/blob/f23d1454e50d0dbb314edd9bf4227ab72303484b/src/pki.c#L443-L454 This may cause intermittent SSH public key authentication failures with no clear reason as SSH logging is disabled in rtrlib.
The fix is based on this suggestion:
https://archive.libssh.org/libssh/2025-05/0000023.html

It is possible to work around the problem by using `PubkeyAcceptedAlgorithms` in `/etc/ssh/config` or `~/.ssh/config`, but there are a couple of issues with this approach:
- with `libssh`, you can't use `PubkeyAcceptedAlgorithms +ssh-rsa` and you must list all the algos instead
- adding `ssh-rsa` to the list of pubkey algos weakens security as it also enables `SHA1` digests, weakening SSH security

Support for `ssh-rsa` public keys is required by RFC8210: https://datatracker.ietf.org/doc/html/rfc8210#section-9.1

> Cache servers supporting SSH transport MUST accept RSA authentication and SHOULD accept Elliptic Curve Digital Signature Algorithm (ECDSA) authentication.

### Testing procedure

In order to reproduce the issue, you need to use `ssh-rsa` key for RPKI SSH authentication.
We tested it using downstream FRR version, with [StayRTR](https://github.com/bgp/stayrtr) being used as the server.
It is not easy to trigger reliably b/c the issue is very time-dependent. The issue with `libssh` `ssh-rsa` public key authentication is [rather known though](https://archive.libssh.org/libssh/2025-05/0000001.html), it started causing problems after `libssh` tightened their security defaults and disabled `SHA1` digest for auth.

