### PR TITLE
Fix memory leaks

### DIFF
--- a/rtrlib/aspa/aspa_private.h
+++ b/rtrlib/aspa/aspa_private.h
@@ -174,6 +174,12 @@ struct aspa_update {
 	struct aspa_update_operation *failed_operation;
 	struct aspa_store_node *node;
 	struct aspa_array *new_array;
+	/**
+	 * This array is used to keep track of all replaced ASPA records while creating the
+	 * new records array. Once the creation of the new ASPA records array was successful,
+	 * the provider ASN list has to freed for all replaced records to avoid memory leaks.
+	 */
+	struct aspa_array *replaced_records;
 };
 
 /**

--- a/rtrlib/config.h
+++ b/rtrlib/config.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef RTR_CONFIG_H
+#define RTR_CONFIG_H
+
+#define RTRLIB_BGPSEC_ENABLED
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/rtrlib/rtr/packets.c
+++ b/rtrlib/rtr/packets.c
@@ -1100,6 +1100,7 @@ static int rtr_compute_update_aspa_table(struct rtr_socket *rtr_socket, struct a
 			RTR_DBG1("ASPA announcement doesn't contain any provider autonomous system numbers");
 			rtr_send_error_pdu_from_host(rtr_socket, pdu, pdu->len, INCORRECT_ASPA_PROVIDER_LIST, NULL, 0);
 			rtr_change_socket_state(rtr_socket, RTR_ERROR_FATAL);
+			lrtr_free(operations);
 
 			return RTR_ERROR;
 		}

--- a/rtrlib/rtr_mgr.c
+++ b/rtrlib/rtr_mgr.c
@@ -499,10 +499,16 @@ RTRLIB_EXPORT void rtr_mgr_free(struct rtr_mgr_config *config)
 	pthread_rwlock_wrlock(&config->mutex);
 
 	pfx_table_free(config->pfx_table);
-	spki_table_free(config->spki_table);
-	aspa_table_free(config->aspa_table, true);
-	lrtr_free(config->spki_table);
 	lrtr_free(config->pfx_table);
+	config->pfx_table = NULL;
+
+	spki_table_free(config->spki_table);
+	lrtr_free(config->spki_table);
+	config->spki_table = NULL;
+
+	aspa_table_free(config->aspa_table, true);
+	lrtr_free(config->aspa_table);
+	config->aspa_table = NULL;
 
 	/* Free linked list */
 	tommy_node *head = tommy_list_head(&config->groups->list);

--- a/rtrlib/rtrlib.h
+++ b/rtrlib/rtrlib.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of RTRlib.
+ *
+ * This file is subject to the terms and conditions of the MIT license.
+ * See the file LICENSE in the top level directory for more details.
+ *
+ * Website: http://rtrlib.realmv6.org/
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef RTRLIB_H
+#define RTRLIB_H
+
+#define RTRLIB_HAVE_LIBSSH
+#define RTRLIB_VERSION_MAJOR 0
+#define RTRLIB_VERSION_MINOR 8
+#define RTRLIB_VERSION_PATCH 0
+
+#include "config.h"
+#include "lib/alloc_utils.h"
+#include "lib/ip.h"
+#include "lib/ipv4.h"
+#include "lib/ipv6.h"
+#include "pfx/pfx.h"
+#include "rtr/rtr.h"
+#include "rtr_mgr.h"
+#include "spki/spkitable.h"
+#include "transport/tcp/tcp_transport.h"
+#include "transport/transport.h"
+#ifdef RTRLIB_HAVE_LIBSSH
+#include "rtrlib/transport/ssh/ssh_transport.h"
+#endif
+#ifdef RTRLIB_BGPSEC_ENABLED
+#include "rtrlib/bgpsec/bgpsec.h"
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/test_bgpsec.c
+++ b/tests/test_bgpsec.c
@@ -80,7 +80,7 @@ static uint8_t wrong_private_key[] = {
 /* Helper function to create a spki_record */
 static struct spki_record *create_record(int ASN, uint8_t *ski, uint8_t *spki)
 {
-	struct spki_record *record = malloc(sizeof(struct spki_record));
+	struct spki_record *record = lrtr_malloc(sizeof(struct spki_record));
 
 	memset(record, 0, sizeof(*record));
 	record->asn = ASN;
@@ -205,9 +205,9 @@ static void validate_bgpsec_path_test(void)
 
 	/* Free all allocated memory. */
 	spki_table_free(&table);
-	free(record1);
-	free(record2);
-	free(duplicate_record);
+	lrtr_free(record1);
+	lrtr_free(record2);
+	lrtr_free(duplicate_record);
 	rtr_mgr_bgpsec_free(bgpsec);
 }
 
@@ -305,8 +305,8 @@ static void generate_signature_test(void)
 
 	/* Free all allocated memory. */
 	spki_table_free(&table);
-	free(record1);
-	free(record2);
+	lrtr_free(record1);
+	lrtr_free(record2);
 	rtr_mgr_bgpsec_free(bgpsec);
 	rtr_mgr_bgpsec_free_signatures(new_sig);
 }
