### PR TITLE
[Fix] aspa: Replace existing ASPA record with new one

### DIFF
--- a/rtrlib/aspa/aspa.c
+++ b/rtrlib/aspa/aspa.c
@@ -353,13 +353,6 @@ static enum aspa_status aspa_table_update_compute_internal(struct rtr_socket *rt
 
 		// MARK: Handling 'add' operations
 		if (current->type == ASPA_ADD) {
-			// Attempt to add record with $CAS, but record with $CAS already exists
-			// Error: Duplicate Add.
-			if (existing_matches_current) {
-				*failed_operation = current;
-				return ASPA_DUPLICATE_RECORD;
-			}
-
 			// Attempt to add record with $CAS twice.
 			// Error: Duplicate Add.
 			if (next_matches_current && next->type == ASPA_ADD) {
@@ -368,17 +361,34 @@ static enum aspa_status aspa_table_update_compute_internal(struct rtr_socket *rt
 				return ASPA_DUPLICATE_RECORD;
 			}
 
-			// This operation adds a record with $CAS, the next op however removes this $CAS record again.
-			// These form a no-op.
+			// This operation adds a new ASPA record with some $CAS; the next operation, however,
+			// removes the ASPA record for the same $CAS again.
+			//
+			// Independently, if a record for this customer number already exists or not, both
+			// instructions cancel each other out and will remove an already present ASPA record.
 			if (next_matches_current && next->type == ASPA_REMOVE) {
+				// Scenario 1
+				if (existing_matches_current) {
+					// "Remove" record by simply not appending it to the new array
+					existing_i += 1;
+
+					// Since the combined outcome of the current and the next operation is the
+					// removal of the existing record, we mark the current replace/add-operation
+					// as no-op and adjust the remove operation so that it will be notified as
+					// removal of the previously existing record.
+					current->is_no_op = true;
+					next->record.provider_count = existing_record->provider_count;
+					next->record.provider_asns = existing_record->provider_asns;
+				} else { // Scenario 2
 #if ASPA_NOTIFY_NO_OPS
-				// Complete record's providers for clients
-				next->record = current->record;
+					// Complete record's providers for clients
+					next->record = current->record;
 #endif
 
-				// Mark as no-op.
-				current->is_no_op = true;
-				next->is_no_op = true;
+					// Mark as no-op.
+					next->is_no_op = true;
+					current->is_no_op = true;
+				}
 
 				// Skip next
 				i += 1;
@@ -419,6 +429,16 @@ static enum aspa_status aspa_table_update_compute_internal(struct rtr_socket *rt
 			current->record.provider_count = existing_record->provider_count;
 			current->record.provider_asns = existing_record->provider_asns;
 		}
+	}
+
+	struct aspa_record *last_record_from_new_array = aspa_array_get_record(new_array, new_array->size - 1);
+	struct aspa_record *next_record_from_old_array = aspa_array_get_record(array, existing_i);
+
+	// If the customer AS number of the next element in the old array is already in the new array, skip that
+	// element and don't copy it to the new array below.
+	if (last_record_from_new_array && next_record_from_old_array &&
+	    last_record_from_new_array->customer_asn == next_record_from_old_array->customer_asn) {
+		existing_i += 1;
 	}
 
 	// Append remaining records (reuse existing provider array)

--- a/rtrlib/aspa/aspa.h
+++ b/rtrlib/aspa/aspa.h
@@ -53,7 +53,11 @@ enum __attribute__((__packed__)) aspa_operation_type {
 	/** The existing record, identified by its customer ASN, shall be withdrawn from the ASPA table. */
 	ASPA_REMOVE = 0,
 
-	/** The new record, identified by its customer ASN, shall be added to the ASPA table. */
+	/**
+	 * The new record, identified by its customer ASN, shall be added to the ASPA table.
+	 * If a record with the same customer ASN already exists, this operation is supposed
+	 * to replace the existing one with the new record.
+	 */
 	ASPA_ADD = 1
 };
 


### PR DESCRIPTION
<!--
The RTRlib community cares about code quality. Therefore, before
describing what your contribution is about, we would like you to make sure
that your modifications are compliant with the RTRlib coding conventions, see
https://github.com/rtrlib/rtrlib/blob/master/CONTRIBUTING.
-->

### Contribution description

This PR changes the ASPA implementation in the following way to meet version 21 of the [draft-ietf-sidrops-8210bis-21] draft:

- Whenever an ASPA announcement PDU is received and an ASPA record for that customer ASN already exists, the new record replaces the old one as defined  in [draft-ietf-sidrops-8210bis-21]. Previously, a `Duplicate Announcement Received (7)` error has been sent.
- When an ASPA announcement and a withdrawal is received (in that order) within one response from the cache server, 
    * it is considered a no-op if the customer ASN doesn't exist yet;
    * if it already exists, the existing record is removed and exactly one `Remove` notification is triggered, containing the pre-existing ASPA record; this means that the received announcement PDU is simply ignored.

[draft-ietf-sidrops-8210bis-21]: https://www.ietf.org/archive/id/draft-ietf-sidrops-8210bis-21.html#name-aspa-pdu

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile and is there a 'test' command
- how to know that it was not working/available in master
- the expected success of the test output
-->

Unit tests have been added and can be run as follows:

```
mkdir build && cd build
cmake ..
make
ctest
```

### Issues/PRs references

n/a

<!--
Examples: Fixes #212. See also #196. Depends on PR #188.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved. This way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

