### PR TITLE
tests: Fix test_aspa byte-order bug causing 32-bit segfault

### DIFF
--- a/tests/test_aspa.c
+++ b/tests/test_aspa.c
@@ -121,10 +121,10 @@ static int custom_send(const struct rtr_tr_socket *socket __attribute__((unused)
 	expected_error_pdus_index++;
 
 	if (err->type == 10) {
-		uint32_t *errlen = (uint32_t *)((char *)err->rest + err->len_enc_pdu);
+		uint32_t *errlen = (uint32_t *)((char *)err->rest + BYTES32(err->len_enc_pdu));
 
 		if ((char *)errlen < (char *)err + BYTES32(err->len))
-			printf("err msg: %.*s\n", *errlen, (char *)(errlen + 1));
+			printf("err msg: %.*s\n", BYTES32(*errlen), (char *)(errlen + 1));
 	}
 	return len;
 }


### PR DESCRIPTION
In custom_send(), err->len_enc_pdu was read without converting from network byte order, which causes the test trying to read 0x1c000000 (448MB) instead of 0x1c (28 bytes).
This caused a segfault on 32-bit systems

Convert err->len_enc_pdu with BYTES32() to match how err->error_code and err->len are already handled. Also apply BYTES32() to *errlen so the diagnostic printf uses the correct length on little-endian.

Before the fix, running the `make test` on a 32bit system gave:
```
Running tests...
Test project /home/ci/cibuild.9/rtrlib-source
   Start  1: test_pfx
1/12 Test  #1: test_pfx .........................   Passed    0.87 sec
   Start  2: test_trie
2/12 Test  #2: test_trie ........................   Passed    0.00 sec
   Start  3: test_ht_spkitable
3/12 Test  #3: test_ht_spkitable ................   Passed    1.23 sec
   Start  4: test_ht_spkitable_locks
4/12 Test  #4: test_ht_spkitable_locks ..........   Passed    1.02 sec
   Start  5: test_live_fetching
5/12 Test  #5: test_live_fetching ...............   Passed    9.83 sec
   Start  6: test_live_disabled_features
6/12 Test  #6: test_live_disabled_features ......   Passed   15.01 sec
   Start  7: test_ipaddr
7/12 Test  #7: test_ipaddr ......................   Passed    0.00 sec
   Start  8: test_getbits
8/12 Test  #8: test_getbits .....................   Passed    0.00 sec
   Start  9: test_aspa
9/12 Test  #9: test_aspa ........................***Exception: SegFault  0.00 sec
(2026/04/22 00:01:23:286689): RTR Socket: Cache Response PDU received
(2026/04/22 00:01:23:286746): RTR Socket: EOD PDU received.
(2026/04/22 00:01:23:286757): RTR Socket: v4 prefixes added
(2026/04/22 00:01:23:286766): RTR Socket: v6 prefixes added
(2026/04/22 00:01:23:286770): RTR Socket: spki data added
(2026/04/22 00:01:23:286774): RTR Socket: ASPA data added
(2026/04/22 00:01:23:286779): RTR Socket: Sync successful, received 0 Prefix PDUs, 0 Router Key PDUs, 0 ASPA PDUs, session_id: 0, SN: 437
(2026/04/22 00:01:23:286790): RTR Socket: Cache Response PDU received
(2026/04/22 00:01:23:286801): RTR Socket: EOD PDU received.
[...]
(2026/04/22 00:01:23:287230): RTR Socket: v4 prefixes added
(2026/04/22 00:01:23:287235): RTR Socket: v6 prefixes added
(2026/04/22 00:01:23:287239): RTR Socket: spki data added
(2026/04/22 00:01:23:287244): RTR Socket: Duplicate Announcement for ASPA customer ASN: 1100 received

   Start 10: test_aspa_array
10/12 Test #10: test_aspa_array ..................   Passed    0.00 sec
   Start 11: test_as_path_verification
11/12 Test #11: test_as_path_verification ........   Passed    0.00 sec
   Start 12: test_bgpsec
12/12 Test #12: test_bgpsec ......................   Passed    0.01 sec

92% tests passed, 1 tests failed out of 12
```

Verified the fix on
- Debian 11/12/13 each on arm7 and i386
- Ubuntu 18.04/20.04/22.04/24.04 on arm7