@@ -379,8 +379,8 @@ static void originate_and_validate_test(void)
 
 	/* Free all allocated memory. */
 	spki_table_free(&table);
-	free(record1);
-	free(record2);
+	lrtr_free(record1);
+	lrtr_free(record2);
 	rtr_mgr_bgpsec_free(bgpsec);
 }
 

--- a/tests/test_dynamic_groups.c
+++ b/tests/test_dynamic_groups.c
@@ -57,7 +57,7 @@ int main(void)
 	rtr_tcp.tr_socket = &tr_tcp;
 
 	/* create a rtr_mr_group array with 1 element */
-	groups[0].sockets = malloc(sizeof(struct rtr_socket *));
+	groups[0].sockets = lrtr_malloc(sizeof(struct rtr_socket *));
 	groups[0].sockets_len = 1;
 	groups[0].sockets[0] = &rtr_tcp;
 	groups[0].preference = 1;
@@ -68,7 +68,7 @@ int main(void)
 
 	tr_tcp_init(&tcp_config, &tr_tcp2);
 	rtr_tcp2.tr_socket = &tr_tcp2;
-	group2.sockets = malloc(sizeof(struct rtr_socket *));
+	group2.sockets = lrtr_malloc(sizeof(struct rtr_socket *));
 	group2.sockets_len = 1;
 	group2.sockets[0] = &rtr_tcp2;
 	group2.preference = 2;
@@ -127,7 +127,7 @@ int main(void)
 
 	tr_tcp_init(&tcp_config, &tr_tcp3);
 	rtr_tcp3.tr_socket = &tr_tcp3;
-	group3.sockets = malloc(sizeof(struct rtr_socket *));
+	group3.sockets = lrtr_malloc(sizeof(struct rtr_socket *));
 	group3.sockets_len = 1;
 	group3.sockets[0] = &rtr_tcp3;
 	group3.preference = 3;
@@ -138,7 +138,7 @@ int main(void)
 
 	tr_tcp_init(&tcp_config, &tr_tcp4);
 	rtr_tcp4.tr_socket = &tr_tcp4;
-	group4.sockets = malloc(sizeof(struct rtr_socket *));
+	group4.sockets = lrtr_malloc(sizeof(struct rtr_socket *));
 	group4.sockets_len = 1;
 	group4.sockets[0] = &rtr_tcp4;
 	group4.preference = 4;
@@ -166,7 +166,7 @@ int main(void)
 
 	tr_tcp_init(&tcp_config, &tr_tcp5);
 	rtr_tcp5.tr_socket = &tr_tcp5;
-	group5.sockets = malloc(sizeof(struct rtr_socket *));
+	group5.sockets = lrtr_malloc(sizeof(struct rtr_socket *));
 	group5.sockets_len = 1;
 	group5.sockets[0] = &rtr_tcp5;
 	group5.preference = 5;
@@ -191,9 +191,9 @@ int main(void)
 	assert(retval == RTR_ERROR);
 	rtr_mgr_stop(conf);
 	rtr_mgr_free(conf);
-	free(groups[0].sockets);
-	free(group2.sockets);
-	free(group3.sockets);
-	free(group4.sockets);
-	free(group5.sockets);
+	lrtr_free(groups[0].sockets);
+	lrtr_free(group2.sockets);
+	lrtr_free(group3.sockets);
+	lrtr_free(group4.sockets);
+	lrtr_free(group5.sockets);
 }

