### PR TITLE
Fix: tommyds: ignore incorrect `-Wfree-nonheap-object` warnings by GCC

### DIFF
--- a/third-party/tommyds/tommyarray.c
+++ b/third-party/tommyds/tommyarray.c
@@ -51,7 +51,12 @@ void tommy_array_done(tommy_array* array)
 	tommy_free(array->bucket[0]);
 	for (i = TOMMY_ARRAY_BIT; i < array->bucket_bit; ++i) {
 		void** segment = array->bucket[i];
+// Ignore the `-Wfree-nonheap-object` warning for the following line
+// because it is a false-positive in GCC 15 (and maybe other versions).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 		tommy_free(&segment[((tommy_ptrdiff_t)1) << i]);
+#pragma GCC diagnostic pop
 	}
 }
 

--- a/third-party/tommyds/tommyhashlin.c
+++ b/third-party/tommyds/tommyhashlin.c
@@ -79,7 +79,12 @@ void tommy_hashlin_done(tommy_hashlin* hashlin)
 	tommy_free(hashlin->bucket[0]);
 	for (i = TOMMY_HASHLIN_BIT; i < hashlin->bucket_bit; ++i) {
 		tommy_hashlin_node** segment = hashlin->bucket[i];
+// Ignore the `-Wfree-nonheap-object` warning for the following line
+// because it is a false-positive in GCC 15 (and maybe other versions).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 		tommy_free(&segment[((tommy_ptrdiff_t)1) << i]);
+#pragma GCC diagnostic pop
 	}
 }
 


### PR DESCRIPTION
### Contribution description

#296 reports that with GCC 15 warnings for freeing non-heap objects are reported while compiling RTRlib.

I could reproduce the warnings when using a release build (`-D CMAKE_BUILD_TYPE=Release`) for the reported version as well as on master. However, the warnings are false positives since the correct pointers (i.e. the pointers that were returned by `tommy_calloc`/`tommy_malloc`) are passed to `tommy_free`.

A quick search online revealed that GCC can report false positives when the `-Wfree-nonheap-object` option is enabled (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54202).

To remove the warning and avoid further bug reports in the future I disabled the warning for the respective lines in the C code by using the following GCC pragma construct:

```c
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
		<lines-to-ignore>
#pragma GCC diagnostic pop
```

### Testing procedure

```shell
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
make # No `-Wfree-nonheap-object` warning is shown in the compilation output anymore
```


### Issues/PRs references

Fixes #296 

