### PR TITLE
aspa: Fix ASPA validation for AS paths with AS path prepending

### DIFF
--- a/rtrlib/aspa/aspa_private.h
+++ b/rtrlib/aspa/aspa_private.h
@@ -92,7 +92,13 @@ enum aspa_hop_result { ASPA_NO_ATTESTATION, ASPA_NOT_PROVIDER_PLUS, ASPA_PROVIDE
 
 /**
  * @brief Checks a hop in the given `AS_PATH`.
- * @return @c aspa_hop_result .
+ *
+ * If the given customer ASN and the provider ASN are equal @c ASPA_PROVIDER_PLUS is immediately returned
+ * without consulting the ASPA table. This is equivalent to ignoring that specific hop and is done because the
+ * <a href="https://www.ietf.org/archive/id/draft-ietf-sidrops-aspa-verification-24.html#name-principles">
+ * ASPA RFC; Section 5.1</a> mandates that ASPA validation must be performed on the compressed AS path.
+ *
+ * @return @c aspa_hop_result.
  */
 enum aspa_hop_result aspa_check_hop(struct rtr_aspa_table *aspa_table, uint32_t customer_asn, uint32_t provider_asn);
 

--- a/rtrlib/aspa/aspa_verification.c
+++ b/rtrlib/aspa/aspa_verification.c
@@ -46,6 +46,13 @@ enum aspa_hop_result aspa_check_hop(struct rtr_aspa_table *aspa_table, uint32_t 
 {
 	bool customer_found = false;
 
+	// ASPA validation must be performed on the compressed AS path, i.e. if the same AS number appears
+	// multiple times in consecutive order in the AS path, they are merged together to one occurrence.
+	// Returning ASPA_PROVIDER_PLUS in this case yields the same result as ignoring that hop all together.
+	if (customer_asn == provider_asn) {
+		return ASPA_PROVIDER_PLUS;
+	}
+
 	for (struct aspa_store_node *node = aspa_table->store; node != NULL; node = node->next) {
 		struct rtr_aspa_record *aspa_record = aspa_array_search(node->aspa_array, customer_asn);
 

--- a/tests/test_as_path_verification.c
+++ b/tests/test_as_path_verification.c
@@ -117,8 +117,6 @@ static void test_hopping(struct rtr_aspa_table *aspa_table)
 	assert(aspa_check_hop(aspa_table, 200, 300) == ASPA_PROVIDER_PLUS);
 	assert(aspa_check_hop(aspa_table, 500, 999) == ASPA_NO_ATTESTATION);
 
-	assert(aspa_check_hop(aspa_table, 999, 999) == ASPA_NO_ATTESTATION);
-
 	// multiple dissimilar aspas
 	assert(aspa_check_hop(aspa_table, 100, 201) == ASPA_PROVIDER_PLUS);
 	assert(aspa_check_hop(aspa_table, 100, 202) == ASPA_PROVIDER_PLUS);
@@ -172,7 +170,7 @@ static void test_downstream(struct rtr_aspa_table *aspa_table)
 
 	// two highest-level hops are nP
 	VERIFY_AS_PATH(aspa_table, RTR_ASPA_DOWNSTREAM, RTR_ASPA_AS_PATH_INVALID,
-		       ASNS(301, 401, 501, 502, 502, 402, 302));
+		       ASNS(301, 401, 501, 502, 999, 402, 302));
 	VERIFY_AS_PATH(aspa_table, RTR_ASPA_DOWNSTREAM, RTR_ASPA_AS_PATH_UNKNOWN,
 		       ASNS(302, 402, 502, 999, 500, 400, 300));
 
@@ -211,9 +209,9 @@ static void test_downstream(struct rtr_aspa_table *aspa_table)
 // clang-format off
 
 /**
- * Example 1 (downstream) (valid)
+ * Example 1 (downstream with AS path prepending) (valid)
  *
- * as_path: 20, 30, 40, 70, 80
+ * as_path: 20, 20, 20, 30, 30, 30, 40, 40, 40, 70, 70, 70, 80, 80, 80
  *
  *          30   40
  *  10  20           70
@@ -234,7 +232,7 @@ static void test_verify_example_1(void)
 	)
 
 	VERIFY_AS_PATH(aspa_table, RTR_ASPA_DOWNSTREAM, RTR_ASPA_AS_PATH_VALID,
-		ASNS(20, 30, 40, 70, 80));
+		ASNS(20, 20, 20, 30, 30, 30, 40, 40, 40, 70, 70, 70, 80, 80, 80));
 
 	rtr_aspa_table_free(aspa_table, false);
 	rtr_free(aspa_table);
@@ -536,9 +534,9 @@ static void test_verify_example_4_fixed(void)
 }
 
 /**
- * Example 5 (upstream) (valid)
+ * Example 5 (upstream, with AS path prepending) (valid)
  *
- * as_path: 20, 30, 40
+ * as_path: 20, 20, 20, 30, 30, 30, 40, 40, 40
  *
  * 10  20
  *        30
@@ -557,7 +555,7 @@ static void test_verify_example_5(void)
 	)
 
 	VERIFY_AS_PATH(aspa_table, RTR_ASPA_UPSTREAM, RTR_ASPA_AS_PATH_VALID,
-		ASNS(20, 30, 40));
+		ASNS(20, 20, 20, 30, 30, 30, 40, 40, 40));
 
 	rtr_aspa_table_free(aspa_table, false);
 	rtr_free(aspa_table);


### PR DESCRIPTION
### Contribution description

Previously, the ASPA validation was not performed on the compressed AS path which yielded incorrect results for AS paths where at least one AS number appeared multiple times in a row and that AS did not add itself as a provider in its ASPA record. This was against the ASPA RFC, which mandates validation on the compressed AS path.

### Testing procedure

The existing ASPA test have been fixed and extended so that the ASPA validation of AS paths with AS path prepending is tested for the upstream and downstream direction.


### Issues/PRs references

n/a


**Edit:** I saw that a function existed for removing consecutive duplicate ASNs, so this is not actually a bug. However, I see two issues with the previous approach: 

1. The calling code needs to do two function calls for the ASPA validation which might lead to bugs. Compressing the AS path inside the ASPA validation functions simplify the library interface.
2. The function for compressing the AS path modified the AS path which means the calling code needs to first copy the whole path if it wants to use it further. The approach proposed in this PR doesn't change the given AS path but simply ignores consecutive duplicates, which should be faster and also make the library easier to use.