--- a/tests/test_ht_spkitable.c
+++ b/tests/test_ht_spkitable.c
@@ -53,7 +53,7 @@ static bool spki_records_are_equal(struct spki_record *r1, struct spki_record *r
  */
 static struct spki_record *create_record(int ASN, int ski_offset, int spki_offset, struct rtr_socket *socket)
 {
-	struct spki_record *record = malloc(sizeof(struct spki_record));
+	struct spki_record *record = lrtr_malloc(sizeof(struct spki_record));
 	uint32_t i;
 
 	memset(record, 0, sizeof(*record));
@@ -100,7 +100,7 @@ static void _spki_table_search_assert(struct spki_table *table, uint8_t *ski)
 
 	assert(spki_table_search_by_ski(table, ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == NUM_SKIS_RECORDS);
-	free(result);
+	lrtr_free(result);
 }
 
 /* ----- TESTS FUNCTIONS ----- */
@@ -115,8 +115,8 @@ static void _spki_table_search_assert(struct spki_table *table, uint8_t *ski)
 static void test_ht_1(void)
 {
 	struct spki_table table;
-	struct rtr_socket *socket_one = malloc(sizeof(struct rtr_socket));
-	struct rtr_socket *socket_two = malloc(sizeof(struct rtr_socket));
+	struct rtr_socket *socket_one = lrtr_malloc(sizeof(struct rtr_socket));
+	struct rtr_socket *socket_two = lrtr_malloc(sizeof(struct rtr_socket));
 	uint8_t ski[SKI_SIZE];
 	uint32_t asn = 1;
 
@@ -125,7 +125,7 @@ static void test_ht_1(void)
 
 	spki_table_init(&table, NULL);
 	memcpy(ski, record->ski, 20);
-	free(record);
+	lrtr_free(record);
 
 	/* create and add records with either socket_one or socket_two */
 	for (int i = 0; i < 255; i++) {
@@ -135,7 +135,7 @@ static void test_ht_1(void)
 			record = create_record(1, 0, i, socket_two);
 
 		_spki_table_add_assert(&table, record);
-		free(record);
+		lrtr_free(record);
 	}
 
 	struct spki_record *result;
@@ -149,7 +149,7 @@ static void test_ht_1(void)
 		count++;
 	}
 	assert(count == 255);
-	free(result);
+	lrtr_free(result);
 
 	/* remove all records with socket_one */
 	spki_table_src_remove(&table, socket_one);
@@ -163,9 +163,9 @@ static void test_ht_1(void)
 
 	/* cleanup: free memory */
 	spki_table_free(&table);
-	free(result);
-	free(socket_one);
-	free(socket_two);
+	lrtr_free(result);
+	lrtr_free(socket_one);
+	lrtr_free(socket_two);
 	printf("%s() complete\n", __func__);
 }
 
@@ -192,14 +192,14 @@ static void test_ht_2(void)
 	/* TEST2: check that returned records are the same we added. */
 	assert(spki_records_are_equal(&result[0], record1) != spki_records_are_equal(&result[0], record2));
 	assert(spki_records_are_equal(&result[1], record1) != spki_records_are_equal(&result[1], record2));
-	free(result);
+	lrtr_free(result);
 
 	/* TEST3: remove record1 and verify result is record2 */
 	_spki_table_remove_assert(&table, record1);
 	spki_table_get_all(&table, 10, record1->ski, &result, &result_len);
 	assert(result_len == 1);
 	assert(spki_records_are_equal(&result[0], record2));
-	free(result);
+	lrtr_free(result);
 
 	/*TEST4: remove record2 and verify search result is empty */
 	_spki_table_remove_assert(&table, record2);
@@ -211,8 +211,8 @@ static void test_ht_2(void)
 	assert(!result);
 
 	/* cleanup: free memory */
-	free(record1);
-	free(record2);
+	lrtr_free(record1);
+	lrtr_free(record2);
 	spki_table_free(&table);
 	printf("%s() complete\n", __func__);
 }
@@ -247,15 +247,15 @@ static void test_ht_3(void)
 	/* Check if other records are still there */
 	assert(spki_table_get_all(&table, record2->asn, record2->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 
 	assert(spki_table_get_all(&table, record3->asn, record3->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 
 	assert(spki_table_get_all(&table, record4->asn, record4->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 	/* (re)add record1 */
 	_spki_table_add_assert(&table, record1);
 
@@ -264,15 +264,15 @@ static void test_ht_3(void)
 	/* Check if other records are still there */
 	assert(spki_table_get_all(&table, record1->asn, record1->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 
 	assert(spki_table_get_all(&table, record3->asn, record3->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 
 	assert(spki_table_get_all(&table, record4->asn, record4->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 	/* (re)add record2 */
 	_spki_table_add_assert(&table, record2);
 
@@ -281,15 +281,15 @@ static void test_ht_3(void)
 	/* Check if other records are still there */
 	assert(spki_table_get_all(&table, record1->asn, record1->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 2);
-	free(result);
+	lrtr_free(result);
 
 	assert(spki_table_get_all(&table, record2->asn, record2->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 2);
-	free(result);
+	lrtr_free(result);
 
 	assert(spki_table_get_all(&table, record4->asn, record4->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 	/* (re)add record3 */
 	_spki_table_add_assert(&table, record3);
 
@@ -298,22 +298,22 @@ static void test_ht_3(void)
 	/* Check if other records are still there */
 	assert(spki_table_get_all(&table, record1->asn, record1->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 2);
-	free(result);
+	lrtr_free(result);
 
 	assert(spki_table_get_all(&table, record2->asn, record2->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 2);
-	free(result);
+	lrtr_free(result);
 
 	assert(spki_table_get_all(&table, record3->asn, record3->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 
 	/* cleanup: free memory */
 	spki_table_free(&table);
-	free(record1);
-	free(record2);
-	free(record3);
-	free(record4);
+	lrtr_free(record1);
+	lrtr_free(record2);
+	lrtr_free(record3);
+	lrtr_free(record4);
 	printf("%s complete\n", __func__);
 }
 
@@ -345,8 +345,8 @@ static void test_ht_4(void)
 						  &result_len) == SPKI_SUCCESS);
 			assert(result_len == 1);
 			_spki_table_remove_assert(&table, records[i][j]);
-			free(result);
-			free(records[i][j]);
+			lrtr_free(result);
+			lrtr_free(records[i][j]);
 		}
 	}
 
@@ -355,7 +355,7 @@ static void test_ht_4(void)
 		for (int j = 0; j < NUM_TABLE_Y; j++) {
 			records[i][j] = create_record(i, j, j, NULL);
 			_spki_table_add_assert(&table, records[i][j]);
-			free(records[i][j]);
+			lrtr_free(records[i][j]);
 		}
 	}
 
@@ -387,12 +387,12 @@ static void test_ht_5(void)
 	/* check that only record1 is in table and matches query */
 	spki_table_get_all(&table, 10, record1->ski, &result, &result_len);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 
 	/* cleanup: free memory */
 	spki_table_free(&table);
-	free(record1);
-	free(record2);
+	lrtr_free(record1);
+	lrtr_free(record2);
 	printf("%s() complete\n", __func__);
 }
 
@@ -417,7 +417,7 @@ static void test_ht_6(void)
 	for (unsigned int i = 0; i < NUM_SKIS; i++) {
 		for (unsigned int j = 0; j < NUM_SKIS_RECORDS; j++) {
 			_spki_table_search_assert(&table, records[i][j]->ski);
-			free(records[i][j]);
+			lrtr_free(records[i][j]);
 		}
 	}
 
@@ -454,8 +454,8 @@ static void test_ht_7(void)
 
 		assert(size == 1);
 		assert(spki_records_are_equal(records[i], &result[0]));
-		free(result);
-		free(records[i]);
+		lrtr_free(result);
+		lrtr_free(records[i]);
 	}
 	spki_table_free(&table);
 
@@ -476,8 +476,8 @@ static void test_ht_7(void)
 
 		assert(size == 1);
 		assert(spki_records_are_equal(records[i], &result[0]));
-		free(result);
-		free(records[i]);
+		lrtr_free(result);
+		lrtr_free(records[i]);
 	}
 	spki_table_free(&table);
 
@@ -503,8 +503,8 @@ static void test_ht_7(void)
 
 			assert(size == 1);
 			assert(spki_records_are_equal(records_n_n[i][j], &result[0]));
-			free(result);
-			free(records_n_n[i][j]);
+			lrtr_free(result);
+			lrtr_free(records_n_n[i][j]);
 		}
 	}
 
@@ -532,30 +532,30 @@ static void test_table_swap(void)
 
 	assert(spki_table_search_by_ski(&table1, test_record1->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 	result = NULL;
 
 	assert(spki_table_search_by_ski(&table2, test_record2->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 	result = NULL;
 
 	spki_table_swap(&table1, &table2);
 
 	assert(spki_table_search_by_ski(&table1, test_record2->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 	result = NULL;
 
 	assert(spki_table_search_by_ski(&table2, test_record1->ski, &result, &result_len) == SPKI_SUCCESS);
 	assert(result_len == 1);
-	free(result);
+	lrtr_free(result);
 	result = NULL;
 
 	spki_table_free(&table1);
 	spki_table_free(&table2);
-	free(test_record1);
-	free(test_record2);
+	lrtr_free(test_record1);
+	lrtr_free(test_record2);
 
 	printf("%s() complete\n", __func__);
 }
@@ -627,9 +627,9 @@ static void test_table_diff(void)
 	printf("Freeing tables\n");
 	spki_table_free(&table1);
 	spki_table_free(&table2);
-	free(test_record1);
-	free(test_record2);
-	free(test_record3);
+	lrtr_free(test_record1);
+	lrtr_free(test_record2);
+	lrtr_free(test_record3);
 
 	printf("%s() complete\n", __func__);
 }

--- a/tests/test_ht_spkitable_locks.c
+++ b/tests/test_ht_spkitable_locks.c
@@ -54,7 +54,7 @@ static bool compare_spki_records(struct spki_record *r1, struct spki_record *r2)
  */
 static struct spki_record *create_record(int ASN, int ski_offset, int spki_offset, struct rtr_socket *socket)
 {
-	struct spki_record *record = malloc(sizeof(struct spki_record));
+	struct spki_record *record = lrtr_malloc(sizeof(struct spki_record));
 	uint32_t i;
 
 	record->asn = ASN;
@@ -82,7 +82,7 @@ static void *add_records(struct add_records_args *args)
 		int ret = spki_table_add_entry(args->table, record);
 
 		assert(ret == SPKI_SUCCESS);
-		free(record);
+		lrtr_free(record);
 	}
 
 	return NULL;
@@ -100,7 +100,7 @@ static void *remove_records(struct remove_records_args *args)
 		int ret = spki_table_remove_entry(args->table, record);
 
 		assert(ret == SPKI_SUCCESS);
-		free(record);
+		lrtr_free(record);
 	}
 
 	return NULL;
@@ -143,8 +143,8 @@ static void lock_test1(void)
 		spki_table_get_all(&spkit, record->asn, record->ski, &result, &result_size);
 		assert(result_size == 1);
 		assert(compare_spki_records(record, &result[0]));
-		free(result);
-		free(record);
+		lrtr_free(result);
+		lrtr_free(record);
 	}
 
 	struct remove_records_args remove_args[max_threads];

--- a/tests/test_live_disabled_features.c
+++ b/tests/test_live_disabled_features.c
@@ -21,7 +21,7 @@
  * (https://www.ripe.net/analyse/internet-measurements/
  *  routing-information-service-ris/current-ris-routing-beacons)
  */
-const int connection_timeout = 20;
+const int connection_timeout = 80;
 enum rtr_mgr_status connection_status = -1;
 
 static void connection_status_callback(const struct rtr_mgr_group *group __attribute__((unused)),
@@ -59,7 +59,7 @@ int main(void)
 	rtr_tcp.tr_socket = &tr_tcp;
 
 	/* create a rtr_mgr_group array with 1 element */
-	groups[0].sockets = malloc(1 * sizeof(struct rtr_socket *));
+	groups[0].sockets = lrtr_malloc(1 * sizeof(struct rtr_socket *));
 	groups[0].sockets_len = 1;
 	groups[0].sockets[0] = &rtr_tcp;
 	groups[0].preference = 1;
@@ -88,6 +88,7 @@ int main(void)
 
 	rtr_mgr_stop(conf);
 	rtr_mgr_free(conf);
+	lrtr_free(groups[0].sockets);
 
 	return EXIT_SUCCESS;
 }

--- a/tests/test_live_fetching.c
+++ b/tests/test_live_fetching.c
@@ -27,7 +27,7 @@ struct test_validity_query {
  * (https://www.ripe.net/analyse/internet-measurements/
  *  routing-information-service-ris/current-ris-routing-beacons)
  */
-const int connection_timeout = 20;
+const int connection_timeout = 80;
 enum rtr_mgr_status connection_status = -1;
 
 static void connection_status_callback(const struct rtr_mgr_group *group __attribute__((unused)),
@@ -50,13 +50,8 @@ int main(void)
 	/* These variables are not in the global scope
 	 * because it would cause warnings about discarding constness
 	 */
-
-	//char RPKI_CACHE_HOST[] = "rpki-validator.realmv6.org";
-	//char RPKI_CACHE_PORT[] = "8283";
-
-	// REPLACE THIS BY YOUR RTR SERVER
 	char RPKI_CACHE_HOST[] = "rpki-cache.netd.cs.tu-dresden.de";
-	char RPKI_CACHE_PORT[] = "3323"; // rir rtr
+	char RPKI_CACHE_PORT[] = "3323";
 
 	/* create a TCP transport socket */
 	struct tr_socket tr_tcp;
@@ -69,7 +64,7 @@ int main(void)
 	rtr_tcp.tr_socket = &tr_tcp;
 
 	/* create a rtr_mgr_group array with 1 element */
-	groups[0].sockets = malloc(1 * sizeof(struct rtr_socket *));
+	groups[0].sockets = lrtr_malloc(1 * sizeof(struct rtr_socket *));
 	groups[0].sockets_len = 1;
 	groups[0].sockets[0] = &rtr_tcp;
 	groups[0].preference = 1;
@@ -81,14 +76,17 @@ int main(void)
 
 	if (rtr_mgr_add_roa_support(conf, NULL) == RTR_ERROR) {
 		fprintf(stderr, "Failed initializing ROA support\n");
+		return EXIT_FAILURE;
 	}
 
 	if (rtr_mgr_add_aspa_support(conf, NULL) == RTR_ERROR) {
 		fprintf(stderr, "Failed initializing ASPA support\n");
+		return EXIT_FAILURE;
 	}
 
 	if (rtr_mgr_add_spki_support(conf, NULL) == RTR_ERROR) {
 		fprintf(stderr, "Failed initializing BGPSEC support\n");
+		return EXIT_FAILURE;
 	}
 
 	rtr_mgr_setup_sockets(conf, groups, 1, 50, 600, 600);
@@ -126,6 +124,7 @@ int main(void)
 
 	rtr_mgr_stop(conf);
 	rtr_mgr_free(conf);
+	lrtr_free(groups[0].sockets);
 
 	return EXIT_SUCCESS;
 }

--- a/tests/test_live_validation.c
+++ b/tests/test_live_validation.c
@@ -58,13 +58,13 @@ int main(void)
 	 * because it would cause warnings about discarding constness
 	 */
 	char RPKI_CACHE_HOST[] = "rpki-cache.netd.cs.tu-dresden.de";
-	char RPKI_CACHE_POST[] = "3323";
+	char RPKI_CACHE_PORT[] = "3323";
 
 	/* create a TCP transport socket */
 	struct tr_socket tr_tcp;
 	struct tr_tcp_config tcp_config = {
 		RPKI_CACHE_HOST, //IP
-		RPKI_CACHE_POST, //Port
+		RPKI_CACHE_PORT, //Port
 		NULL, //source address
 		NULL, //data
 		NULL, //new_socket()
@@ -78,7 +78,7 @@ int main(void)
 	rtr_tcp.tr_socket = &tr_tcp;
 
 	/* create a rtr_mgr_group array with 1 element */
-	groups[0].sockets = malloc(1 * sizeof(struct rtr_socket *));
+	groups[0].sockets = lrtr_malloc(1 * sizeof(struct rtr_socket *));
 	groups[0].sockets_len = 1;
 	groups[0].sockets[0] = &rtr_tcp;
 	groups[0].preference = 1;
@@ -104,7 +104,6 @@ int main(void)
 	}
 
 	rtr_mgr_setup_sockets(conf, groups, 1, 50, 600, 600);
-
 	rtr_mgr_start(conf);
 	int sleep_counter = 0;
 	/* wait for connection, or timeout and exit eventually */
@@ -130,6 +129,7 @@ int main(void)
 		lrtr_ip_str_to_addr(q.pfx, &pref);
 		pfx_table_validate_r(groups[0].sockets[0]->pfx_table, &reason, &reason_len, q.asn, &pref, q.len,
 				     &result);
+		lrtr_free(reason);
 		if (result != q.val) {
 			printf("ERROR: prefix validation mismatch.\n");
 			return EXIT_FAILURE;
@@ -140,6 +140,7 @@ int main(void)
 
 	rtr_mgr_stop(conf);
 	rtr_mgr_free(conf);
+	lrtr_free(groups[0].sockets);
 
 	return EXIT_SUCCESS;
 }

--- a/tests/test_pfx.c
+++ b/tests/test_pfx.c
@@ -13,6 +13,7 @@
 #include "rtrlib/pfx/pfx_private.h"
 #include "rtrlib/pfx/trie/trie_private.h"
 #include "rtrlib/rtr/rtr.h"
+#include "rtrlib/rtrlib.h"
 
 #include <arpa/inet.h>
 #include <assert.h>
@@ -75,7 +76,7 @@ static void remove_src_test(void)
 	struct trie_node **array = NULL;
 	/* verify that table has 3 distinct prefix entries */
 	assert(trie_get_children(pfxt.ipv4, &array, &len) != -1);
-	free(array);
+	lrtr_free(array);
 	array = NULL;
 	assert((len + 1) == 3);
 
@@ -83,7 +84,7 @@ static void remove_src_test(void)
 	pfx_table_src_remove(&pfxt, &tr1);
 	len = 0;
 	assert(trie_get_children(pfxt.ipv4, &array, &len) != -1);
-	free(array);
+	lrtr_free(array);
 	assert((len + 1) == 2);
 
 	/* verify validation of prefixes */
@@ -366,7 +367,7 @@ static void test_issue99(void)
 static void test_issue152(void)
 {
 	struct pfx_table pfxt;
-	struct pfx_record *records = calloc(6, sizeof(struct pfx_record));
+	struct pfx_record *records = lrtr_calloc(6, sizeof(struct pfx_record));
 
 	pfx_table_init(&pfxt, NULL);
 	create_ip4_pfx_record(&records[0], 1, "89.18.183.0", 24, 24);
@@ -382,7 +383,7 @@ static void test_issue152(void)
 	for (size_t i = 0; i < 6; i++)
 		assert(pfx_table_remove(&pfxt, &records[i]) == PFX_SUCCESS);
 
-	free(records);
+	lrtr_free(records);
 }
 
 static void update_cb1(struct pfx_table *p __attribute__((unused)), const struct pfx_record rec, const bool added)

--- a/tests/unittests/test_packets_static.c
+++ b/tests/unittests/test_packets_static.c
@@ -113,7 +113,7 @@ static void test_rtr_get_pdu_type(void **state)
 static void test_pdu_to_network_byte_order(void **state)
 {
 	struct pdu_serial_query pdu_serial;
-	struct pdu_aspa *aspa = malloc(24);
+	struct pdu_aspa *aspa = lrtr_malloc(24);
 
 	memset(aspa, 0, 24);
 
@@ -162,7 +162,7 @@ static void test_pdu_to_host_byte_order(void **state)
 {
 	struct pdu_serial_notify pdu_serial;
 	struct pdu_end_of_data_v1_v2 pdu_eod;
-	struct pdu_aspa *aspa = malloc(24);
+	struct pdu_aspa *aspa = lrtr_malloc(24);
 
 	memset(aspa, 0, 24);
 


### PR DESCRIPTION
<!--
The RTRlib community cares about code quality. Therefore, before
describing what your contribution is about, we would like you to make sure
that your modifications are compliant with the RTRlib coding conventions, see
https://github.com/rtrlib/rtrlib/blob/master/CONTRIBUTING.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RTRlib is (are) involved
- if this is a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This pull request fixes multiple memory leaks in the test cases and the RTRlib itself. All fixed memory leaks have been found by running `valgrind --leak-check=full <path-to-test-case>`.

**Note**: One memory leak still exists in `test_dynamic_groups.c`. To me it looks like it's caused by the test code and not the RTRlib and thus it can be fixed later.

**Note**: Valgrind shows memory leaks (still reachable) for the tests that start new threads. These are, however, not caused by any code in the tests or RTRlib but by the C runtime and thus can be ignored or rather ignores should be created for those leaks in the future.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile and is there a 'test' command
- how to know that it was not working/available in master
- the expected success of the test output
-->

Run `valgrind --leak-check=full <path-to-test-case>` for each test with and without the changes of this pull request.

### Issues/PRs references

n/a

<!--
Examples: Fixes #212. See also #196. Depends on PR #188.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved. This way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

